### PR TITLE
Correct handling of play errors in IMediaPlayer, MediaPlayerSynchronizer, and samples

### DIFF
--- a/packages/live-share-media/src/IMediaPlayer.ts
+++ b/packages/live-share-media/src/IMediaPlayer.ts
@@ -15,7 +15,7 @@ export interface IMediaPlayer {
     volume: number;
     load(): void;
     pause(): void;
-    play(): void;
+    play(): Promise<void>;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }

--- a/samples/02.react-video/src/pages/MeetingStage.jsx
+++ b/samples/02.react-video/src/pages/MeetingStage.jsx
@@ -56,13 +56,13 @@ const MeetingStage = () => {
       const { mediaSession } = container.initialObjects;
       synchronizer.current = mediaSession.synchronize(videoElement.current);
       synchronizer.current.addEventListener(MediaPlayerSynchronizerEvents.groupaction, (evt) => {
-        if (evt.details.action === "play" && evt.playerError?.name === "NotAllowedError") {
+        if (evt.details.action === "play" && evt.error?.name === "NotAllowedError") {
           // The user has not interacted with the document so the browser blocked the play action
           // mute the player and try again
           synchronizer.current.player.muted = true;
           synchronizer.current.player.play();
-        } else if (evt.playerError) {
-          console.error(evt.playerError);
+        } else if (evt.error) {
+          console.error(evt.error);
         }
       });
       await mediaSession.start();

--- a/samples/02.react-video/src/pages/MeetingStage.jsx
+++ b/samples/02.react-video/src/pages/MeetingStage.jsx
@@ -7,7 +7,7 @@ import { useEffect, useRef } from "react";
 import { getVideoStyle } from "../styles/styles";
 import { getInitialMediaItem } from "../utils/getInitialMediaItem";
 import { MediaPlayerContainer } from "../components";
-import { EphemeralMediaSession } from "@microsoft/live-share-media";
+import { EphemeralMediaSession, MediaPlayerSynchronizerEvents } from "@microsoft/live-share-media";
 import { TeamsFluidClient } from "@microsoft/live-share";
 import { inTeams } from "../utils/inTeams";
 import { LOCAL_MODE_TENANT_ID } from "@fluidframework/azure-client";
@@ -27,9 +27,6 @@ const MeetingStage = () => {
     (async function () {
       // Set the initial video src for the player element
       videoElement.current.src = initialMediaItem.current.src;
-      // Browsers require a click before a video can be played automatically
-      // Either capture a click or mute the audio by default
-      videoElement.current.muted = true;
 
       let connection;
       if (!inTeams()) {
@@ -58,6 +55,16 @@ const MeetingStage = () => {
       const { container } = await client.joinContainer(schema);
       const { mediaSession } = container.initialObjects;
       synchronizer.current = mediaSession.synchronize(videoElement.current);
+      synchronizer.current.addEventListener(MediaPlayerSynchronizerEvents.groupaction, (evt) => {
+        if (evt.details.action === "play" && evt.playerError?.name === "NotAllowedError") {
+          // The user has not interacted with the document so the browser blocked the play action
+          // mute the player and try again
+          synchronizer.current.player.muted = true;
+          synchronizer.current.player.play();
+        } else if (evt.playerError) {
+          console.error(evt.playerError);
+        }
+      });
       await mediaSession.start();
     })();
   }, []);

--- a/samples/21.react-media-template/src/utils/AzureMediaPlayer.js
+++ b/samples/21.react-media-template/src/utils/AzureMediaPlayer.js
@@ -208,7 +208,7 @@ export class AzureMediaPlayer extends EventTarget {
     this._player.src(this._track.src);
   }
 
-  play() {
+  async play() {
     this._player.play();
     if (!this._autoplayPolicyChecked) {
       this._autoplayPolicyChecked = true;
@@ -217,6 +217,9 @@ export class AzureMediaPlayer extends EventTarget {
         this.play();
       }
     }
+    // HTMLMediaPlayer spec is Promise<void> but AMP does not adhere to this spec for play, so we simply
+    // resolve the promise.
+    return Promise.resolve();
   }
 
   pause() {


### PR DESCRIPTION
- Updated IMediaPlayer interface to adhere to HTMLMediaPlayer spec for `play(): Promise<void>`
- Updated `MediaPlayerSynchronizer` to emit `playerError` with `groupaction` events when a player error is encountered.
- Updated sample 02 to handle error.
- Updated sample 21 to resolve promise in `play()` method in `AzureMediaPlayer.ts`