### PR TITLE
Stevenic/presence event delay

### DIFF
--- a/packages/live-share/src/test/EphemeralEventTimer.spec.ts
+++ b/packages/live-share/src/test/EphemeralEventTimer.spec.ts
@@ -38,7 +38,7 @@ describe("EphemeralEventTimer", () => {
             assert(triggered == created * 2, `Messages created is ${created} but received is an unexpected ${triggered}`);
             localTimer.stop();
             done();
-        }, 30);
+        }, 50);
     });
 
     it("Should repeatedly send events after a delay", (done) => {
@@ -62,6 +62,6 @@ describe("EphemeralEventTimer", () => {
             assert(triggered == created * 2, `Messages created is ${created} but received is an unexpected ${triggered}`);
             localTimer.stop();
             done();
-        }, 30);
+        }, 50);
     });
 });


### PR DESCRIPTION
Fixed a race condition around role verification. The `EphemeralPresence` class needs to yield the current thread after a "connected" event is received. This gives time for `registerClientId()` to get called before `getRoles()` is called.