### PR TITLE
Upgrade React samples to fluentui v9.0.1

### DIFF
--- a/samples/02.react-video/package.json
+++ b/samples/02.react-video/package.json
@@ -6,7 +6,7 @@
   "license": "Microsoft",
   "author": "Microsoft",
   "dependencies": {
-    "@fluentui/react-components": "^9.0.0-rc.10",
+    "@fluentui/react-components": "^9.0.1",
     "@microsoft/live-share": "~0.3.1",
     "@microsoft/live-share-media": "~0.3.1",
     "@microsoft/teams-js": "2.0.0-experimental.0",
@@ -21,7 +21,8 @@
     "react-scripts": "^4.0.0",
     "uuid": "^8.3.2",
     "web-vitals": "^2.1.4",
-    "use-resize-observer": "^8.0.0"
+    "use-resize-observer": "^8.0.0",
+    "tabster": "1.4.2"
   },
   "devDependencies": {
     "@fluidframework/test-client-utils": "~0.59.0",

--- a/samples/02.react-video/package.json
+++ b/samples/02.react-video/package.json
@@ -7,6 +7,7 @@
   "author": "Microsoft",
   "dependencies": {
     "@fluentui/react-components": "^9.0.1",
+    "@fluidframework/azure-client": "~0.59.0",
     "@microsoft/live-share": "~0.3.1",
     "@microsoft/live-share-media": "~0.3.1",
     "@microsoft/teams-js": "2.0.0-experimental.0",
@@ -21,8 +22,7 @@
     "react-scripts": "^4.0.0",
     "uuid": "^8.3.2",
     "web-vitals": "^2.1.4",
-    "use-resize-observer": "^8.0.0",
-    "tabster": "1.4.2"
+    "use-resize-observer": "^8.0.0"
   },
   "devDependencies": {
     "@fluidframework/test-client-utils": "~0.59.0",

--- a/samples/02.react-video/src/components/PlayerProgressBar.jsx
+++ b/samples/02.react-video/src/components/PlayerProgressBar.jsx
@@ -109,7 +109,7 @@ const PlayerProgressBar = ({
       <div className={styles.pageEl}>
         <Tooltip
           withArrow
-          positioning={{ popperRef }}
+          positioning={{ positioningRef: popperRef }}
           content={toolTipContent}
           relationship="label"
         >

--- a/samples/21.react-media-template/manifest/manifest.json
+++ b/samples/21.react-media-template/manifest/manifest.json
@@ -66,7 +66,7 @@
                     "type": "Delegated"
                 },
                 {
-                    "name": "“OnlineMeetingIncomingAudio.Detect.Group",
+                    "name": "OnlineMeetingIncomingAudio.Detect.Group",
                     "type": "Delegated"
                 }
             ]

--- a/samples/21.react-media-template/package.json
+++ b/samples/21.react-media-template/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@fluentui/react-components": "^9.0.1",
+    "@fluidframework/azure-client": "~0.59.0",
     "@microsoft/live-share": "~0.3.1",
     "@microsoft/live-share-media": "~0.3.1",
     "@microsoft/teams-js": "2.0.0-experimental.0",
@@ -20,8 +21,7 @@
     "react-scripts": "^4.0.0",
     "use-resize-observer": "^8.0.0",
     "uuid": "^8.3.2",
-    "web-vitals": "^2.1.4",
-    "tabster": "1.4.2"
+    "web-vitals": "^2.1.4"
   },
   "devDependencies": {
     "@fluidframework/test-client-utils": "~0.59.0",

--- a/samples/21.react-media-template/package.json
+++ b/samples/21.react-media-template/package.json
@@ -5,7 +5,7 @@
   "author": "Microsoft",
   "license": "MIT",
   "dependencies": {
-    "@fluentui/react-components": "^9.0.0-rc.10",
+    "@fluentui/react-components": "^9.0.1",
     "@microsoft/live-share": "~0.3.1",
     "@microsoft/live-share-media": "~0.3.1",
     "@microsoft/teams-js": "2.0.0-experimental.0",
@@ -20,7 +20,8 @@
     "react-scripts": "^4.0.0",
     "use-resize-observer": "^8.0.0",
     "uuid": "^8.3.2",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "tabster": "1.4.2"
   },
   "devDependencies": {
     "@fluidframework/test-client-utils": "~0.59.0",

--- a/samples/21.react-media-template/src/components/MediaCard.jsx
+++ b/samples/21.react-media-template/src/components/MediaCard.jsx
@@ -42,7 +42,7 @@ export const MediaCard = ({
             minHeight: "0px",
             maxHeight: "140px",
             overflow: "hidden",
-            marginBottom: "0.8rem",
+            marginBottom: "0.4rem",
           }}
         >
           <Image
@@ -52,15 +52,31 @@ export const MediaCard = ({
             style={{ minHeight: "0px" }}
           />
         </CardPreview>
-        <div style={{ minHeight: "0px" }}>
+        <div
+          style={{
+            minHeight: "0px",
+            paddingLeft: "0.8rem",
+            paddingRight: "0.8rem",
+          }}
+        >
           <Text size={400} weight="semibold">
             {mediaItem.title}
           </Text>
         </div>
-        <CardFooter
-          styles={{ padding: "0px 12px", minHeight: "0px", minWidth: "0px" }}
-        >
-          <div className={mergeClasses(flexRowStyle.root, flexRowStyle.vAlignCenter)} style={{width: "100%"}}>
+        <CardFooter styles={{ padding: "0rem", minHeight: "0px", minWidth: "0px" }}>
+          <div
+            className={mergeClasses(
+              flexRowStyle.root,
+              flexRowStyle.vAlignCenter
+            )}
+            style={{
+              width: "100%",
+              paddingLeft: "0.8rem",
+              paddingRight: "0.8rem",
+              paddingBottom: "1.2rem",
+              paddingTop: "0rem",
+            }}
+          >
             <div className={flexItemStyles.grow}>
               <Button
                 appearance="outline"

--- a/samples/21.react-media-template/src/components/PlayerProgressBar.jsx
+++ b/samples/21.react-media-template/src/components/PlayerProgressBar.jsx
@@ -65,6 +65,8 @@ const PlayerProgressBar = ({
 
       setToolTipContent(formatTimeValue(hoverTime));
 
+      console.log(xPosition, dimension.top - scrollOffSet)
+
       popperRef.current?.setTarget({
         getBoundingClientRect: getRect(xPosition, dimension.top - scrollOffSet),
         positionFixed: true,
@@ -95,7 +97,7 @@ const PlayerProgressBar = ({
   return (
     <div className={flexItemStyles.noShrink} ref={resizeRef}>
       <div className={styles.pageEl}>
-        <Tooltip withArrow positioning={{ popperRef }} content={toolTipContent} relationship="label">
+        <Tooltip withArrow positioning={{ positioningRef: popperRef }} content={toolTipContent} relationship="label">
           <Slider
             root={{ ref: sliderRef }}
             min={0}

--- a/samples/21.react-media-template/src/components/PlayerProgressBar.jsx
+++ b/samples/21.react-media-template/src/components/PlayerProgressBar.jsx
@@ -18,7 +18,7 @@ const PlayerProgressBar = ({
   isPlaybackDisabled,
   onSeek
 }) => {
-  const popperRef = useRef();
+  const toolTipPositioningRef = useRef();
   const sliderRef = useRef();
   const [dimension, setDimensions] = useState();
   const [toolTipContent, setToolTipContent] = useState("0:00");
@@ -65,9 +65,7 @@ const PlayerProgressBar = ({
 
       setToolTipContent(formatTimeValue(hoverTime));
 
-      console.log(xPosition, dimension.top - scrollOffSet)
-
-      popperRef.current?.setTarget({
+      toolTipPositioningRef.current?.setTarget({
         getBoundingClientRect: getRect(xPosition, dimension.top - scrollOffSet),
         positionFixed: true,
       });
@@ -84,7 +82,7 @@ const PlayerProgressBar = ({
 
       setToolTipContent(formatTimeValue(hoverTime));
 
-      popperRef.current?.setTarget({
+      toolTipPositioningRef.current?.setTarget({
         getBoundingClientRect: getRect(xPosition, dimension.top - scrollOffSet),
         positionFixed: true,
       });
@@ -97,7 +95,7 @@ const PlayerProgressBar = ({
   return (
     <div className={flexItemStyles.noShrink} ref={resizeRef}>
       <div className={styles.pageEl}>
-        <Tooltip withArrow positioning={{ positioningRef: popperRef }} content={toolTipContent} relationship="label">
+        <Tooltip withArrow positioning={{ positioningRef: toolTipPositioningRef }} content={toolTipContent} relationship="label">
           <Slider
             root={{ ref: sliderRef }}
             min={0}

--- a/samples/21.react-media-template/src/components/TabbedList.jsx
+++ b/samples/21.react-media-template/src/components/TabbedList.jsx
@@ -3,9 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import { mergeClasses } from "@fluentui/react-components";
+import { mergeClasses, TabList, Tab } from "@fluentui/react-components";
 import { getFlexItemStyles, getFlexRowStyles } from "../styles/layouts";
-import { TabList, Tab } from "@fluentui/react-components";
 import { MediaCard } from "./MediaCard";
 import { useMemo, useState } from "react";
 

--- a/samples/21.react-media-template/src/styles/layouts.js
+++ b/samples/21.react-media-template/src/styles/layouts.js
@@ -92,13 +92,13 @@ export const getFlexColumnStyles = makeStyles({
     "::-webkit-scrollbar-thumb": {
       backgroundColor: tokens.colorPaletteCharcoalBackground3,
       borderLeftColor: tokens.colorPaletteCharcoalBackground2,
-      borderLeftWidth: "4px",
+      borderLeftWidth: "6px",
       borderLeftStyle: "solid",
       backgroundClip: "padding-box",
-      borderTopLeftRadius: "5px",
-      borderTopRightRadius: "4px",
+      borderTopLeftRadius: "4px",
+      borderTopRightRadius: "14px",
       borderBottomLeftRadius: "5px",
-      borderBottomRightRadius: "4px",
+      borderBottomRightRadius: "14px",
     },
     "::-webkit-scrollbar-thumb:hover": {
       backgroundColor: tokens.colorPaletteCharcoalForeground3,

--- a/samples/22.react-agile-poker/package.json
+++ b/samples/22.react-agile-poker/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "@fluentui/react-components": "^9.0.1",
+    "@fluidframework/azure-client": "~0.59.0",
     "@microsoft/live-share": "~0.3.1",
     "@microsoft/teams-js": "2.0.0-experimental.0",
     "@testing-library/jest-dom": "^5.16.2",
@@ -17,8 +18,7 @@
     "react-router-dom": "^6.2.2",
     "react-scripts": "^4.0.0",
     "uuid": "^8.3.2",
-    "web-vitals": "^2.1.4",
-    "tabster": "1.4.2"
+    "web-vitals": "^2.1.4"
   },
   "devDependencies": {
     "@fluidframework/test-client-utils": "~0.59.0",

--- a/samples/22.react-agile-poker/package.json
+++ b/samples/22.react-agile-poker/package.json
@@ -5,7 +5,7 @@
   "author": "Microsoft",
   "license": "MIT",
   "dependencies": {
-    "@fluentui/react-components": "^9.0.0-rc.10",
+    "@fluentui/react-components": "^9.0.1",
     "@microsoft/live-share": "~0.3.1",
     "@microsoft/teams-js": "2.0.0-experimental.0",
     "@testing-library/jest-dom": "^5.16.2",
@@ -17,7 +17,8 @@
     "react-router-dom": "^6.2.2",
     "react-scripts": "^4.0.0",
     "uuid": "^8.3.2",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "tabster": "1.4.2"
   },
   "devDependencies": {
     "@fluidframework/test-client-utils": "~0.59.0",


### PR DESCRIPTION
- Upgraded React samples to Fluent UI v9.0.1, including a fix for regression to the hover tooltip for media controls
- Added `@fluidframework/azure-client` as a dependency for the React samples to fix issue when building app without Lerna