### PR TITLE
Reverting linter promise changes in request handlers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,6 +32,8 @@
         "@typescript-eslint/no-empty-function": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-namespace": "off",
+        "no-async-promise-executor": "off",
+        "no-constant-condition": "off",
         "no-undef": "off", // Disabled due to conflicts with @typescript/eslint
         "no-unused-vars": "off", // Disabled due to conflicts with @typescript/eslint
         "react/react-in-jsx-scope": "off",


### PR DESCRIPTION
- Reverting linter promise changes in Role validation request handlers
- In Linter update, commit: [Add eslint & prettier by corinagum · Pull Request #110 · microsoft/live-share-sdk (github.com)](https://github.com/microsoft/live-share-sdk/pull/110) linter forced some unintentional changes, resulted in removal of async generator in compiled js. Since these are used only for role calls: `registerClientRoles` and `getClientRoles`, the call would never finish and would keep retrying. Reverting this.
- Validated in YouTube
![image](https://user-images.githubusercontent.com/5934356/198483249-4e6bf9d4-d768-4eb1-ae9c-be3a826e85e0.png)
