### PR TITLE
Lock down on samples versions

### DIFF
--- a/samples/01.dice-roller/package.json
+++ b/samples/01.dice-roller/package.json
@@ -15,7 +15,7 @@
     },
     "dependencies": {
         "@fluidframework/test-client-utils": "~0.59.0",
-        "@microsoft/live-share": "~0.3.01",
+        "@microsoft/live-share": "0.3.0",
         "@microsoft/teams-js": "2.0.0-experimental.0",
         "fluid-framework": "~0.59.0"
     },

--- a/samples/02.react-video/package.json
+++ b/samples/02.react-video/package.json
@@ -7,8 +7,8 @@
   "author": "Microsoft",
   "dependencies": {
     "@fluentui/react-components": "^9.0.0-rc.10",
-    "@microsoft/live-share": "~0.3.0",
-    "@microsoft/live-share-media": "~0.3.0",
+    "@microsoft/live-share": "0.3.0",
+    "@microsoft/live-share-media": "0.3.0",
     "@microsoft/teams-js": "2.0.0-experimental.0",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",

--- a/samples/21.react-media-template/package.json
+++ b/samples/21.react-media-template/package.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "dependencies": {
     "@fluentui/react-components": "^9.0.0-rc.10",
-    "@microsoft/live-share": "~0.3.0",
-    "@microsoft/live-share-media": "~0.3.0",
+    "@microsoft/live-share": "0.3.0",
+    "@microsoft/live-share-media": "0.3.0",
     "@microsoft/teams-js": "2.0.0-experimental.0",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",

--- a/samples/22.react-agile-poker/package.json
+++ b/samples/22.react-agile-poker/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@fluentui/react-components": "^9.0.0-rc.10",
-    "@microsoft/live-share": "~0.3.0",
+    "@microsoft/live-share": "0.3.0",
     "@microsoft/teams-js": "2.0.0-experimental.0",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",


### PR DESCRIPTION
When running `npm install` in root, the samples attempt to bump to the as-of-yet non-existent 0.3.01