### PR TITLE
Remove network request for local client getRoles() call

### DIFF
--- a/packages/live-share/src/internals/RequestCache.ts
+++ b/packages/live-share/src/internals/RequestCache.ts
@@ -31,6 +31,10 @@ export class RequestCache<TResult = any> {
         this._cache.set(key, { startTime, promise });
         return promise;
     }
+
+    public has(key: string): boolean {
+        return this._cache.has(key);
+    }
 }
 
 /**

--- a/packages/live-share/src/internals/RoleVerifier.ts
+++ b/packages/live-share/src/internals/RoleVerifier.ts
@@ -38,6 +38,13 @@ export class RoleVerifier implements IRoleVerifier {
             throw new Error(`RoleVerifier: called getCLientRoles() without a clientId`);
         }
 
+        // Check for local client ID
+        // - For the local client we want to short circuit any network calls and just use the
+        //   cached value from the registerClientId() call. 
+        if (this._registerRequestCache.has(clientId)) {
+            return await this.registerClientId(clientId);
+        }
+
         return this._getRequestCache.cacheRequest(clientId, () => {
             return waitForResult(async () => {
                 const teamsClient = await this.getTeamsClient();


### PR DESCRIPTION
We currently call the server for every getRoles() call, even for the local client. The register role call can take a while which can lead to this get call timing out. The change being checked in causes local role lookups to just use the results returned from the registerRoles() call. This ensures that we only make a single network request on behalf of the local client and we properly wait for that registration request to complete before proceding.