### PR TITLE
[LiveCanvas] Add support for straight lines and arrows

### DIFF
--- a/packages/live-share-canvas/src/canvas/InkingCanvas.ts
+++ b/packages/live-share-canvas/src/canvas/InkingCanvas.ts
@@ -447,6 +447,7 @@ export abstract class InkingCanvas {
      */
     cancelStroke() {
         this.internalCancelStroke();
+        this.clear();
 
         this._strokeStarted = false;
     }

--- a/packages/live-share-canvas/src/core/Brush.ts
+++ b/packages/live-share-canvas/src/core/Brush.ts
@@ -48,6 +48,16 @@ export const DefaultPenBrush: Readonly<IBrush> = {
 };
 
 /**
+ * The default line brush.
+ */
+export const DefaultLineBrush: Readonly<IBrush> = {
+    type: "pen",
+    color: PenColors.black,
+    tip: "ellipse",
+    tipSize: 10
+};
+
+/**
  * The default highlighter brush.
  */
 export const DefaultHighlighterBrush: IBrush = {

--- a/packages/live-share-canvas/src/core/Brush.ts
+++ b/packages/live-share-canvas/src/core/Brush.ts
@@ -16,6 +16,11 @@ export type BrushTipShape = "ellipse" | "rectangle";
 export type BrushType = "pen" | "highlighter" | "laser";
 
 /**
+ * 
+ */
+export type ArrowType = "none" | "open";
+
+/**
  * Defines a brush as used to draw strokes.
  */
 export interface IBrush {
@@ -35,6 +40,11 @@ export interface IBrush {
      * The size of the brush's tip. Must be greater than 0.
      */
     tipSize: number;
+    /**
+     * Optional. The type of arrow at the end of a line drawn with
+     * the brush. Defaults to `none`.
+     */
+    endArrow?: ArrowType;
 }
 
 /**

--- a/packages/live-share-canvas/src/core/InkingManager.ts
+++ b/packages/live-share-canvas/src/core/InkingManager.ts
@@ -581,13 +581,23 @@ export class InkingManager extends EventEmitter {
                 this.queuePointerMovedNotification(filteredPoint);
             }
         }
-
         // Otherwise, we handle the pointer move event only if the pointer it comes
         // from is the one we have captured
-        if (e.isPointerDown) {
+        else {
             const filteredPoint = this._inputFilters.filterPoint(e);
 
             if (this._currentStroke) {
+                if (this._currentStroke.mode === StrokeMode.line && e.ctrlKey) {
+                    const firstPoint = this._currentStroke.getPointAt(0);
+
+                    if (Math.abs(filteredPoint.x - firstPoint.x) > Math.abs(filteredPoint.y - firstPoint.y)) {
+                        filteredPoint.y = firstPoint.y;
+                    }
+                    else {
+                        filteredPoint.x = firstPoint.x;
+                    }
+                }
+
                 this._currentStroke.addPoints(filteredPoint);
 
                 this.notifyAddPoints(this._currentStroke.id, filteredPoint);

--- a/packages/live-share-canvas/src/core/InkingManager.ts
+++ b/packages/live-share-canvas/src/core/InkingManager.ts
@@ -319,16 +319,19 @@ class WetLineStroke extends WetStroke {
 
         this.canvas.cancelStroke();
         this.canvas.beginStroke(this.getPointAt(0));
-        this.canvas.addPoint(this.getPointAt(1));
 
-        if (this.length > 1 && this.brush.endArrow === "open") {
-            const arrowPath = computeEndArrow(this.getPointAt(0), this.getPointAt(1));
+        if (this.length > 1) {
+            this.canvas.addPoint(this.getPointAt(1));
 
-            for (let i = 0; i < arrowPath.length; i++) {
-                const p = { ...arrowPath[i], pressure: this.getPointAt(1).pressure };
+            if (this.brush.endArrow === "open") {
+                const arrowPath = computeEndArrow(this.getPointAt(0), this.getPointAt(1));
 
-                this.addPoint(p);
-                this.canvas.addPoint(p);
+                for (let i = 0; i < arrowPath.length; i++) {
+                    const p = { ...arrowPath[i], pressure: this.getPointAt(1).pressure };
+
+                    this.addPoint(p);
+                    this.canvas.addPoint(p);
+                }
             }
         }
 

--- a/packages/live-share-canvas/src/core/InkingManager.ts
+++ b/packages/live-share-canvas/src/core/InkingManager.ts
@@ -10,7 +10,7 @@ import { Stroke, IStroke, IStrokeCreationOptions, StrokeType, StrokeMode } from 
 import { InputFilter, InputFilterCollection, JitterFilter, IPointerEvent, InputProvider,
     PointerInputProvider, IPointerMoveEvent } from "../input";
 import { DefaultHighlighterBrush, DefaultLaserPointerBrush, DefaultLineBrush, DefaultPenBrush,
-    IBrush, ArrowType } from "./Brush";
+    IBrush } from "./Brush";
 import { makeRectangle, generateUniqueId, computeEndArrow } from "./Internals";
 
 /**
@@ -400,6 +400,12 @@ export class InkingManager extends EventEmitter {
      */
     public static ephemeralCanvasRemovalDelay = 1500;
 
+    /**
+     * Configures whether the Ctrl, Shift and Alt keys can be used to alter the way strokes
+     * are drawn using various tools.
+     */
+    public static enableStrokeModifierHotKeys = true;
+
     private static ScreenToViewportCoordinateTransform = class extends InputFilter {
         constructor(private _owner: InkingManager) {
             super();
@@ -577,10 +583,10 @@ export class InkingManager extends EventEmitter {
             case InkingTool.line:
             case InkingTool.highlighter:
             case InkingTool.laserPointer:
-                const mode = this.tool === InkingTool.line ? StrokeMode.line : (e.ctrlKey ? StrokeMode.line : StrokeMode.freeHand);
+                const mode = this.tool === InkingTool.line ? StrokeMode.line : (e.ctrlKey && InkingManager.enableStrokeModifierHotKeys ? StrokeMode.line : StrokeMode.freeHand);
                 const brush = { ...this.getBrushForTool(this.tool) };
 
-                if (e.altKey) {
+                if (e.altKey && InkingManager.enableStrokeModifierHotKeys) {
                     brush.endArrow = "open";
                 }
 
@@ -646,7 +652,7 @@ export class InkingManager extends EventEmitter {
             let filteredPoint = this._inputFilters.filterPoint(e);
 
             if (this._currentStroke) {
-                if (e.shiftKey) {
+                if (e.shiftKey && InkingManager.enableStrokeModifierHotKeys) {
                     filteredPoint = this._currentStroke.straighten(filteredPoint);
                 }
 
@@ -679,7 +685,7 @@ export class InkingManager extends EventEmitter {
         let filteredPoint = this._inputFilters.filterPoint(e);
 
         if (this._currentStroke) {
-            if (e.shiftKey) {
+            if (e.shiftKey && InkingManager.enableStrokeModifierHotKeys) {
                 filteredPoint = this._currentStroke.straighten(filteredPoint);
             }
 

--- a/packages/live-share-canvas/src/core/InkingManager.ts
+++ b/packages/live-share-canvas/src/core/InkingManager.ts
@@ -646,8 +646,6 @@ export class InkingManager extends EventEmitter {
             let filteredPoint = this._inputFilters.filterPoint(e);
 
             if (this._currentStroke) {
-                this._currentStroke.brush.endArrow = e.altKey ? "open" : undefined;
-
                 if (e.shiftKey) {
                     filteredPoint = this._currentStroke.straighten(filteredPoint);
                 }
@@ -681,8 +679,6 @@ export class InkingManager extends EventEmitter {
         let filteredPoint = this._inputFilters.filterPoint(e);
 
         if (this._currentStroke) {
-            this._currentStroke.brush.endArrow = e.altKey ? "open" : undefined;
-            
             if (e.shiftKey) {
                 filteredPoint = this._currentStroke.straighten(filteredPoint);
             }

--- a/packages/live-share-canvas/src/core/InkingManager.ts
+++ b/packages/live-share-canvas/src/core/InkingManager.ts
@@ -646,6 +646,8 @@ export class InkingManager extends EventEmitter {
             let filteredPoint = this._inputFilters.filterPoint(e);
 
             if (this._currentStroke) {
+                this._currentStroke.brush.endArrow = e.altKey ? "open" : undefined;
+
                 if (e.shiftKey) {
                     filteredPoint = this._currentStroke.straighten(filteredPoint);
                 }
@@ -679,6 +681,8 @@ export class InkingManager extends EventEmitter {
         let filteredPoint = this._inputFilters.filterPoint(e);
 
         if (this._currentStroke) {
+            this._currentStroke.brush.endArrow = e.altKey ? "open" : undefined;
+            
             if (e.shiftKey) {
                 filteredPoint = this._currentStroke.straighten(filteredPoint);
             }

--- a/packages/live-share-canvas/src/core/Internals.ts
+++ b/packages/live-share-canvas/src/core/Internals.ts
@@ -21,19 +21,6 @@ export function generateUniqueId(): string {
 }
 
 /**
- * Converts a PointerEvent into an IPointerPoint.
- * @param e The pointer event to convert.
- * @returns An IPointerPoint object.
- */
-export function pointerEventToPoint(e: PointerEvent): IPointerPoint {
-    return {
-        x: e.offsetX,
-        y: e.offsetY,
-        pressure: e.pressure
-    };
-}
-
-/**
  * Determines if a number is within a range.
  * @param n The number to check.
  * @param r1 The first range boundary.
@@ -381,4 +368,36 @@ export function getSegmentIntersectionsWithRectangle(s: ISegment, r: IRect): IPo
     }
 
     return result;
+}
+
+/**
+ * Calculates the points defining the path of an arrow at the end of
+ * a segment.
+ * @param from The start point of the arrow segment.
+ * @param to The end point of the arrow segment.
+ * @returns The points making up the arrow.
+ */
+export function computeEndArrow(from: IPoint, to: IPoint, arrowSize: number = 20): IPoint[] {
+    // dx,dy = arrow line vector
+    const dx = to.x - from.x;
+    const dy = to.y - from.y;
+
+    // Normalize the vector
+    const length = Math.sqrt(dx * dx + dy * dy);
+    const unitDx = dx / length;
+    const unitDy = dy / length;
+
+    // The two additional points are on either side of the perpendicular to
+    // vector.
+    return [
+        {
+            x: to.x - arrowSize * (unitDx - unitDy),
+            y: to.y - arrowSize * (unitDy + unitDx)
+        },
+        to,
+        {
+            x: to.x - arrowSize * (unitDx + unitDy),
+            y: to.y - arrowSize * (unitDy - unitDx)
+        }    
+    ]
 }

--- a/packages/live-share-canvas/src/core/LiveCanvas.ts
+++ b/packages/live-share-canvas/src/core/LiveCanvas.ts
@@ -449,6 +449,7 @@ export class LiveCanvas extends DataObject {
                 if (!local && this._inkingManager) {
                     const stroke = this._inkingManager.beginWetStroke(
                         evt.type,
+                        evt.mode,
                         evt.startPoint,
                         {
                             id: evt.strokeId,

--- a/packages/live-share-canvas/src/core/Stroke.ts
+++ b/packages/live-share-canvas/src/core/Stroke.ts
@@ -46,23 +46,37 @@ interface ISerializedStrokeData {
 }
 
 /**
+ * Stroke modes.
+ */
+export enum StrokeMode {
+    /**
+     * A freehand stroke that follows a path.
+     */
+    freeHand = 0,
+    /**
+     * A straight line stroke between two points.
+     */
+    line = 1
+}
+
+/**
  * Stroke types.
  */
 export enum StrokeType {
     /**
      * Laser pointer stroke, with a vanishing tail.
      */
-    laserPointer,
+    laserPointer = 0,
     /**
      * Ephemeral stroke, which vanishes all at once after
      * a set amount of time.
      */
-    ephemeral,
+    ephemeral = 1,
     /**
      * Persistent stroke, that remains on the canvas until
      * erased.
      */
-    persistent
+    persistent = 2
 }
 
 /**
@@ -165,22 +179,6 @@ export class Stroke implements IStroke, Iterable<IPointerPoint> {
     private _timeStamp: number;
     private _boundingRect?: IRect;
 
-    private addPoint(p: IPointerPoint): boolean {
-        let lastPoint = this._points.length > 0 ? this._points[this._points.length - 1] : undefined;
-
-        if (lastPoint === undefined || lastPoint.x !== p.x || lastPoint.y !== p.y) {
-            this._points.push(p);
-
-            if (this._boundingRect && !isPointInsideRectangle(p, this._boundingRect)) {
-                this._boundingRect = undefined;
-            }
-
-            return true;
-        }
-
-        return false;
-    }
-
     /**
      * In order to reduce the amount of data a serialized stroke uses, points
      * are serialized in a minimal way:
@@ -249,6 +247,22 @@ export class Stroke implements IStroke, Iterable<IPointerPoint> {
         return result;
     }
 
+    protected addPoint(p: IPointerPoint): boolean {
+        let lastPoint = this._points.length > 0 ? this._points[this._points.length - 1] : undefined;
+
+        if (lastPoint === undefined || lastPoint.x !== p.x || lastPoint.y !== p.y) {
+            this._points.push(p);
+
+            if (this._boundingRect && !isPointInsideRectangle(p, this._boundingRect)) {
+                this._boundingRect = undefined;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
     /**
      * Creates a new Stroke instance.
      * @param options Optional creation options such as id, points, etc.
@@ -285,6 +299,14 @@ export class Stroke implements IStroke, Iterable<IPointerPoint> {
         }
 
         return pointsAdded;
+    }
+
+    /**
+     * CLears the stroke, i.e. removes all of its points.
+     */
+    clear() {
+        this._points = [];
+        this._boundingRect = undefined;
     }
 
     /**

--- a/samples/03.live-canvas-demo/src/stage-view.ts
+++ b/samples/03.live-canvas-demo/src/stage-view.ts
@@ -29,6 +29,7 @@ const appTemplate = `
         <div id="buttonStrip">
             <div class="toolbar">
                 <button id="btnStroke">Stroke</button>
+                <button id="btnArrow">Arrow</button>
                 <button id="btnLaserPointer">Laser pointer</button>
                 <button id="btnHighlighter">Highlighter</button>
                 <button id="btnEraser">Eraser</button>
@@ -230,6 +231,11 @@ export class StageView extends View {
         }
 
         setupButton("btnStroke", () => { this._inkingManager.tool = InkingTool.pen });
+        setupButton(
+            "btnArrow", () => {
+                this._inkingManager.tool = InkingTool.line;
+                this._inkingManager.lineBrush.endArrow = "open";
+            });
         setupButton("btnLaserPointer", () => { this._inkingManager.tool = InkingTool.laserPointer });
         setupButton("btnHighlighter", () => { this._inkingManager.tool = InkingTool.highlighter });
         setupButton("btnEraser", () => { this._inkingManager.tool = InkingTool.eraser });


### PR DESCRIPTION
This PR add support for drawing straight lines and arrows:
- Hold `CTRL` down as you start a stroke with the pen, highlighter or laser pointer, and you will draw a straight line. You can release CTRL after you've started; the stroke will remain straight.
- Hold `ALT` as you start a stroke and once it is completed it will get an arrow at the end
- Hold both `CTRL` + `ALT` down as you start a stroke and you will draw a straight arrow
- Hold `SHIFT` down as you draw a line to force the line to be horizontal or vertical
- You can also select the new "line" tool which forces all strokes to be straight lines