### PR TITLE
Add call to register client id for local user

### DIFF
--- a/packages/live-share/src/EphemeralEvent.ts
+++ b/packages/live-share/src/EphemeralEvent.ts
@@ -128,11 +128,11 @@ export interface IEphemeralEventEvents<TEvent extends IEphemeralEvent> extends I
     }
 
      /**
-     * Registers client of the current user.
+     * Registers client id of the current user.
      * @param clientId Client ID to map to current user.
      * @returns The list of roles for the client.
      */
-     public static registerClientRoles(clientId: string): Promise<UserMeetingRole[]> {
+     public static registerClientId(clientId: string): Promise<UserMeetingRole[]> {
         return EphemeralEvent._roleVerifier.registerClientId(clientId);
     }
 

--- a/packages/live-share/src/EphemeralEvent.ts
+++ b/packages/live-share/src/EphemeralEvent.ts
@@ -127,6 +127,15 @@ export interface IEphemeralEventEvents<TEvent extends IEphemeralEvent> extends I
         return EphemeralEvent._roleVerifier.getClientRoles(clientId);
     }
 
+     /**
+     * Registers client of the current user.
+     * @param clientId Client ID to map to current user.
+     * @returns The list of roles for the client.
+     */
+     public static registerClientRoles(clientId: string): Promise<UserMeetingRole[]> {
+        return EphemeralEvent._roleVerifier.registerClientId(clientId);
+    }
+
     /**
      * Verifies that a client has one of the specified roles. 
      * @param clientId Client ID to inspect.

--- a/packages/live-share/src/EphemeralPresence.ts
+++ b/packages/live-share/src/EphemeralPresence.ts
@@ -306,15 +306,7 @@ export class EphemeralPresence<TData extends object = object> extends DataObject
         return new Promise((resolve) => {
             const onConnected = (clientId: string) => {
                 this.runtime.off('connected', onConnected);
-
-                // Yield current thread.
-                // - This addresses a race condition that exists around role verification. We had a 
-                //   situation where registerClientId() and getClientRoles() for the local client 
-                //   were both being called in response to the 'connected' event. getClientRoles() 
-                //   was winning out and we want that call to come after the register call so that 
-                //   it can just wait for the register call to finish and avoid a separate network
-                //   request. Simply yielding the current thread solves the issue.
-                setTimeout(() => resolve(clientId));
+                resolve(clientId);
             };
 
             if (this.runtime.connected) {

--- a/packages/live-share/src/EphemeralPresenceUser.ts
+++ b/packages/live-share/src/EphemeralPresenceUser.ts
@@ -86,8 +86,12 @@ export class EphemeralPresenceUser<TData = object> {
     /**
      * Returns the users meeting roles.
      */
-    public getRoles(): Promise<UserMeetingRole[]> {
-        return EphemeralEvent.getClientRoles(this._evt.clientId!);
+     public getRoles(): Promise<UserMeetingRole[]> {
+        if (this._isLocalUser) {
+            return EphemeralEvent.registerClientRoles(this._evt.clientId!);
+        } else {
+            return EphemeralEvent.getClientRoles(this._evt.clientId!);
+        }
     }
 
     /**

--- a/packages/live-share/src/EphemeralPresenceUser.ts
+++ b/packages/live-share/src/EphemeralPresenceUser.ts
@@ -88,7 +88,7 @@ export class EphemeralPresenceUser<TData = object> {
      */
      public getRoles(): Promise<UserMeetingRole[]> {
         if (this._isLocalUser) {
-            return EphemeralEvent.registerClientRoles(this._evt.clientId!);
+            return EphemeralEvent.registerClientId(this._evt.clientId!);
         } else {
             return EphemeralEvent.getClientRoles(this._evt.clientId!);
         }

--- a/packages/live-share/src/EphemeralPresenceUser.ts
+++ b/packages/live-share/src/EphemeralPresenceUser.ts
@@ -84,7 +84,7 @@ export class EphemeralPresenceUser<TData = object> {
     }
 
     /**
-     * Returns the users meeting roles.
+     * Returns the user's meeting roles.
      */
      public getRoles(): Promise<UserMeetingRole[]> {
         if (this._isLocalUser) {

--- a/packages/live-share/src/LocalRoleVerifier.ts
+++ b/packages/live-share/src/LocalRoleVerifier.ts
@@ -46,6 +46,11 @@ export class LocalRoleVerifier implements IRoleVerifier {
         return Promise.resolve(roles);
     }
 
+    public registerClientId(clientId: string): Promise<UserMeetingRole[]> {
+        this.addClient(clientId, this.defaultRoles);
+        return Promise.resolve(this.defaultRoles);
+    }
+
     public async verifyRolesAllowed(clientId: string, allowedRoles: UserMeetingRole[]): Promise<boolean> {
         LocalRoleVerifier.ensureWarned();
 

--- a/packages/live-share/src/interfaces.ts
+++ b/packages/live-share/src/interfaces.ts
@@ -88,6 +88,13 @@ export interface IRoleVerifier {
     getClientRoles(clientId: string): Promise<UserMeetingRole[]>;
 
     /**
+     * Registers client of the current user.
+     * @param clientId Client ID to map to current user.
+     * @returns The list of roles for the client.
+     */
+     registerClientId(clientId: string): Promise<UserMeetingRole[]>;
+
+    /**
      * Verifies that a client has one of the specified roles. 
      * @param clientId Client ID to inspect.
      * @param allowedRoles User roles that are allowed.


### PR DESCRIPTION
- Add `registerClientId()` to IRoleVerifier
- Implement the same as test method in LocalRoleVerifier
- Implement `registerClientId()` in `EphemeralEvent`
- Fix race happening in EphemeralPresenceUser where `getClientRoles` may happen before `registerClientId` is called, by calling `EphemeralEvent.registerClientRoles` in presence updates.