### PR TITLE
Fix runtime PropType errors for 21.react-media-template and 22.react-agile-poker React samples

### DIFF
--- a/samples/21.react-media-template/src/components/flex/FlexColumn.jsx
+++ b/samples/21.react-media-template/src/components/flex/FlexColumn.jsx
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import { mergeClasses } from "@fluentui/react-components";
 import { getFlexColumnStyles } from "./FlexStyles";
 
@@ -19,7 +20,7 @@ export const FlexColumn = (props) => {
     const flexColumnStyles = getFlexColumnStyles();
     const mergedClasses = mergeClasses(
         flexColumnStyles.root,
-        fill ? flexColumnStyles.fill : "",
+        fill ? flexColumnStyles.fill : PropTypes.oneOf([""]),
         hAlignCenter ? flexColumnStyles.hAlignCenter : "",
         hAlignEnd ? flexColumnStyles.hAlignEnd : "",
         hAlignStart ? flexColumnStyles.hAlignStart : "",
@@ -40,15 +41,15 @@ export const FlexColumn = (props) => {
 
 FlexColumn.propTypes = {
     children: PropTypes.node,
-    className: string,
-    fill: "both" | "height" | "width" | "view",
-    gap: "smaller" | "small" | "medium" | "large",
-    hAlign: "start" | "center" | "end",
+    className: PropTypes.string,
+    fill: PropTypes.oneOf(["both", "height", "width", "view"]),
+    gap: PropTypes.oneOf(["smaller", "small", "medium", "large"]),
+    hAlign: PropTypes.oneOf(["start", "center", "end"]),
     inline: PropTypes.bool,
     name: PropTypes.string,
     role: PropTypes.string,
     spaceBetween: PropTypes.bool,
     style: PropTypes.object,
     transparent: PropTypes.bool,
-    vAlign: "start" | "center" | "end",
+    vAlign: PropTypes.oneOf(["start", "center", "end"]),
 };

--- a/samples/21.react-media-template/src/components/flex/FlexRow.jsx
+++ b/samples/21.react-media-template/src/components/flex/FlexRow.jsx
@@ -40,15 +40,15 @@ export const FlexRow = (props) => {
 
 FlexRow.propTypes = {
     children: PropTypes.node,
-    className: string,
-    fill: "both" | "height" | "width" | "view",
-    gap: "smaller" | "small" | "medium" | "large",
-    hAlign: "start" | "center" | "end",
+    className: PropTypes.string,
+    fill: PropTypes.oneOf(["both", "height", "width", "view"]),
+    gap: PropTypes.oneOf(["smaller", "small", "medium", "large"]),
+    hAlign: PropTypes.oneOf(["start", "center", "end"]),
     inline: PropTypes.bool,
     name: PropTypes.string,
     role: PropTypes.string,
     spaceBetween: PropTypes.bool,
     style: PropTypes.object,
     transparent: PropTypes.bool,
-    vAlign: "start" | "center" | "end",
+    vAlign: PropTypes.oneOf(["start", "center", "end"]),
 };

--- a/samples/22.react-agile-poker/src/components/flex/FlexColumn.jsx
+++ b/samples/22.react-agile-poker/src/components/flex/FlexColumn.jsx
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import { mergeClasses } from "@fluentui/react-components";
 import { getFlexColumnStyles } from "./FlexStyles";
 
@@ -40,15 +41,15 @@ export const FlexColumn = (props) => {
 
 FlexColumn.propTypes = {
     children: PropTypes.node,
-    className: string,
-    fill: "both" | "height" | "width" | "view",
-    gap: "smaller" | "small" | "medium" | "large",
-    hAlign: "start" | "center" | "end",
+    className: PropTypes.string,
+    fill: PropTypes.oneOf(["both", "height", "width", "view"]),
+    gap: PropTypes.oneOf(["smaller", "small", "medium", "large"]),
+    hAlign: PropTypes.oneOf(["start", "center", "end"]),
     inline: PropTypes.bool,
     name: PropTypes.string,
     role: PropTypes.string,
     spaceBetween: PropTypes.bool,
     style: PropTypes.object,
     transparent: PropTypes.bool,
-    vAlign: "start" | "center" | "end",
+    vAlign: PropTypes.oneOf(["start", "center", "end"]),
 };

--- a/samples/22.react-agile-poker/src/components/flex/FlexRow.jsx
+++ b/samples/22.react-agile-poker/src/components/flex/FlexRow.jsx
@@ -40,15 +40,15 @@ export const FlexRow = (props) => {
 
 FlexRow.propTypes = {
     children: PropTypes.node,
-    className: string,
-    fill: "both" | "height" | "width" | "view",
-    gap: "smaller" | "small" | "medium" | "large",
-    hAlign: "start" | "center" | "end",
+    className: PropTypes.string,
+    fill: PropTypes.oneOf(["both", "height", "width", "view"]),
+    gap: PropTypes.oneOf(["smaller", "small", "medium", "large"]),
+    hAlign: PropTypes.oneOf(["start", "center", "end"]),
     inline: PropTypes.bool,
     name: PropTypes.string,
     role: PropTypes.string,
     spaceBetween: PropTypes.bool,
     style: PropTypes.object,
     transparent: PropTypes.bool,
-    vAlign: "start" | "center" | "end",
+    vAlign: PropTypes.oneOf(["start", "center", "end"]),
 };


### PR DESCRIPTION
I noticed while checking out the samples, that out of the box I was seeing errors like the below around PropTypes for the 21.react-media-template and 22.react-agile-poker templates. 

Issue: #132 

```javascript
Uncaught ReferenceError: PropTypes is not defined
    at ./src/components/flex/FlexColumn.jsx (FlexColumn.jsx:42:1)

Uncaught ReferenceError: string is not defined
    at ./src/components/flex/FlexColumn.jsx (FlexColumn.jsx:44:1)
    
Warning: Failed prop type: FlexColumn: prop type `fill` is invalid; it must be a function, usually from the `prop-types` package, but received `number`.This often happens because of typos such as `PropTypes.function` instead of `PropTypes.func`.
    at FlexColumn (http://localhost:3000/static/js/bundle.js:3501:5)
```

I created a simple PR to fix these issues so that they work out of the box.