### PR TITLE
Stevenic/is newer fix

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.0.0",
 			"license": "Microsoft",
 			"dependencies": {
-				"@fluentui/react-components": "^9.0.0-rc.10",
+				"@fluentui/react-components": "^9.0.1",
 				"@fluidframework/azure-client": "~0.59.0",
 				"@fluidframework/test-client-utils": "~0.59.0",
 				"@fluidframework/test-runtime-utils": "~0.59.0",
@@ -1957,9 +1957,9 @@
 			}
 		},
 		"node_modules/@fluentui/keyboard-keys": {
-			"version": "9.0.0-rc.6",
-			"resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.0-rc.6.tgz",
-			"integrity": "sha512-YQ7Zf2V0kvLNs27jPbd9+ii30yQQgqN44aaliEdlIXcGXk76Fvb2eEBkvKd9mk8tVbCeVRpgNJOsZKAocIqm3w==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.0.tgz",
+			"integrity": "sha512-8oxbUYfsUG9Qwy0akfXkECyMj6wJtrRB6ZOO1ngYDBvSq6yY6Ifg+ezFiRC8IxRaHf/yqwXjGOHUZy1ZOrd+Ww==",
 			"dependencies": {
 				"tslib": "^2.1.0"
 			}
@@ -1970,9 +1970,9 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/priority-overflow": {
-			"version": "9.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.0.0-beta.1.tgz",
-			"integrity": "sha512-g0kpjnkou0c28HLCXjSN/c3ZfYEw8+WJExDuG/AG/JNvbqzPnB75iFYjDxk+UPErZYPvbaqbCcMB9yI4cv479A==",
+			"version": "9.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.0.0-beta.2.tgz",
+			"integrity": "sha512-Syhl+psD3tIKVVR+eS28poRoVbtyZ4iN+izOeuV01hZELOoMaud/MM1qIUSeH8AnBSydDDCaXWgwwJ+pnUHPAQ==",
 			"dependencies": {
 				"tslib": "^2.1.0"
 			}
@@ -1983,25 +1983,26 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-accordion": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.0.0-rc.14.tgz",
-			"integrity": "sha512-//+wwYEDHiC9Z2muMjHAoyFjHAnimEiUPe3OJxtdZ0BTxbnKaTTQrX4eokklPv1p5hkYWZcrGaCgWo/altW75w==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.0.3.tgz",
+			"integrity": "sha512-NL2nMZ1LvWV1E3nkTyVlrRqdsPJ5PlbrWo6tPpDKo/53RceBBehPB8tSiwQTaRMu5ns39ouN2HgnFn04woDLaw==",
 			"dependencies": {
-				"@fluentui/react-aria": "9.0.0-rc.10",
-				"@fluentui/react-context-selector": "9.0.0-rc.10",
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-aria": "^9.0.2",
+				"@fluentui/react-context-selector": "^9.0.2",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
 				"@types/react": ">=16.8.0 <18.0.0",
 				"@types/react-dom": ">=16.8.0 <18.0.0",
 				"react": ">=16.8.0 <18.0.0",
-				"react-dom": ">=16.8.0 <18.0.0"
+				"react-dom": ">=16.8.0 <18.0.0",
+				"scheduler": "^0.19.0 || ^0.20.0"
 			}
 		},
 		"node_modules/@fluentui/react-accordion/node_modules/tslib": {
@@ -2010,15 +2011,16 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-alert": {
-			"version": "9.0.0-beta.3",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.3.tgz",
-			"integrity": "sha512-hwkg33/1uFEYmD+YrqpQkMPV65P7MDEvjwHJ7GDbmnxZjIiQogh1PZdkUdvzwy4+eqg7WUIhc1k1W13u/yyMuQ==",
+			"version": "9.0.0-beta.7",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.7.tgz",
+			"integrity": "sha512-oWgjLylwNbV9XoEJx9NEwN3nQ8F3GvRwlY1+VFMYxfe5TGteGUOy+8gFG+sPJ/0aXFocI7oAaHw88wnN6fVhGg==",
 			"dependencies": {
-				"@fluentui/react-button": "9.0.0-rc.14",
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-avatar": "^9.0.3",
+				"@fluentui/react-button": "^9.0.3",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2034,12 +2036,12 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-aria": {
-			"version": "9.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.0.0-rc.10.tgz",
-			"integrity": "sha512-x2JyqUb1cMEXm0JOB8/VvSCLrYzQbgGjt6gAjcJrDZ334JgyS8np3EznAR58r0bx+NfAqC1XXGnvE5iJiZhQGQ==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.0.2.tgz",
+			"integrity": "sha512-aJ3yNtbHPeSlyWr/9zXQ0tbHwOnH4rJP4QraUZch7FvxCfRkiBcJk5hIZFpdNU3t94L0t8CmZVJdluukQkAcDg==",
 			"dependencies": {
-				"@fluentui/keyboard-keys": "9.0.0-rc.6",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
+				"@fluentui/keyboard-keys": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2055,26 +2057,28 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-avatar": {
-			"version": "9.0.0-rc.13",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.0.0-rc.13.tgz",
-			"integrity": "sha512-B3aNeKFwfI4LrMS8WGzfQAmnUQZgd15nS+NmfXNK7467JAYItQQdcpR6QhS9LUPXbC78TmgCr8eNXpdwUkQNSA==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.0.3.tgz",
+			"integrity": "sha512-aXAHJLwn5+fiw9XlNy55ejboDzu3oQxEQ44OGsbirKPNudiyT+dF+tL5AkVvkTyl2NIO/DVN3ku7Zatgd+MajA==",
 			"dependencies": {
-				"@fluentui/react-badge": "9.0.0-rc.13",
-				"@fluentui/react-button": "9.0.0-rc.14",
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-popover": "9.0.0-rc.14",
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-tooltip": "9.0.0-rc.14",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-badge": "^9.0.3",
+				"@fluentui/react-context-selector": "^9.0.2",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-popover": "^9.0.3",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-tooltip": "^9.0.3",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
 				"@types/react": ">=16.8.0 <18.0.0",
 				"@types/react-dom": ">=16.8.0 <18.0.0",
 				"react": ">=16.8.0 <18.0.0",
-				"react-dom": ">=16.8.0 <18.0.0"
+				"react-dom": ">=16.8.0 <18.0.0",
+				"scheduler": "^0.19.0 || ^0.20.0"
 			}
 		},
 		"node_modules/@fluentui/react-avatar/node_modules/tslib": {
@@ -2083,14 +2087,14 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-badge": {
-			"version": "9.0.0-rc.13",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.0.0-rc.13.tgz",
-			"integrity": "sha512-12vYiuDjp4pGYaXT4mHzv7ctxVi34bSDlYwEB7yGly9C63eeM01yT1nsYHOI/lRwJcmoeCOHZL1KCwrcAN4fNg==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.0.3.tgz",
+			"integrity": "sha512-ItgrmgRVxM3B1HHbQmdshfL6YoVXBB61oD9xYfN9xEQopApED/eqncEP0LkKYxxiNKMDZPYWGRogwLfRtzX5hg==",
 			"dependencies": {
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2106,17 +2110,17 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-button": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.0.0-rc.14.tgz",
-			"integrity": "sha512-UKj3aX+Sz1ZZaYnfpl0eQhV/sb8Svfi3UdyLPmK3e2LcVwdXHUhpCfe81ew2p5bx6Vys+pvmSId+PYi+1rz9Rg==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.0.3.tgz",
+			"integrity": "sha512-W+/tH6HuvWBVepuZhOzlVBrj14BDWiiZC9f9/+80exGVMwR6Iq8A1rF4JeeOcv7Nyp0tQ7dkgAVNRu0Q8aaWPg==",
 			"dependencies": {
-				"@fluentui/keyboard-keys": "9.0.0-rc.6",
-				"@fluentui/react-aria": "9.0.0-rc.10",
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/keyboard-keys": "^9.0.0",
+				"@fluentui/react-aria": "^9.0.2",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2132,14 +2136,14 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-card": {
-			"version": "9.0.0-beta.19",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.0.0-beta.19.tgz",
-			"integrity": "sha512-zhbNGQDx/egdBfzIwixvt7dOqMPfL1NOy+bgYW/hvctnaynmszDwBsWY4yWfIwcAN3A6mOXiqyng6jHlPRy+Og==",
+			"version": "9.0.0-beta.23",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.0.0-beta.23.tgz",
+			"integrity": "sha512-e3uupguxVn2mFuR2e22f2eJoTzhhotdazsWy1A4/hYEgFw4vth6Mo6P3jeegalef/mkvBUHonIBWJHnok3XM4Q==",
 			"dependencies": {
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2155,16 +2159,16 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-checkbox": {
-			"version": "9.0.0-rc.6",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.0.0-rc.6.tgz",
-			"integrity": "sha512-swdrMiScXkQJi6AyNBcJem1PZatI2L6R5QJLC8eYo+FtaBv527cK5CT4eF8DCbMTho+0Ciro9QOyX5wxnMJsYQ==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.0.3.tgz",
+			"integrity": "sha512-Ys2Y6Mq0Wj9AUgKpQnwqfD7iL3UVcuvVsUe/gqAvDk7u76+TzfYCy9ykwZyyd7uIV1z6CSoddnUtB+tcu8qNuw==",
 			"dependencies": {
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-label": "9.0.0-rc.6",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-label": "^9.0.3",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2179,50 +2183,81 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
-		"node_modules/@fluentui/react-components": {
-			"version": "9.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.0.0-rc.15.tgz",
-			"integrity": "sha512-rLnnRY75R6Ige/sjFVig1g4fPeUIuaS0d0bh3qrzKO0k9n5yTngYJF5h4oYeBdbCl06CmdX+UCI9ObIn2Xx/Aw==",
+		"node_modules/@fluentui/react-combobox": {
+			"version": "9.0.0-beta.7",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.0.0-beta.7.tgz",
+			"integrity": "sha512-9t3FoJr8dfPuQ3Q7utoM744WZ0cjonvJCjhrfKPoS8aQpCUkiZIvIxfUjfb0Pj4IN3FHfa04xPm0X9sJz3Swww==",
 			"dependencies": {
-				"@fluentui/react-accordion": "9.0.0-rc.14",
-				"@fluentui/react-alert": "9.0.0-beta.3",
-				"@fluentui/react-avatar": "9.0.0-rc.13",
-				"@fluentui/react-badge": "9.0.0-rc.13",
-				"@fluentui/react-button": "9.0.0-rc.14",
-				"@fluentui/react-card": "9.0.0-beta.19",
-				"@fluentui/react-checkbox": "9.0.0-rc.6",
-				"@fluentui/react-divider": "9.0.0-rc.12",
-				"@fluentui/react-image": "9.0.0-rc.12",
-				"@fluentui/react-input": "9.0.0-rc.6",
-				"@fluentui/react-label": "9.0.0-rc.6",
-				"@fluentui/react-link": "9.0.0-rc.14",
-				"@fluentui/react-menu": "9.0.0-rc.14",
-				"@fluentui/react-overflow": "9.0.0-beta.4",
-				"@fluentui/react-popover": "9.0.0-rc.14",
-				"@fluentui/react-positioning": "9.0.0-rc.12",
-				"@fluentui/react-provider": "9.0.0-rc.14",
-				"@fluentui/react-radio": "9.0.0-rc.7",
-				"@fluentui/react-select": "9.0.0-beta.3",
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-slider": "9.0.0-beta.19",
-				"@fluentui/react-spinbutton": "9.0.0-beta.14",
-				"@fluentui/react-spinner": "9.0.0-rc.6",
-				"@fluentui/react-switch": "9.0.0-rc.14",
-				"@fluentui/react-tabs": "9.0.0-rc.6",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-text": "9.0.0-rc.12",
-				"@fluentui/react-textarea": "9.0.0-rc.6",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-tooltip": "9.0.0-rc.14",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/keyboard-keys": "^9.0.0",
+				"@fluentui/react-context-selector": "^9.0.2",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-portal": "^9.0.3",
+				"@fluentui/react-positioning": "^9.1.1",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
 				"@types/react": ">=16.8.0 <18.0.0",
 				"@types/react-dom": ">=16.8.0 <18.0.0",
 				"react": ">=16.8.0 <18.0.0",
-				"react-dom": ">=16.8.0 <18.0.0"
+				"react-dom": ">=16.8.0 <18.0.0",
+				"scheduler": "^0.19.0 || ^0.20.0"
+			}
+		},
+		"node_modules/@fluentui/react-combobox/node_modules/tslib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+		},
+		"node_modules/@fluentui/react-components": {
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.1.1.tgz",
+			"integrity": "sha512-2fMNPz0l1IyvjrX6ys8lEJZBp9NF+zMcHqO/yjhIyPV0h5YKBQrV+nFuYR+zBEPsHaDkd1aWtCxTenPHEy+KXw==",
+			"dependencies": {
+				"@fluentui/react-accordion": "^9.0.3",
+				"@fluentui/react-alert": "9.0.0-beta.7",
+				"@fluentui/react-avatar": "^9.0.3",
+				"@fluentui/react-badge": "^9.0.3",
+				"@fluentui/react-button": "^9.0.3",
+				"@fluentui/react-card": "9.0.0-beta.23",
+				"@fluentui/react-checkbox": "^9.0.3",
+				"@fluentui/react-combobox": "^9.0.0-beta.7",
+				"@fluentui/react-divider": "^9.0.3",
+				"@fluentui/react-image": "^9.0.3",
+				"@fluentui/react-input": "^9.0.3",
+				"@fluentui/react-label": "^9.0.3",
+				"@fluentui/react-link": "^9.0.3",
+				"@fluentui/react-menu": "^9.0.3",
+				"@fluentui/react-overflow": "9.0.0-beta.8",
+				"@fluentui/react-popover": "^9.0.3",
+				"@fluentui/react-positioning": "^9.1.1",
+				"@fluentui/react-provider": "^9.0.3",
+				"@fluentui/react-radio": "^9.0.3",
+				"@fluentui/react-select": "9.0.0-beta.7",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-slider": "^9.0.2",
+				"@fluentui/react-spinbutton": "9.0.0-beta.18",
+				"@fluentui/react-spinner": "^9.0.3",
+				"@fluentui/react-switch": "^9.0.3",
+				"@fluentui/react-tabs": "^9.0.3",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-text": "^9.0.3",
+				"@fluentui/react-textarea": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-toolbar": "9.0.0-beta.4",
+				"@fluentui/react-tooltip": "^9.0.3",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
+				"tslib": "^2.1.0"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.8.0 <18.0.0",
+				"@types/react-dom": ">=16.8.0 <18.0.0",
+				"react": ">=16.8.0 <18.0.0",
+				"react-dom": ">=16.8.0 <18.0.0",
+				"scheduler": "^0.19.0 || ^0.20.0"
 			}
 		},
 		"node_modules/@fluentui/react-components/node_modules/tslib": {
@@ -2231,11 +2266,11 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-context-selector": {
-			"version": "9.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.0.0-rc.10.tgz",
-			"integrity": "sha512-1WlzzQ0/6DnwlrDSvtFuC8qlDUeD5j4L+WVXpfObcQeAkRpDTmiUkN356tU6a5v6t+XualXsI5cBOa30GH5MPA==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.0.2.tgz",
+			"integrity": "sha512-4ypIKRqAKyywmIq+OHNE85q30wwXJgAcOY7i37eNW2FgKbfC9qY0R0C/JS1kkvv4PwHzkl/mRq/+bgzWenxZNQ==",
 			"dependencies": {
-				"@fluentui/react-utilities": "9.0.0-rc.10",
+				"@fluentui/react-utilities": "^9.0.2",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2252,13 +2287,13 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-divider": {
-			"version": "9.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.0.0-rc.12.tgz",
-			"integrity": "sha512-vLNfULHMPbKQVOoC21ZC87/0xaV0Gk6kKzSNf1E3nFMwwFDVZ1lvxXKTw091JBzvva9yqejWsa59dyx2K1aLZg==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.0.3.tgz",
+			"integrity": "sha512-CrDkwvb5od9qfW143oYnuxW8D2Yh+aw0puUqADfr6u25FXnM5uZbhB8HOT3o13qO5XRG/fVUihKcOf6IEG8oyg==",
 			"dependencies": {
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2274,22 +2309,31 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-icons": {
-			"version": "2.0.174",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.174.tgz",
-			"integrity": "sha512-PN65EH8vDbHqQ9DJb2CMV37iiR+clFF3Orl4KZN7OW3AjdHc9GVaznWh/kmTfPpg1ScS6i/Fs2F7m9J61WIwYw==",
+			"version": "2.0.178",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.178.tgz",
+			"integrity": "sha512-10GprgDPzAj5wz0BDz4NLSEgong0DZBEeoS6R2xt9Pf1nHYmfQEonz6xFT4y094xgI+9XzpC8pohnenhmdZ97w==",
+			"dependencies": {
+				"@griffel/react": "^1.0.0",
+				"tslib": "^2.1.0"
+			},
 			"peerDependencies": {
 				"@griffel/react": "^1.0.0",
 				"react": ">=16.8.0 <18.0.0"
 			}
 		},
+		"node_modules/@fluentui/react-icons/node_modules/tslib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+		},
 		"node_modules/@fluentui/react-image": {
-			"version": "9.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.0.0-rc.12.tgz",
-			"integrity": "sha512-okhnmxtUX50k+sUB9npuFO+IsM3XtQgpBCgJaEBwrMwqCq3s+9C0RlTJ0e/ajN+qocfYKyyELn52CXQd/XfSZg==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.0.3.tgz",
+			"integrity": "sha512-dfkHZ5Dp8bhCTtowLXYBMcSE3S3sXEx9Ipnyl1bOasy7h0KgnueFV1a2ySBxT/GGeSklEhYvXUot7eJEq40gXg==",
 			"dependencies": {
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2305,13 +2349,13 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-input": {
-			"version": "9.0.0-rc.6",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.0.0-rc.6.tgz",
-			"integrity": "sha512-+SvcO4gnHiSCqgDPwmcb7nSbWShyMSHJeUrJe9jvWaCBORMUbwDTMLT0WeHCB+o2b2pJgMnjq2uymARFkqkvBA==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.0.3.tgz",
+			"integrity": "sha512-Y94IWdCFS4KqR0dfFBHoACI1JOB0/w3YQyYmGeDsbylt3+g5eZt8yC8+Ed/kqfclm2y2sz9VeMPfCsC7YJxnPg==",
 			"dependencies": {
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2327,13 +2371,13 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-label": {
-			"version": "9.0.0-rc.6",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.0.0-rc.6.tgz",
-			"integrity": "sha512-Mz+ErPx0hSwI3panrFHzssn3NiIS6Aj1d1FWlkglWhS7VJQsdx0/aaDFDAXAk60AyWWWtZnJZ8HoTXbACtEu8A==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.0.3.tgz",
+			"integrity": "sha512-It9HFIHeGDkw1fb17vawb3/kY60wz7ygrGUbC13b8JaGSO9Sud6+r5M0WDJMlNp2niMJ5CpNrdH7NXXemLc3pQ==",
 			"dependencies": {
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2349,15 +2393,15 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-link": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.0.0-rc.14.tgz",
-			"integrity": "sha512-Tj907IZFL8lSE/HQfg4otwCBEgwlvZyDI2Pq/hK8A1NuSTf/hHUhEXEMcbpN4ZsOOPzlk3fkPGtIpt0IvVYaTQ==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.0.3.tgz",
+			"integrity": "sha512-ncjEcUTD8gOg0p/vuAgYTT+mMwlbjcTieVRcw3EHZJ1tRAIlhRrz5XxNrymTM8pPuiDDuGJN+LrjggKm/3BdhA==",
 			"dependencies": {
-				"@fluentui/keyboard-keys": "9.0.0-rc.6",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/keyboard-keys": "^9.0.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2373,27 +2417,28 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-menu": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.0.0-rc.14.tgz",
-			"integrity": "sha512-CpfENrTjb0QyyTTkV+3BxcwUvwub9bKPbuw5CO4PmftrN1cPEjL2oe//zyb7uSaDn5VgXBN8yQsr1dFs4IvgSQ==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.0.3.tgz",
+			"integrity": "sha512-niTrp7FLhrC6WM3FI04h8f/9MFhe++nkBdiDN8vGdD0ttQbLP9Z5YpUEoEkNIhhoq+h1kvVroW5XZTC5ypPtkA==",
 			"dependencies": {
-				"@fluentui/keyboard-keys": "9.0.0-rc.6",
-				"@fluentui/react-context-selector": "9.0.0-rc.10",
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-portal": "9.0.0-rc.14",
-				"@fluentui/react-positioning": "9.0.0-rc.12",
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/keyboard-keys": "^9.0.0",
+				"@fluentui/react-context-selector": "^9.0.2",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-portal": "^9.0.3",
+				"@fluentui/react-positioning": "^9.1.1",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
 				"@types/react": ">=16.8.0 <18.0.0",
 				"@types/react-dom": ">=16.8.0 <18.0.0",
 				"react": ">=16.8.0 <18.0.0",
-				"react-dom": ">=16.8.0 <18.0.0"
+				"react-dom": ">=16.8.0 <18.0.0",
+				"scheduler": "^0.19.0 || ^0.20.0"
 			}
 		},
 		"node_modules/@fluentui/react-menu/node_modules/tslib": {
@@ -2402,22 +2447,23 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-overflow": {
-			"version": "9.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.0.0-beta.4.tgz",
-			"integrity": "sha512-XBCC1cnvOsKeGqbZNBe/MJT7ep+7zYMWyW3NEAJLSOFq4lriESzDSgmQuxLlesewKIz4DRbXompw87NupdJ3Wg==",
+			"version": "9.0.0-beta.8",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.0.0-beta.8.tgz",
+			"integrity": "sha512-nq/Kh10iZBEUSl9KtQrbKqb0d8MOtIHdmyQ8lnnaNdIWVsxLd/J0NW494IpMIBdeK8WtRp0TeuBV0KJWwHaUtw==",
 			"dependencies": {
-				"@fluentui/priority-overflow": "^9.0.0-beta.1",
-				"@fluentui/react-context-selector": "9.0.0-rc.10",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/priority-overflow": "^9.0.0-beta.2",
+				"@fluentui/react-context-selector": "^9.0.2",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
 				"@types/react": ">=16.8.0 <18.0.0",
 				"@types/react-dom": ">=16.8.0 <18.0.0",
 				"react": ">=16.8.0 <18.0.0",
-				"react-dom": ">=16.8.0 <18.0.0"
+				"react-dom": ">=16.8.0 <18.0.0",
+				"scheduler": "^0.19.0 || ^0.20.0"
 			}
 		},
 		"node_modules/@fluentui/react-overflow/node_modules/tslib": {
@@ -2426,25 +2472,26 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-popover": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.0.0-rc.14.tgz",
-			"integrity": "sha512-O7HQ+9sraVffZqGMOb26ck+gsdtHMv3Gcrv3IELFKrlGbucaT8zCwupgawJmHVRpvILqcoEskII5QpHCruODfA==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.0.3.tgz",
+			"integrity": "sha512-18jqT1TtylTWWRGviMZMqY9nk961CKNeOJhOxtZ45QlUWbu5urILYhtpMfDAf1Tx/HZQarztlqgY5/aS4zfWZg==",
 			"dependencies": {
-				"@fluentui/react-context-selector": "9.0.0-rc.10",
-				"@fluentui/react-portal": "9.0.0-rc.14",
-				"@fluentui/react-positioning": "9.0.0-rc.12",
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-context-selector": "^9.0.2",
+				"@fluentui/react-portal": "^9.0.3",
+				"@fluentui/react-positioning": "^9.1.1",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
 				"@types/react": ">=16.8.0 <18.0.0",
 				"@types/react-dom": ">=16.8.0 <18.0.0",
 				"react": ">=16.8.0 <18.0.0",
-				"react-dom": ">=16.8.0 <18.0.0"
+				"react-dom": ">=16.8.0 <18.0.0",
+				"scheduler": "^0.19.0 || ^0.20.0"
 			}
 		},
 		"node_modules/@fluentui/react-popover/node_modules/tslib": {
@@ -2453,13 +2500,14 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-portal": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.0.0-rc.14.tgz",
-			"integrity": "sha512-monL7hmb3/cGYo5nn3Kbhbog+iiueSN9seAKG8NA5zpiLwjvBcwaPfvxg6NQTUOAMafx9BdMMEqBRY14RKutgw==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.0.3.tgz",
+			"integrity": "sha512-sPKO/sUy9Ew0xVPfcPKphzTLZD7FoACiMDtmnt3NuUc9mJOFWkFZOEQ2bYGs+lgnkMciuA17GxQTEzO1Fn77jw==",
 			"dependencies": {
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2475,14 +2523,14 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-positioning": {
-			"version": "9.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.0.0-rc.12.tgz",
-			"integrity": "sha512-RS+zxpC6r3fIxrEBx3uGBIo2lTtxAmceeX0TI3Yv7Oqum6Jf/6qg8zrMt4+KNZrUlAlJjGtTU53E+f9JQP5NSA==",
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.1.1.tgz",
+			"integrity": "sha512-bQFbJV+W8fdDwNHsgZ+vLMzKYUcwyPrYuQYwqqlnstTYYZkXPSz3KV0QFCdcCK1DIjNTOukq5ppnEvPWw+j2OQ==",
 			"dependencies": {
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"@popperjs/core": "~2.4.3",
 				"tslib": "^2.1.0"
 			},
@@ -2499,15 +2547,16 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-provider": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.0.0-rc.14.tgz",
-			"integrity": "sha512-7axsF9UQP2FUtUK0b4l/Aqm98PGfKXHxswb5gqRYeTAJtsKAf33HfceCvpOuLwfzRMUNrps0sNgvfN4/OV1ADQ==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.0.3.tgz",
+			"integrity": "sha512-0OUv3UgE9t2gdeYY0yuVq2blqaC0FDUHK+fCAmPHhj2Pj9p62JC5NbYX0e0ucqIW7caB4iZE0oQ+muI7xzVibw==",
 			"dependencies": {
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/core": "^1.4.1",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2523,24 +2572,25 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-radio": {
-			"version": "9.0.0-rc.7",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.0.0-rc.7.tgz",
-			"integrity": "sha512-BIHyjBmhwjPKMuyrpGWOstBeBjJNjyktw2nmLBkuCd+qFdWCBxdQYXZKH9Y6KPZaeCVU1A831Yts7O3nHEuMMA==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.0.3.tgz",
+			"integrity": "sha512-MFbNWoEShIvMKCtr8DjM0XC6AhMxoyYKZvHMbYyFYzBtsq3OZz5uV04+JltBZRPz7darwiYJp6hfTpFFr/T3YQ==",
 			"dependencies": {
-				"@fluentui/react-context-selector": "9.0.0-rc.10",
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-label": "9.0.0-rc.6",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-context-selector": "^9.0.2",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-label": "^9.0.3",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
 				"@types/react": ">=16.8.0 <18.0.0",
 				"@types/react-dom": ">=16.8.0 <18.0.0",
 				"react": ">=16.8.0 <18.0.0",
-				"react-dom": ">=16.8.0 <18.0.0"
+				"react-dom": ">=16.8.0 <18.0.0",
+				"scheduler": "^0.19.0 || ^0.20.0"
 			}
 		},
 		"node_modules/@fluentui/react-radio/node_modules/tslib": {
@@ -2549,14 +2599,14 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-select": {
-			"version": "9.0.0-beta.3",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.0.0-beta.3.tgz",
-			"integrity": "sha512-jiaRptqMgev+1Wh5lVgR9Wd2aYCm+4kAokESy9SozA0BLCChGAigRIXTQq9Q7WnoaeV/SNXMwqAIEhEM2ZP7hQ==",
+			"version": "9.0.0-beta.7",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.0.0-beta.7.tgz",
+			"integrity": "sha512-yKvvcP3XFw29XafpiBl/b9rE3cnajPklvYzLcOe2HqgQMOokLXTrBHMELv0JsGIOdaP+M0As2ZoLujc+8GisLA==",
 			"dependencies": {
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2572,11 +2622,11 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-shared-contexts": {
-			"version": "9.0.0-rc.11",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.0.0-rc.11.tgz",
-			"integrity": "sha512-bLlJ5B7BuRgI5v+WB2Rr8/6+Ms0Y3r2Ci3R7087iRFWYxW4yAX3Y0WiapASRW25UL6khwYpWil2s6s50rY12Cw==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.0.0.tgz",
+			"integrity": "sha512-ZuUO5ZxBaVQR/4rXJIrV9coYYk7QXkDThDS5W7ueUWjEmdRfiUjxAEhpK8vl56lnWdaTRaWCNKrKNOKKua4JBg==",
 			"dependencies": {
-				"@fluentui/react-theme": "9.0.0-rc.10",
+				"@fluentui/react-theme": "^9.0.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2590,15 +2640,15 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-slider": {
-			"version": "9.0.0-beta.19",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.0.0-beta.19.tgz",
-			"integrity": "sha512-jV4o6U5yldB2o4JfLWv0G9vAl1DEBOOlMFFvX85nYsiuQCYX2cIl1bm+eKVI1RLqp0l/lBs/mVhxBqaN+8/ZcA==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.0.2.tgz",
+			"integrity": "sha512-f5sWitymxKnM6AfkesjqlaAE9Dmmq8bR45KxxEIR/blLV+yFNgWlUF0fZdaSgtx9DV+JI7c7J95g26Z/LmvlUA==",
 			"dependencies": {
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2614,16 +2664,16 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-spinbutton": {
-			"version": "9.0.0-beta.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.0.0-beta.14.tgz",
-			"integrity": "sha512-AX2VjQmmi5Bj8v6RVX/MdLAD/V9x3BOoe2cvghBzgCMwl9GHQJ+xMkmLsMheTfIeiAraw2bSg/p1pjc7nEVD/g==",
+			"version": "9.0.0-beta.18",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.0.0-beta.18.tgz",
+			"integrity": "sha512-wIKAuEXC4qqGwFvFgUQI9CDkHyICjoy5bfG+CNSlxHvc2tFSZArBRploXHc/4oS0i2yW4WuNcVgtB2UMnwBaMw==",
 			"dependencies": {
-				"@fluentui/keyboard-keys": "9.0.0-rc.6",
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-input": "9.0.0-rc.6",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/keyboard-keys": "^9.0.0",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-input": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2639,14 +2689,14 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-spinner": {
-			"version": "9.0.0-rc.6",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.0.0-rc.6.tgz",
-			"integrity": "sha512-n0cBgTMdE7MehK45U/jQAXOwbBOiBsUzCEv/7LjR5i8uMAKBcT2WCgfCFNdMzqbrQX/+FJ2+WJyauPmKb5gEgQ==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.0.3.tgz",
+			"integrity": "sha512-danPBKfeqVaCaBal80Nbk/TIZ53Otp0Ys4YK0AxjCChSyWhsc1hILJYWIZjng2109PYgQgxZJPD6VvwT9sb4iQ==",
 			"dependencies": {
-				"@fluentui/react-label": "9.0.0-rc.6",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-label": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2662,16 +2712,16 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-switch": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.0.0-rc.14.tgz",
-			"integrity": "sha512-97b6rgg6WzOWQiHEcjqC7cIBSAXCfbZ3jzgqHP8DTxuqJzzs1Tdbe413AtvDlEhp/22dWXY0wwadmfZ1PRiV+g==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.0.3.tgz",
+			"integrity": "sha512-hy2Wjz9i8Iv+usebqJfW0WAoP5RabeXl6y1yZLkS9kbrMUzKLdSvh+QaOpTTniaDt2yCClz1/MKcEdzzejI2Iw==",
 			"dependencies": {
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-label": "9.0.0-rc.6",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-label": "^9.0.3",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2687,22 +2737,23 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-tabs": {
-			"version": "9.0.0-rc.6",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.0.0-rc.6.tgz",
-			"integrity": "sha512-M50b5LhF3LTzDguNatlUnGXlM1P6Ggd6PgNkJqDkYMTu1COO+LtJ1AfRn/bymz97+Mh/LOsmLw36snXGigcTvA==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.0.3.tgz",
+			"integrity": "sha512-UkSGlHKXNTIE0DU2AbNiR6sWRiJPqE0+hNBjTa+jrQdXPc1DGcYEp3lYZW+t90ZYeH6r547ixVlY5KzXdupiaQ==",
 			"dependencies": {
-				"@fluentui/react-context-selector": "9.0.0-rc.10",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-context-selector": "^9.0.2",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
 				"@types/react": ">=16.8.0 <18.0.0",
 				"@types/react-dom": ">=16.8.0 <18.0.0",
 				"react": ">=16.8.0 <18.0.0",
-				"react-dom": ">=16.8.0 <18.0.0"
+				"react-dom": ">=16.8.0 <18.0.0",
+				"scheduler": "^0.19.0 || ^0.20.0"
 			}
 		},
 		"node_modules/@fluentui/react-tabs/node_modules/tslib": {
@@ -2711,16 +2762,16 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-tabster": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.0.0-rc.14.tgz",
-			"integrity": "sha512-44svMUJXZH6OsLIT8a0mg/kEMz26WCXxIjTjQ9sB3BP3+e+NNwm1geNp3fj0OPnMfiCrLQIgl/EoKxwBUwQk0A==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.0.3.tgz",
+			"integrity": "sha512-96qGBwMlBkayiLIdiaTZ9X73AryP+ywq6/4UynXqZr3VhdxSlN4TzwblZCLVjeexmY6sX9C74vRLxKtfgWaU2w==",
 			"dependencies": {
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"keyborg": "^1.1.0",
-				"tabster": "^1.4.0",
+				"tabster": "^1.4.2",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2736,13 +2787,13 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-text": {
-			"version": "9.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.0.0-rc.12.tgz",
-			"integrity": "sha512-w/CpPZCO13Heq5KWP7XaINDuBBXhx6IpiFaSygkPCXHcUnL9yWAw7ft791Y49bjzwr9BZ2uja3yTgpOptHS94Q==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.0.3.tgz",
+			"integrity": "sha512-rlbcDq0LXsZUvTzQYudlHoAvAZR+YmjN2yu7AFa7jJ4aqN96QM9EldLmuwDrlTb2PtgkBrNIvFFU137+P+nagA==",
 			"dependencies": {
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2758,13 +2809,13 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-textarea": {
-			"version": "9.0.0-rc.6",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.0.0-rc.6.tgz",
-			"integrity": "sha512-SzyNn+rAFXIhbms0xmEt4S/hJzGEZZd/M+7uYwbNhbaYWd0Mzk/NIdJS/ftQ7Qhr98w6QL+iREcAsLtr1uOC+w==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.0.3.tgz",
+			"integrity": "sha512-3cadUsEG9flK3fOGX1Mw0z/osi0Cdg8i3Tvwb+d/StYPjMGEjJ/LGYcdoDRIlzqBHnAnmWsdl3LLFO3Peo7WIw==",
 			"dependencies": {
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2780,9 +2831,9 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-theme": {
-			"version": "9.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.0.0-rc.10.tgz",
-			"integrity": "sha512-fR8xDnkbA82lERBtroByIY8sisru+xel0UpTYQAtkGv0ZvgJ+DTuVzvQ/mKvIcKH2JDw3TA4MzP+cWHQrg5IXQ==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.0.0.tgz",
+			"integrity": "sha512-/cmGk4Yax/5hdumylkccSAydmlsvuEs/Vu5IFFxpFui0Nq8WrhHvyCzErQksInVP0Arl/UnbQKFO21qcR48Y+w==",
 			"dependencies": {
 				"tslib": "^2.1.0"
 			},
@@ -2798,17 +2849,43 @@
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
-		"node_modules/@fluentui/react-tooltip": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.0.0-rc.14.tgz",
-			"integrity": "sha512-iLI3JydzgraYE1HueSeDveUK3kVXr8fu1y0GOeAN8wnm7wMeIdHs77Brn6oP0z0p4raknzB2TqiQOyvE35Ic5Q==",
+		"node_modules/@fluentui/react-toolbar": {
+			"version": "9.0.0-beta.4",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.0.0-beta.4.tgz",
+			"integrity": "sha512-+/NyJA7oAgo8707HpvjGaHgUrmA67Qf/2HNV4VgMdbU+mnXb86jgkS4zjQmcduDNNpio+4IqSOhb5WOhSfsEqw==",
 			"dependencies": {
-				"@fluentui/react-portal": "9.0.0-rc.14",
-				"@fluentui/react-positioning": "9.0.0-rc.12",
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-button": "^9.0.3",
+				"@fluentui/react-divider": "^9.0.3",
+				"@fluentui/react-radio": "^9.0.3",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
+				"tslib": "^2.1.0"
+			},
+			"peerDependencies": {
+				"@types/react": ">=16.8.0 <18.0.0",
+				"@types/react-dom": ">=16.8.0 <18.0.0",
+				"react": ">=16.8.0 <18.0.0",
+				"react-dom": ">=16.8.0 <18.0.0"
+			}
+		},
+		"node_modules/@fluentui/react-toolbar/node_modules/tslib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+		},
+		"node_modules/@fluentui/react-tooltip": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.0.3.tgz",
+			"integrity": "sha512-2DxANLos5/bmMrov3hmJu6NO3p//ogm3uxuCHvxYBx+QrefE0BHCSkpPwU4lO+8J4SPn91hJMEsLF2Juwh1SoQ==",
+			"dependencies": {
+				"@fluentui/react-portal": "^9.0.3",
+				"@fluentui/react-positioning": "^9.1.1",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -2824,11 +2901,11 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@fluentui/react-utilities": {
-			"version": "9.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.0.0-rc.10.tgz",
-			"integrity": "sha512-vs4ZLG2VW+4Fd5PpUQJn24tEZ+e2Or8h+Lzj8vPBLLxhtU0AHxzZmpWrcAWCAnVHh0C9HDSrisxJX5KnmWCelQ==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.0.2.tgz",
+			"integrity": "sha512-oPIJg6da/PFZ5mTP03/hYmaTR73pV0LZvF3VCSgdTi5T70voQiY+T5enItGedxQ/vBy6HxW0Y+vzSCwyPGrQNA==",
 			"dependencies": {
-				"@fluentui/keyboard-keys": "9.0.0-rc.6",
+				"@fluentui/keyboard-keys": "^9.0.0",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -4074,13 +4151,13 @@
 			"integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
 		},
 		"node_modules/@griffel/core": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.4.0.tgz",
-			"integrity": "sha512-FxgUJYaL2KZkgpr1uDdgt5hSmgPrhwOYrrnnF8CM5JOWS4wLN/ajwxi38InKy4iCRO9l3iHIjGOes2Jm+OpRIQ==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.5.1.tgz",
+			"integrity": "sha512-x/8P+ch6Mv6B5T8AxIyCVDdDzSiFRPsaIz/3KuxpsT+RoiwT9nbMUsVMxMFrCBN3aQABGR8QyCv0wPZJU4pOOw==",
 			"dependencies": {
 				"@emotion/hash": "^0.8.0",
 				"csstype": "^3.0.10",
-				"rtl-css-js": "^1.15.0",
+				"rtl-css-js": "^1.16.0",
 				"stylis": "^4.0.13",
 				"tslib": "^2.1.0"
 			}
@@ -4091,11 +4168,11 @@
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
 		},
 		"node_modules/@griffel/react": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.1.0.tgz",
-			"integrity": "sha512-DxbDufQZrOPtGf/RiEeG6CKGHIdQb8Z6pJveeLioDQJe/lZar+u1NhOjILTih+saX/ZRGuhYX74uNWWUxmFb6w==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.2.3.tgz",
+			"integrity": "sha512-YUHQINfDu5VbgkGK1ezfFL7f3VpxacEVLQiiy9FR1E+OeENaXYkPWePhi8PN2dQiF5elpnwOhrFnCYopSq6X2w==",
 			"dependencies": {
-				"@griffel/core": "^1.3.1",
+				"@griffel/core": "^1.5.1",
 				"tslib": "^2.1.0"
 			},
 			"peerDependencies": {
@@ -27275,9 +27352,9 @@
 			}
 		},
 		"node_modules/rtl-css-js": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.15.0.tgz",
-			"integrity": "sha512-99Cu4wNNIhrI10xxUaABHsdDqzalrSRTie4GeCmbGVuehm4oj+fIy8fTzB+16pmKe8Bv9rl+hxIBez6KxExTew==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.0.tgz",
+			"integrity": "sha512-Oc7PnzwIEU4M0K1J4h/7qUUaljXhQ0kCObRsZjxs2HjkpKsnoTMvSmvJ4sqgJZd0zBoEfAyTdnK/jMIYvrjySQ==",
 			"dependencies": {
 				"@babel/runtime": "^7.1.2"
 			}
@@ -29512,9 +29589,9 @@
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 		},
 		"node_modules/tabster": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/tabster/-/tabster-1.4.2.tgz",
-			"integrity": "sha512-WdEu9vzVVUPD1hXHRI8Pwji5+UrMXidMtsMlL3Z1QyfLdML/p6jv2TA4cVGT1Tc6CPQ8xqn27fHXAzR/0K8AwQ==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/tabster/-/tabster-1.5.4.tgz",
+			"integrity": "sha512-3WZYLUHLon0rdbwqVQJ2x9QAr5FLegYBEQr+r5M54oZ/NJ5DuUsjjn5c9A9/XbTvfWqkQ5K9KABrbOgG6XLxkQ==",
 			"dependencies": {
 				"keyborg": "^1.1.0",
 				"tslib": "^2.3.1"
@@ -30219,7 +30296,6 @@
 			"version": "4.7.4",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
 			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -34361,9 +34437,9 @@
 			}
 		},
 		"@fluentui/keyboard-keys": {
-			"version": "9.0.0-rc.6",
-			"resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.0-rc.6.tgz",
-			"integrity": "sha512-YQ7Zf2V0kvLNs27jPbd9+ii30yQQgqN44aaliEdlIXcGXk76Fvb2eEBkvKd9mk8tVbCeVRpgNJOsZKAocIqm3w==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/keyboard-keys/-/keyboard-keys-9.0.0.tgz",
+			"integrity": "sha512-8oxbUYfsUG9Qwy0akfXkECyMj6wJtrRB6ZOO1ngYDBvSq6yY6Ifg+ezFiRC8IxRaHf/yqwXjGOHUZy1ZOrd+Ww==",
 			"requires": {
 				"tslib": "^2.1.0"
 			},
@@ -34376,9 +34452,9 @@
 			}
 		},
 		"@fluentui/priority-overflow": {
-			"version": "9.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.0.0-beta.1.tgz",
-			"integrity": "sha512-g0kpjnkou0c28HLCXjSN/c3ZfYEw8+WJExDuG/AG/JNvbqzPnB75iFYjDxk+UPErZYPvbaqbCcMB9yI4cv479A==",
+			"version": "9.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/priority-overflow/-/priority-overflow-9.0.0-beta.2.tgz",
+			"integrity": "sha512-Syhl+psD3tIKVVR+eS28poRoVbtyZ4iN+izOeuV01hZELOoMaud/MM1qIUSeH8AnBSydDDCaXWgwwJ+pnUHPAQ==",
 			"requires": {
 				"tslib": "^2.1.0"
 			},
@@ -34391,18 +34467,18 @@
 			}
 		},
 		"@fluentui/react-accordion": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.0.0-rc.14.tgz",
-			"integrity": "sha512-//+wwYEDHiC9Z2muMjHAoyFjHAnimEiUPe3OJxtdZ0BTxbnKaTTQrX4eokklPv1p5hkYWZcrGaCgWo/altW75w==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-accordion/-/react-accordion-9.0.3.tgz",
+			"integrity": "sha512-NL2nMZ1LvWV1E3nkTyVlrRqdsPJ5PlbrWo6tPpDKo/53RceBBehPB8tSiwQTaRMu5ns39ouN2HgnFn04woDLaw==",
 			"requires": {
-				"@fluentui/react-aria": "9.0.0-rc.10",
-				"@fluentui/react-context-selector": "9.0.0-rc.10",
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-aria": "^9.0.2",
+				"@fluentui/react-context-selector": "^9.0.2",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34414,15 +34490,16 @@
 			}
 		},
 		"@fluentui/react-alert": {
-			"version": "9.0.0-beta.3",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.3.tgz",
-			"integrity": "sha512-hwkg33/1uFEYmD+YrqpQkMPV65P7MDEvjwHJ7GDbmnxZjIiQogh1PZdkUdvzwy4+eqg7WUIhc1k1W13u/yyMuQ==",
+			"version": "9.0.0-beta.7",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-alert/-/react-alert-9.0.0-beta.7.tgz",
+			"integrity": "sha512-oWgjLylwNbV9XoEJx9NEwN3nQ8F3GvRwlY1+VFMYxfe5TGteGUOy+8gFG+sPJ/0aXFocI7oAaHw88wnN6fVhGg==",
 			"requires": {
-				"@fluentui/react-button": "9.0.0-rc.14",
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-avatar": "^9.0.3",
+				"@fluentui/react-button": "^9.0.3",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34434,12 +34511,12 @@
 			}
 		},
 		"@fluentui/react-aria": {
-			"version": "9.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.0.0-rc.10.tgz",
-			"integrity": "sha512-x2JyqUb1cMEXm0JOB8/VvSCLrYzQbgGjt6gAjcJrDZ334JgyS8np3EznAR58r0bx+NfAqC1XXGnvE5iJiZhQGQ==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-aria/-/react-aria-9.0.2.tgz",
+			"integrity": "sha512-aJ3yNtbHPeSlyWr/9zXQ0tbHwOnH4rJP4QraUZch7FvxCfRkiBcJk5hIZFpdNU3t94L0t8CmZVJdluukQkAcDg==",
 			"requires": {
-				"@fluentui/keyboard-keys": "9.0.0-rc.6",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
+				"@fluentui/keyboard-keys": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34451,19 +34528,20 @@
 			}
 		},
 		"@fluentui/react-avatar": {
-			"version": "9.0.0-rc.13",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.0.0-rc.13.tgz",
-			"integrity": "sha512-B3aNeKFwfI4LrMS8WGzfQAmnUQZgd15nS+NmfXNK7467JAYItQQdcpR6QhS9LUPXbC78TmgCr8eNXpdwUkQNSA==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-avatar/-/react-avatar-9.0.3.tgz",
+			"integrity": "sha512-aXAHJLwn5+fiw9XlNy55ejboDzu3oQxEQ44OGsbirKPNudiyT+dF+tL5AkVvkTyl2NIO/DVN3ku7Zatgd+MajA==",
 			"requires": {
-				"@fluentui/react-badge": "9.0.0-rc.13",
-				"@fluentui/react-button": "9.0.0-rc.14",
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-popover": "9.0.0-rc.14",
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-tooltip": "9.0.0-rc.14",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-badge": "^9.0.3",
+				"@fluentui/react-context-selector": "^9.0.2",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-popover": "^9.0.3",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-tooltip": "^9.0.3",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34475,14 +34553,14 @@
 			}
 		},
 		"@fluentui/react-badge": {
-			"version": "9.0.0-rc.13",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.0.0-rc.13.tgz",
-			"integrity": "sha512-12vYiuDjp4pGYaXT4mHzv7ctxVi34bSDlYwEB7yGly9C63eeM01yT1nsYHOI/lRwJcmoeCOHZL1KCwrcAN4fNg==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-badge/-/react-badge-9.0.3.tgz",
+			"integrity": "sha512-ItgrmgRVxM3B1HHbQmdshfL6YoVXBB61oD9xYfN9xEQopApED/eqncEP0LkKYxxiNKMDZPYWGRogwLfRtzX5hg==",
 			"requires": {
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34494,17 +34572,17 @@
 			}
 		},
 		"@fluentui/react-button": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.0.0-rc.14.tgz",
-			"integrity": "sha512-UKj3aX+Sz1ZZaYnfpl0eQhV/sb8Svfi3UdyLPmK3e2LcVwdXHUhpCfe81ew2p5bx6Vys+pvmSId+PYi+1rz9Rg==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-button/-/react-button-9.0.3.tgz",
+			"integrity": "sha512-W+/tH6HuvWBVepuZhOzlVBrj14BDWiiZC9f9/+80exGVMwR6Iq8A1rF4JeeOcv7Nyp0tQ7dkgAVNRu0Q8aaWPg==",
 			"requires": {
-				"@fluentui/keyboard-keys": "9.0.0-rc.6",
-				"@fluentui/react-aria": "9.0.0-rc.10",
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/keyboard-keys": "^9.0.0",
+				"@fluentui/react-aria": "^9.0.2",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34516,14 +34594,14 @@
 			}
 		},
 		"@fluentui/react-card": {
-			"version": "9.0.0-beta.19",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.0.0-beta.19.tgz",
-			"integrity": "sha512-zhbNGQDx/egdBfzIwixvt7dOqMPfL1NOy+bgYW/hvctnaynmszDwBsWY4yWfIwcAN3A6mOXiqyng6jHlPRy+Og==",
+			"version": "9.0.0-beta.23",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-card/-/react-card-9.0.0-beta.23.tgz",
+			"integrity": "sha512-e3uupguxVn2mFuR2e22f2eJoTzhhotdazsWy1A4/hYEgFw4vth6Mo6P3jeegalef/mkvBUHonIBWJHnok3XM4Q==",
 			"requires": {
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34535,16 +34613,39 @@
 			}
 		},
 		"@fluentui/react-checkbox": {
-			"version": "9.0.0-rc.6",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.0.0-rc.6.tgz",
-			"integrity": "sha512-swdrMiScXkQJi6AyNBcJem1PZatI2L6R5QJLC8eYo+FtaBv527cK5CT4eF8DCbMTho+0Ciro9QOyX5wxnMJsYQ==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-checkbox/-/react-checkbox-9.0.3.tgz",
+			"integrity": "sha512-Ys2Y6Mq0Wj9AUgKpQnwqfD7iL3UVcuvVsUe/gqAvDk7u76+TzfYCy9ykwZyyd7uIV1z6CSoddnUtB+tcu8qNuw==",
 			"requires": {
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-label": "9.0.0-rc.6",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-label": "^9.0.3",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+				}
+			}
+		},
+		"@fluentui/react-combobox": {
+			"version": "9.0.0-beta.7",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-combobox/-/react-combobox-9.0.0-beta.7.tgz",
+			"integrity": "sha512-9t3FoJr8dfPuQ3Q7utoM744WZ0cjonvJCjhrfKPoS8aQpCUkiZIvIxfUjfb0Pj4IN3FHfa04xPm0X9sJz3Swww==",
+			"requires": {
+				"@fluentui/keyboard-keys": "^9.0.0",
+				"@fluentui/react-context-selector": "^9.0.2",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-portal": "^9.0.3",
+				"@fluentui/react-positioning": "^9.1.1",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34556,42 +34657,44 @@
 			}
 		},
 		"@fluentui/react-components": {
-			"version": "9.0.0-rc.15",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.0.0-rc.15.tgz",
-			"integrity": "sha512-rLnnRY75R6Ige/sjFVig1g4fPeUIuaS0d0bh3qrzKO0k9n5yTngYJF5h4oYeBdbCl06CmdX+UCI9ObIn2Xx/Aw==",
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-components/-/react-components-9.1.1.tgz",
+			"integrity": "sha512-2fMNPz0l1IyvjrX6ys8lEJZBp9NF+zMcHqO/yjhIyPV0h5YKBQrV+nFuYR+zBEPsHaDkd1aWtCxTenPHEy+KXw==",
 			"requires": {
-				"@fluentui/react-accordion": "9.0.0-rc.14",
-				"@fluentui/react-alert": "9.0.0-beta.3",
-				"@fluentui/react-avatar": "9.0.0-rc.13",
-				"@fluentui/react-badge": "9.0.0-rc.13",
-				"@fluentui/react-button": "9.0.0-rc.14",
-				"@fluentui/react-card": "9.0.0-beta.19",
-				"@fluentui/react-checkbox": "9.0.0-rc.6",
-				"@fluentui/react-divider": "9.0.0-rc.12",
-				"@fluentui/react-image": "9.0.0-rc.12",
-				"@fluentui/react-input": "9.0.0-rc.6",
-				"@fluentui/react-label": "9.0.0-rc.6",
-				"@fluentui/react-link": "9.0.0-rc.14",
-				"@fluentui/react-menu": "9.0.0-rc.14",
-				"@fluentui/react-overflow": "9.0.0-beta.4",
-				"@fluentui/react-popover": "9.0.0-rc.14",
-				"@fluentui/react-positioning": "9.0.0-rc.12",
-				"@fluentui/react-provider": "9.0.0-rc.14",
-				"@fluentui/react-radio": "9.0.0-rc.7",
-				"@fluentui/react-select": "9.0.0-beta.3",
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-slider": "9.0.0-beta.19",
-				"@fluentui/react-spinbutton": "9.0.0-beta.14",
-				"@fluentui/react-spinner": "9.0.0-rc.6",
-				"@fluentui/react-switch": "9.0.0-rc.14",
-				"@fluentui/react-tabs": "9.0.0-rc.6",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-text": "9.0.0-rc.12",
-				"@fluentui/react-textarea": "9.0.0-rc.6",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-tooltip": "9.0.0-rc.14",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-accordion": "^9.0.3",
+				"@fluentui/react-alert": "9.0.0-beta.7",
+				"@fluentui/react-avatar": "^9.0.3",
+				"@fluentui/react-badge": "^9.0.3",
+				"@fluentui/react-button": "^9.0.3",
+				"@fluentui/react-card": "9.0.0-beta.23",
+				"@fluentui/react-checkbox": "^9.0.3",
+				"@fluentui/react-combobox": "^9.0.0-beta.7",
+				"@fluentui/react-divider": "^9.0.3",
+				"@fluentui/react-image": "^9.0.3",
+				"@fluentui/react-input": "^9.0.3",
+				"@fluentui/react-label": "^9.0.3",
+				"@fluentui/react-link": "^9.0.3",
+				"@fluentui/react-menu": "^9.0.3",
+				"@fluentui/react-overflow": "9.0.0-beta.8",
+				"@fluentui/react-popover": "^9.0.3",
+				"@fluentui/react-positioning": "^9.1.1",
+				"@fluentui/react-provider": "^9.0.3",
+				"@fluentui/react-radio": "^9.0.3",
+				"@fluentui/react-select": "9.0.0-beta.7",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-slider": "^9.0.2",
+				"@fluentui/react-spinbutton": "9.0.0-beta.18",
+				"@fluentui/react-spinner": "^9.0.3",
+				"@fluentui/react-switch": "^9.0.3",
+				"@fluentui/react-tabs": "^9.0.3",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-text": "^9.0.3",
+				"@fluentui/react-textarea": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-toolbar": "9.0.0-beta.4",
+				"@fluentui/react-tooltip": "^9.0.3",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34603,11 +34706,11 @@
 			}
 		},
 		"@fluentui/react-context-selector": {
-			"version": "9.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.0.0-rc.10.tgz",
-			"integrity": "sha512-1WlzzQ0/6DnwlrDSvtFuC8qlDUeD5j4L+WVXpfObcQeAkRpDTmiUkN356tU6a5v6t+XualXsI5cBOa30GH5MPA==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-context-selector/-/react-context-selector-9.0.2.tgz",
+			"integrity": "sha512-4ypIKRqAKyywmIq+OHNE85q30wwXJgAcOY7i37eNW2FgKbfC9qY0R0C/JS1kkvv4PwHzkl/mRq/+bgzWenxZNQ==",
 			"requires": {
-				"@fluentui/react-utilities": "9.0.0-rc.10",
+				"@fluentui/react-utilities": "^9.0.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34619,13 +34722,13 @@
 			}
 		},
 		"@fluentui/react-divider": {
-			"version": "9.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.0.0-rc.12.tgz",
-			"integrity": "sha512-vLNfULHMPbKQVOoC21ZC87/0xaV0Gk6kKzSNf1E3nFMwwFDVZ1lvxXKTw091JBzvva9yqejWsa59dyx2K1aLZg==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-divider/-/react-divider-9.0.3.tgz",
+			"integrity": "sha512-CrDkwvb5od9qfW143oYnuxW8D2Yh+aw0puUqADfr6u25FXnM5uZbhB8HOT3o13qO5XRG/fVUihKcOf6IEG8oyg==",
 			"requires": {
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34637,18 +34740,29 @@
 			}
 		},
 		"@fluentui/react-icons": {
-			"version": "2.0.174",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.174.tgz",
-			"integrity": "sha512-PN65EH8vDbHqQ9DJb2CMV37iiR+clFF3Orl4KZN7OW3AjdHc9GVaznWh/kmTfPpg1ScS6i/Fs2F7m9J61WIwYw=="
+			"version": "2.0.178",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-icons/-/react-icons-2.0.178.tgz",
+			"integrity": "sha512-10GprgDPzAj5wz0BDz4NLSEgong0DZBEeoS6R2xt9Pf1nHYmfQEonz6xFT4y094xgI+9XzpC8pohnenhmdZ97w==",
+			"requires": {
+				"@griffel/react": "^1.0.0",
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+				}
+			}
 		},
 		"@fluentui/react-image": {
-			"version": "9.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.0.0-rc.12.tgz",
-			"integrity": "sha512-okhnmxtUX50k+sUB9npuFO+IsM3XtQgpBCgJaEBwrMwqCq3s+9C0RlTJ0e/ajN+qocfYKyyELn52CXQd/XfSZg==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-image/-/react-image-9.0.3.tgz",
+			"integrity": "sha512-dfkHZ5Dp8bhCTtowLXYBMcSE3S3sXEx9Ipnyl1bOasy7h0KgnueFV1a2ySBxT/GGeSklEhYvXUot7eJEq40gXg==",
 			"requires": {
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34660,13 +34774,13 @@
 			}
 		},
 		"@fluentui/react-input": {
-			"version": "9.0.0-rc.6",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.0.0-rc.6.tgz",
-			"integrity": "sha512-+SvcO4gnHiSCqgDPwmcb7nSbWShyMSHJeUrJe9jvWaCBORMUbwDTMLT0WeHCB+o2b2pJgMnjq2uymARFkqkvBA==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-input/-/react-input-9.0.3.tgz",
+			"integrity": "sha512-Y94IWdCFS4KqR0dfFBHoACI1JOB0/w3YQyYmGeDsbylt3+g5eZt8yC8+Ed/kqfclm2y2sz9VeMPfCsC7YJxnPg==",
 			"requires": {
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34678,13 +34792,13 @@
 			}
 		},
 		"@fluentui/react-label": {
-			"version": "9.0.0-rc.6",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.0.0-rc.6.tgz",
-			"integrity": "sha512-Mz+ErPx0hSwI3panrFHzssn3NiIS6Aj1d1FWlkglWhS7VJQsdx0/aaDFDAXAk60AyWWWtZnJZ8HoTXbACtEu8A==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-label/-/react-label-9.0.3.tgz",
+			"integrity": "sha512-It9HFIHeGDkw1fb17vawb3/kY60wz7ygrGUbC13b8JaGSO9Sud6+r5M0WDJMlNp2niMJ5CpNrdH7NXXemLc3pQ==",
 			"requires": {
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34696,15 +34810,15 @@
 			}
 		},
 		"@fluentui/react-link": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.0.0-rc.14.tgz",
-			"integrity": "sha512-Tj907IZFL8lSE/HQfg4otwCBEgwlvZyDI2Pq/hK8A1NuSTf/hHUhEXEMcbpN4ZsOOPzlk3fkPGtIpt0IvVYaTQ==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-link/-/react-link-9.0.3.tgz",
+			"integrity": "sha512-ncjEcUTD8gOg0p/vuAgYTT+mMwlbjcTieVRcw3EHZJ1tRAIlhRrz5XxNrymTM8pPuiDDuGJN+LrjggKm/3BdhA==",
 			"requires": {
-				"@fluentui/keyboard-keys": "9.0.0-rc.6",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/keyboard-keys": "^9.0.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34716,20 +34830,20 @@
 			}
 		},
 		"@fluentui/react-menu": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.0.0-rc.14.tgz",
-			"integrity": "sha512-CpfENrTjb0QyyTTkV+3BxcwUvwub9bKPbuw5CO4PmftrN1cPEjL2oe//zyb7uSaDn5VgXBN8yQsr1dFs4IvgSQ==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-menu/-/react-menu-9.0.3.tgz",
+			"integrity": "sha512-niTrp7FLhrC6WM3FI04h8f/9MFhe++nkBdiDN8vGdD0ttQbLP9Z5YpUEoEkNIhhoq+h1kvVroW5XZTC5ypPtkA==",
 			"requires": {
-				"@fluentui/keyboard-keys": "9.0.0-rc.6",
-				"@fluentui/react-context-selector": "9.0.0-rc.10",
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-portal": "9.0.0-rc.14",
-				"@fluentui/react-positioning": "9.0.0-rc.12",
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/keyboard-keys": "^9.0.0",
+				"@fluentui/react-context-selector": "^9.0.2",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-portal": "^9.0.3",
+				"@fluentui/react-positioning": "^9.1.1",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34741,15 +34855,15 @@
 			}
 		},
 		"@fluentui/react-overflow": {
-			"version": "9.0.0-beta.4",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.0.0-beta.4.tgz",
-			"integrity": "sha512-XBCC1cnvOsKeGqbZNBe/MJT7ep+7zYMWyW3NEAJLSOFq4lriESzDSgmQuxLlesewKIz4DRbXompw87NupdJ3Wg==",
+			"version": "9.0.0-beta.8",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-overflow/-/react-overflow-9.0.0-beta.8.tgz",
+			"integrity": "sha512-nq/Kh10iZBEUSl9KtQrbKqb0d8MOtIHdmyQ8lnnaNdIWVsxLd/J0NW494IpMIBdeK8WtRp0TeuBV0KJWwHaUtw==",
 			"requires": {
-				"@fluentui/priority-overflow": "^9.0.0-beta.1",
-				"@fluentui/react-context-selector": "9.0.0-rc.10",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/priority-overflow": "^9.0.0-beta.2",
+				"@fluentui/react-context-selector": "^9.0.2",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34761,18 +34875,18 @@
 			}
 		},
 		"@fluentui/react-popover": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.0.0-rc.14.tgz",
-			"integrity": "sha512-O7HQ+9sraVffZqGMOb26ck+gsdtHMv3Gcrv3IELFKrlGbucaT8zCwupgawJmHVRpvILqcoEskII5QpHCruODfA==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-popover/-/react-popover-9.0.3.tgz",
+			"integrity": "sha512-18jqT1TtylTWWRGviMZMqY9nk961CKNeOJhOxtZ45QlUWbu5urILYhtpMfDAf1Tx/HZQarztlqgY5/aS4zfWZg==",
 			"requires": {
-				"@fluentui/react-context-selector": "9.0.0-rc.10",
-				"@fluentui/react-portal": "9.0.0-rc.14",
-				"@fluentui/react-positioning": "9.0.0-rc.12",
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-context-selector": "^9.0.2",
+				"@fluentui/react-portal": "^9.0.3",
+				"@fluentui/react-positioning": "^9.1.1",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34784,13 +34898,14 @@
 			}
 		},
 		"@fluentui/react-portal": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.0.0-rc.14.tgz",
-			"integrity": "sha512-monL7hmb3/cGYo5nn3Kbhbog+iiueSN9seAKG8NA5zpiLwjvBcwaPfvxg6NQTUOAMafx9BdMMEqBRY14RKutgw==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-portal/-/react-portal-9.0.3.tgz",
+			"integrity": "sha512-sPKO/sUy9Ew0xVPfcPKphzTLZD7FoACiMDtmnt3NuUc9mJOFWkFZOEQ2bYGs+lgnkMciuA17GxQTEzO1Fn77jw==",
 			"requires": {
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34802,14 +34917,14 @@
 			}
 		},
 		"@fluentui/react-positioning": {
-			"version": "9.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.0.0-rc.12.tgz",
-			"integrity": "sha512-RS+zxpC6r3fIxrEBx3uGBIo2lTtxAmceeX0TI3Yv7Oqum6Jf/6qg8zrMt4+KNZrUlAlJjGtTU53E+f9JQP5NSA==",
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-positioning/-/react-positioning-9.1.1.tgz",
+			"integrity": "sha512-bQFbJV+W8fdDwNHsgZ+vLMzKYUcwyPrYuQYwqqlnstTYYZkXPSz3KV0QFCdcCK1DIjNTOukq5ppnEvPWw+j2OQ==",
 			"requires": {
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"@popperjs/core": "~2.4.3",
 				"tslib": "^2.1.0"
 			},
@@ -34822,15 +34937,16 @@
 			}
 		},
 		"@fluentui/react-provider": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.0.0-rc.14.tgz",
-			"integrity": "sha512-7axsF9UQP2FUtUK0b4l/Aqm98PGfKXHxswb5gqRYeTAJtsKAf33HfceCvpOuLwfzRMUNrps0sNgvfN4/OV1ADQ==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-provider/-/react-provider-9.0.3.tgz",
+			"integrity": "sha512-0OUv3UgE9t2gdeYY0yuVq2blqaC0FDUHK+fCAmPHhj2Pj9p62JC5NbYX0e0ucqIW7caB4iZE0oQ+muI7xzVibw==",
 			"requires": {
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/core": "^1.4.1",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34842,17 +34958,17 @@
 			}
 		},
 		"@fluentui/react-radio": {
-			"version": "9.0.0-rc.7",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.0.0-rc.7.tgz",
-			"integrity": "sha512-BIHyjBmhwjPKMuyrpGWOstBeBjJNjyktw2nmLBkuCd+qFdWCBxdQYXZKH9Y6KPZaeCVU1A831Yts7O3nHEuMMA==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-radio/-/react-radio-9.0.3.tgz",
+			"integrity": "sha512-MFbNWoEShIvMKCtr8DjM0XC6AhMxoyYKZvHMbYyFYzBtsq3OZz5uV04+JltBZRPz7darwiYJp6hfTpFFr/T3YQ==",
 			"requires": {
-				"@fluentui/react-context-selector": "9.0.0-rc.10",
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-label": "9.0.0-rc.6",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-context-selector": "^9.0.2",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-label": "^9.0.3",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34864,14 +34980,14 @@
 			}
 		},
 		"@fluentui/react-select": {
-			"version": "9.0.0-beta.3",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.0.0-beta.3.tgz",
-			"integrity": "sha512-jiaRptqMgev+1Wh5lVgR9Wd2aYCm+4kAokESy9SozA0BLCChGAigRIXTQq9Q7WnoaeV/SNXMwqAIEhEM2ZP7hQ==",
+			"version": "9.0.0-beta.7",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-select/-/react-select-9.0.0-beta.7.tgz",
+			"integrity": "sha512-yKvvcP3XFw29XafpiBl/b9rE3cnajPklvYzLcOe2HqgQMOokLXTrBHMELv0JsGIOdaP+M0As2ZoLujc+8GisLA==",
 			"requires": {
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34883,11 +34999,11 @@
 			}
 		},
 		"@fluentui/react-shared-contexts": {
-			"version": "9.0.0-rc.11",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.0.0-rc.11.tgz",
-			"integrity": "sha512-bLlJ5B7BuRgI5v+WB2Rr8/6+Ms0Y3r2Ci3R7087iRFWYxW4yAX3Y0WiapASRW25UL6khwYpWil2s6s50rY12Cw==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-shared-contexts/-/react-shared-contexts-9.0.0.tgz",
+			"integrity": "sha512-ZuUO5ZxBaVQR/4rXJIrV9coYYk7QXkDThDS5W7ueUWjEmdRfiUjxAEhpK8vl56lnWdaTRaWCNKrKNOKKua4JBg==",
 			"requires": {
-				"@fluentui/react-theme": "9.0.0-rc.10",
+				"@fluentui/react-theme": "^9.0.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34899,15 +35015,15 @@
 			}
 		},
 		"@fluentui/react-slider": {
-			"version": "9.0.0-beta.19",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.0.0-beta.19.tgz",
-			"integrity": "sha512-jV4o6U5yldB2o4JfLWv0G9vAl1DEBOOlMFFvX85nYsiuQCYX2cIl1bm+eKVI1RLqp0l/lBs/mVhxBqaN+8/ZcA==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-slider/-/react-slider-9.0.2.tgz",
+			"integrity": "sha512-f5sWitymxKnM6AfkesjqlaAE9Dmmq8bR45KxxEIR/blLV+yFNgWlUF0fZdaSgtx9DV+JI7c7J95g26Z/LmvlUA==",
 			"requires": {
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34919,16 +35035,16 @@
 			}
 		},
 		"@fluentui/react-spinbutton": {
-			"version": "9.0.0-beta.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.0.0-beta.14.tgz",
-			"integrity": "sha512-AX2VjQmmi5Bj8v6RVX/MdLAD/V9x3BOoe2cvghBzgCMwl9GHQJ+xMkmLsMheTfIeiAraw2bSg/p1pjc7nEVD/g==",
+			"version": "9.0.0-beta.18",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-spinbutton/-/react-spinbutton-9.0.0-beta.18.tgz",
+			"integrity": "sha512-wIKAuEXC4qqGwFvFgUQI9CDkHyICjoy5bfG+CNSlxHvc2tFSZArBRploXHc/4oS0i2yW4WuNcVgtB2UMnwBaMw==",
 			"requires": {
-				"@fluentui/keyboard-keys": "9.0.0-rc.6",
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-input": "9.0.0-rc.6",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/keyboard-keys": "^9.0.0",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-input": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34940,14 +35056,14 @@
 			}
 		},
 		"@fluentui/react-spinner": {
-			"version": "9.0.0-rc.6",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.0.0-rc.6.tgz",
-			"integrity": "sha512-n0cBgTMdE7MehK45U/jQAXOwbBOiBsUzCEv/7LjR5i8uMAKBcT2WCgfCFNdMzqbrQX/+FJ2+WJyauPmKb5gEgQ==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-spinner/-/react-spinner-9.0.3.tgz",
+			"integrity": "sha512-danPBKfeqVaCaBal80Nbk/TIZ53Otp0Ys4YK0AxjCChSyWhsc1hILJYWIZjng2109PYgQgxZJPD6VvwT9sb4iQ==",
 			"requires": {
-				"@fluentui/react-label": "9.0.0-rc.6",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-label": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34959,16 +35075,16 @@
 			}
 		},
 		"@fluentui/react-switch": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.0.0-rc.14.tgz",
-			"integrity": "sha512-97b6rgg6WzOWQiHEcjqC7cIBSAXCfbZ3jzgqHP8DTxuqJzzs1Tdbe413AtvDlEhp/22dWXY0wwadmfZ1PRiV+g==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-switch/-/react-switch-9.0.3.tgz",
+			"integrity": "sha512-hy2Wjz9i8Iv+usebqJfW0WAoP5RabeXl6y1yZLkS9kbrMUzKLdSvh+QaOpTTniaDt2yCClz1/MKcEdzzejI2Iw==",
 			"requires": {
-				"@fluentui/react-icons": "^2.0.166-rc.3",
-				"@fluentui/react-label": "9.0.0-rc.6",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-icons": "^2.0.175",
+				"@fluentui/react-label": "^9.0.3",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -34980,15 +35096,15 @@
 			}
 		},
 		"@fluentui/react-tabs": {
-			"version": "9.0.0-rc.6",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.0.0-rc.6.tgz",
-			"integrity": "sha512-M50b5LhF3LTzDguNatlUnGXlM1P6Ggd6PgNkJqDkYMTu1COO+LtJ1AfRn/bymz97+Mh/LOsmLw36snXGigcTvA==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-tabs/-/react-tabs-9.0.3.tgz",
+			"integrity": "sha512-UkSGlHKXNTIE0DU2AbNiR6sWRiJPqE0+hNBjTa+jrQdXPc1DGcYEp3lYZW+t90ZYeH6r547ixVlY5KzXdupiaQ==",
 			"requires": {
-				"@fluentui/react-context-selector": "9.0.0-rc.10",
-				"@fluentui/react-tabster": "9.0.0-rc.14",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-context-selector": "^9.0.2",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -35000,16 +35116,16 @@
 			}
 		},
 		"@fluentui/react-tabster": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.0.0-rc.14.tgz",
-			"integrity": "sha512-44svMUJXZH6OsLIT8a0mg/kEMz26WCXxIjTjQ9sB3BP3+e+NNwm1geNp3fj0OPnMfiCrLQIgl/EoKxwBUwQk0A==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-tabster/-/react-tabster-9.0.3.tgz",
+			"integrity": "sha512-96qGBwMlBkayiLIdiaTZ9X73AryP+ywq6/4UynXqZr3VhdxSlN4TzwblZCLVjeexmY6sX9C74vRLxKtfgWaU2w==",
 			"requires": {
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"keyborg": "^1.1.0",
-				"tabster": "^1.4.0",
+				"tabster": "^1.4.2",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -35021,13 +35137,13 @@
 			}
 		},
 		"@fluentui/react-text": {
-			"version": "9.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.0.0-rc.12.tgz",
-			"integrity": "sha512-w/CpPZCO13Heq5KWP7XaINDuBBXhx6IpiFaSygkPCXHcUnL9yWAw7ft791Y49bjzwr9BZ2uja3yTgpOptHS94Q==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-text/-/react-text-9.0.3.tgz",
+			"integrity": "sha512-rlbcDq0LXsZUvTzQYudlHoAvAZR+YmjN2yu7AFa7jJ4aqN96QM9EldLmuwDrlTb2PtgkBrNIvFFU137+P+nagA==",
 			"requires": {
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -35039,13 +35155,13 @@
 			}
 		},
 		"@fluentui/react-textarea": {
-			"version": "9.0.0-rc.6",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.0.0-rc.6.tgz",
-			"integrity": "sha512-SzyNn+rAFXIhbms0xmEt4S/hJzGEZZd/M+7uYwbNhbaYWd0Mzk/NIdJS/ftQ7Qhr98w6QL+iREcAsLtr1uOC+w==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-textarea/-/react-textarea-9.0.3.tgz",
+			"integrity": "sha512-3cadUsEG9flK3fOGX1Mw0z/osi0Cdg8i3Tvwb+d/StYPjMGEjJ/LGYcdoDRIlzqBHnAnmWsdl3LLFO3Peo7WIw==",
 			"requires": {
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -35057,10 +35173,32 @@
 			}
 		},
 		"@fluentui/react-theme": {
-			"version": "9.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.0.0-rc.10.tgz",
-			"integrity": "sha512-fR8xDnkbA82lERBtroByIY8sisru+xel0UpTYQAtkGv0ZvgJ+DTuVzvQ/mKvIcKH2JDw3TA4MzP+cWHQrg5IXQ==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-theme/-/react-theme-9.0.0.tgz",
+			"integrity": "sha512-/cmGk4Yax/5hdumylkccSAydmlsvuEs/Vu5IFFxpFui0Nq8WrhHvyCzErQksInVP0Arl/UnbQKFO21qcR48Y+w==",
 			"requires": {
+				"tslib": "^2.1.0"
+			},
+			"dependencies": {
+				"tslib": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+				}
+			}
+		},
+		"@fluentui/react-toolbar": {
+			"version": "9.0.0-beta.4",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-toolbar/-/react-toolbar-9.0.0-beta.4.tgz",
+			"integrity": "sha512-+/NyJA7oAgo8707HpvjGaHgUrmA67Qf/2HNV4VgMdbU+mnXb86jgkS4zjQmcduDNNpio+4IqSOhb5WOhSfsEqw==",
+			"requires": {
+				"@fluentui/react-button": "^9.0.3",
+				"@fluentui/react-divider": "^9.0.3",
+				"@fluentui/react-radio": "^9.0.3",
+				"@fluentui/react-tabster": "^9.0.3",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -35072,16 +35210,16 @@
 			}
 		},
 		"@fluentui/react-tooltip": {
-			"version": "9.0.0-rc.14",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.0.0-rc.14.tgz",
-			"integrity": "sha512-iLI3JydzgraYE1HueSeDveUK3kVXr8fu1y0GOeAN8wnm7wMeIdHs77Brn6oP0z0p4raknzB2TqiQOyvE35Ic5Q==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-tooltip/-/react-tooltip-9.0.3.tgz",
+			"integrity": "sha512-2DxANLos5/bmMrov3hmJu6NO3p//ogm3uxuCHvxYBx+QrefE0BHCSkpPwU4lO+8J4SPn91hJMEsLF2Juwh1SoQ==",
 			"requires": {
-				"@fluentui/react-portal": "9.0.0-rc.14",
-				"@fluentui/react-positioning": "9.0.0-rc.12",
-				"@fluentui/react-shared-contexts": "9.0.0-rc.11",
-				"@fluentui/react-theme": "9.0.0-rc.10",
-				"@fluentui/react-utilities": "9.0.0-rc.10",
-				"@griffel/react": "1.1.0",
+				"@fluentui/react-portal": "^9.0.3",
+				"@fluentui/react-positioning": "^9.1.1",
+				"@fluentui/react-shared-contexts": "^9.0.0",
+				"@fluentui/react-theme": "^9.0.0",
+				"@fluentui/react-utilities": "^9.0.2",
+				"@griffel/react": "^1.2.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -35093,11 +35231,11 @@
 			}
 		},
 		"@fluentui/react-utilities": {
-			"version": "9.0.0-rc.10",
-			"resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.0.0-rc.10.tgz",
-			"integrity": "sha512-vs4ZLG2VW+4Fd5PpUQJn24tEZ+e2Or8h+Lzj8vPBLLxhtU0AHxzZmpWrcAWCAnVHh0C9HDSrisxJX5KnmWCelQ==",
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/@fluentui/react-utilities/-/react-utilities-9.0.2.tgz",
+			"integrity": "sha512-oPIJg6da/PFZ5mTP03/hYmaTR73pV0LZvF3VCSgdTi5T70voQiY+T5enItGedxQ/vBy6HxW0Y+vzSCwyPGrQNA==",
 			"requires": {
-				"@fluentui/keyboard-keys": "9.0.0-rc.6",
+				"@fluentui/keyboard-keys": "^9.0.0",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -36278,13 +36416,13 @@
 			"integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
 		},
 		"@griffel/core": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.4.0.tgz",
-			"integrity": "sha512-FxgUJYaL2KZkgpr1uDdgt5hSmgPrhwOYrrnnF8CM5JOWS4wLN/ajwxi38InKy4iCRO9l3iHIjGOes2Jm+OpRIQ==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@griffel/core/-/core-1.5.1.tgz",
+			"integrity": "sha512-x/8P+ch6Mv6B5T8AxIyCVDdDzSiFRPsaIz/3KuxpsT+RoiwT9nbMUsVMxMFrCBN3aQABGR8QyCv0wPZJU4pOOw==",
 			"requires": {
 				"@emotion/hash": "^0.8.0",
 				"csstype": "^3.0.10",
-				"rtl-css-js": "^1.15.0",
+				"rtl-css-js": "^1.16.0",
 				"stylis": "^4.0.13",
 				"tslib": "^2.1.0"
 			},
@@ -36297,11 +36435,11 @@
 			}
 		},
 		"@griffel/react": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.1.0.tgz",
-			"integrity": "sha512-DxbDufQZrOPtGf/RiEeG6CKGHIdQb8Z6pJveeLioDQJe/lZar+u1NhOjILTih+saX/ZRGuhYX74uNWWUxmFb6w==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@griffel/react/-/react-1.2.3.tgz",
+			"integrity": "sha512-YUHQINfDu5VbgkGK1ezfFL7f3VpxacEVLQiiy9FR1E+OeENaXYkPWePhi8PN2dQiF5elpnwOhrFnCYopSq6X2w==",
 			"requires": {
-				"@griffel/core": "^1.3.1",
+				"@griffel/core": "^1.5.1",
 				"tslib": "^2.1.0"
 			},
 			"dependencies": {
@@ -38331,7 +38469,8 @@
 		"@octokit/plugin-request-log": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA=="
+			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+			"requires": {}
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
 			"version": "5.15.0",
@@ -39338,7 +39477,8 @@
 		"@webpack-cli/configtest": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
-			"integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg=="
+			"integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
+			"requires": {}
 		},
 		"@webpack-cli/info": {
 			"version": "1.5.0",
@@ -39351,7 +39491,8 @@
 		"@webpack-cli/serve": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
-			"integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q=="
+			"integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
+			"requires": {}
 		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
@@ -39407,7 +39548,8 @@
 		"acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"requires": {}
 		},
 		"acorn-walk": {
 			"version": "7.2.0",
@@ -39491,12 +39633,14 @@
 		"ajv-errors": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+			"integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+			"requires": {}
 		},
 		"ajv-keywords": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+			"requires": {}
 		},
 		"alphanum-sort": {
 			"version": "1.0.2",
@@ -40114,7 +40258,8 @@
 		"babel-plugin-named-asset-import": {
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
-			"integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q=="
+			"integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
+			"requires": {}
 		},
 		"babel-plugin-polyfill-corejs2": {
 			"version": "0.3.1",
@@ -42778,7 +42923,8 @@
 				"ws": {
 					"version": "8.2.3",
 					"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-					"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA=="
+					"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+					"requires": {}
 				}
 			}
 		},
@@ -43148,7 +43294,8 @@
 		"eslint-config-prettier": {
 			"version": "8.5.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q=="
+			"integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+			"requires": {}
 		},
 		"eslint-config-react-app": {
 			"version": "6.0.0",
@@ -43402,7 +43549,8 @@
 		"eslint-plugin-react-hooks": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
-			"integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g=="
+			"integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+			"requires": {}
 		},
 		"eslint-plugin-testing-library": {
 			"version": "3.10.2",
@@ -47855,7 +48003,8 @@
 		"jest-pnp-resolver": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
+			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+			"requires": {}
 		},
 		"jest-puppeteer": {
 			"version": "6.1.0",
@@ -54423,9 +54572,9 @@
 			"integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
 		},
 		"rtl-css-js": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.15.0.tgz",
-			"integrity": "sha512-99Cu4wNNIhrI10xxUaABHsdDqzalrSRTie4GeCmbGVuehm4oj+fIy8fTzB+16pmKe8Bv9rl+hxIBez6KxExTew==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.16.0.tgz",
+			"integrity": "sha512-Oc7PnzwIEU4M0K1J4h/7qUUaljXhQ0kCObRsZjxs2HjkpKsnoTMvSmvJ4sqgJZd0zBoEfAyTdnK/jMIYvrjySQ==",
 			"requires": {
 				"@babel/runtime": "^7.1.2"
 			}
@@ -56187,9 +56336,9 @@
 			}
 		},
 		"tabster": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/tabster/-/tabster-1.4.2.tgz",
-			"integrity": "sha512-WdEu9vzVVUPD1hXHRI8Pwji5+UrMXidMtsMlL3Z1QyfLdML/p6jv2TA4cVGT1Tc6CPQ8xqn27fHXAzR/0K8AwQ==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/tabster/-/tabster-1.5.4.tgz",
+			"integrity": "sha512-3WZYLUHLon0rdbwqVQJ2x9QAr5FLegYBEQr+r5M54oZ/NJ5DuUsjjn5c9A9/XbTvfWqkQ5K9KABrbOgG6XLxkQ==",
 			"requires": {
 				"keyborg": "^1.1.0",
 				"tslib": "^2.3.1"
@@ -56715,8 +56864,7 @@
 		"typescript": {
 			"version": "4.7.4",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-			"dev": true
+			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
 		},
 		"uglify-js": {
 			"version": "3.16.1",
@@ -58870,7 +59018,8 @@
 		"ws": {
 			"version": "7.5.8",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
-			"integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw=="
+			"integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
+			"requires": {}
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7878,7 +7878,8 @@
     "@octokit/plugin-request-log": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA=="
+      "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.15.0",

--- a/packages/live-share/src/EphemeralEvent.ts
+++ b/packages/live-share/src/EphemeralEvent.ts
@@ -171,10 +171,13 @@ export interface IEphemeralEventEvents<TEvent extends IEphemeralEvent> extends I
             if (current.timestamp == received.timestamp) {
                 // In a case where both clientId's are blank that's the local client in a disconnected state
                 const cmp = (current.clientId || '').localeCompare(received.clientId || '');
-                if (cmp < 0) {
-                    // cmp == 0 is same user and we want to take latest event from a given user.
-                    // cmp > 0 is a tie breaker so we'll take that event as well (comparing 'a' with 'c' 
-                    // will result in a negative value).
+                if (cmp <= 0) {
+                    // - cmp == 0 is same user. We use to identify events for same user as newer but 
+                    //   that was causing us to fire duplicate state & presence change events. The better
+                    //   approach is to update the timestamp provider to never return the same timestamp 
+                    //   twice.  (Comparison was changed on 8/2/2022)
+                    // - cmp > 0 is a tie breaker so we'll take that event as well (comparing 'a' with 'c' 
+                    //   will result in a negative value).
                     return false;
                 }
             } else if (current.timestamp > received.timestamp) {

--- a/packages/live-share/src/EphemeralPresence.ts
+++ b/packages/live-share/src/EphemeralPresence.ts
@@ -151,6 +151,13 @@ export class EphemeralPresence<TData extends object = object> extends DataObject
 
         // Create object synchronizer
         this._synchronizer = new EphemeralObjectSynchronizer<IEphemeralPresenceEvent<TData>>(this.id, this.context.containerRuntime, (connecting) => {
+                // Update timestamp for current presence
+                // - If we don't do this the user will timeout and show as "offline" for all other
+                //   clients. That's because the EphemeralEvent.isNewer() check will fail.  Updating
+                //   the timestamp of the outgoing update is the best way to show proof that the client
+                //   is still alive.
+                this._currentPresence.timestamp = EphemeralEvent.getTimestamp();
+
                 // Return current presence
                 return this._currentPresence;
             }, (connecting, state, sender) => {

--- a/packages/live-share/src/LocalTimestampProvider.ts
+++ b/packages/live-share/src/LocalTimestampProvider.ts
@@ -11,6 +11,7 @@ import { ITimestampProvider } from "./interfaces";
  */
 export class LocalTimestampProvider implements ITimestampProvider {
     private static _warned: boolean = false;
+    private _lastTimeSent = 0;
 
     constructor(noWarn = false) {
         if (noWarn) {
@@ -24,7 +25,10 @@ export class LocalTimestampProvider implements ITimestampProvider {
             LocalTimestampProvider._warned = true;
         }
 
-        return new Date().getTime();
+        // Return timestamp and save last
+        // - We never want to generate the same timestamp twice and we always want a greater 
+        //   timestamp then what we previously sent.
+        return this._lastTimeSent = Math.max(new Date().getTime(), this._lastTimeSent + 1);
     }
 
     public getMaxTimestampError(): number {

--- a/packages/live-share/src/internals/SharedClock.ts
+++ b/packages/live-share/src/internals/SharedClock.ts
@@ -45,10 +45,11 @@ interface IServerTimeOffset {
             throw new Error(`SharedClock: can't call getTimestamp() before calling start().`);
         }
 
-        // Return adjusted timestamp
-        // - We're remember the last time we sent and returning that if we ever predict an earlier time.
-        //   This can happen if our accuracy improves and we end up with a smaller offset then before.
-        return this._lastTimeSent = Math.max(new Date().getTime() + this._serverTime.offset, this._lastTimeSent);
+        // Return adjusted timestamp and save last
+        // - We never want to generate the same timestamp twice and we always want a greater 
+        //   timestamp then what we previously sent. This can happen if our accuracy improves 
+        //   and we end up with a smaller offset then before.
+        return this._lastTimeSent = Math.max(new Date().getTime() + this._serverTime.offset, this._lastTimeSent + 1);
     }
 
     public getMaxTimestampError(): number {

--- a/packages/live-share/src/test/EphemeralEvent.spec.ts
+++ b/packages/live-share/src/test/EphemeralEvent.spec.ts
@@ -186,7 +186,7 @@ describeNoCompat("EphemeralEvent", (getTestObjectProvider) => {
         assert(!allowed, `event allowed`);
     });
 
-    it("Should allow events with same timestamp from same client", () => {
+    it("Should block events with same timestamp from same client", () => {
         const current: IEphemeralEvent = {
             name: 'test',
             clientId: 'CA',
@@ -200,7 +200,7 @@ describeNoCompat("EphemeralEvent", (getTestObjectProvider) => {
         };
 
         const allowed = EphemeralEvent.isNewer(current, received);
-        assert(allowed, `event blocked`);
+        assert(!allowed, `event allowed`);
     });
 
     it("Should allow events with same timestamp and a different clientId that sorts lower", () => {


### PR DESCRIPTION
Fixes #50 

- Fixed comparison in EphemeralEvent.isNewer() that was letting duplicate events/state objects return `true` when from the same clientId.
- Fixed an issue in Presence that was depending on the current behavior of isNewer().
- Changed the SharedClock and LocalTimestampProviders to never return the same timestamp twice.

The isNewer() function was considering events/objects from the same client with the same timestamp as newer. This behavior was originally intended to handle multiple events being generated really fast by a client.  The better way to approach that is to just never generate the same timestamp twice which is what the code does now.