### PR TITLE
Add CODEOWNERS and make a fix to react-video's getInitialMediaId

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@arun2k17 @corinagum @halbondmsft @pradeepananth @ryanbliss @siduppal @Stevenic

--- a/samples/02.react-video/src/utils/getInitialMediaItem.js
+++ b/samples/02.react-video/src/utils/getInitialMediaItem.js
@@ -3,7 +3,7 @@ import { mediaList } from "./media-list";
 function getInitialMediaId() {
   const url = new URL(window.location);
   const params = url.searchParams;
-  return `${params.get("mediaId")}`;
+  return params.get("mediaId");
 }
 
 export function getInitialMediaItem() {


### PR DESCRIPTION
- `CODEOWNERS` file - is there anyone else I should add? 
- `getInitialMediaItem.js` - return param instead of stringified param