### PR TITLE
Resize video fixes for sample 21 (JS + TS)

### DIFF
--- a/samples/javascript/21.react-media-template/src/components/InkCanvas.jsx
+++ b/samples/javascript/21.react-media-template/src/components/InkCanvas.jsx
@@ -1,15 +1,14 @@
-import React, { useEffect } from "react";
-import useResizeObserver from "use-resize-observer";
-import { getInkCanvasStyles } from "../styles/styles";
-import { useVisibleVideoSize } from "../utils/useVisibleVideoSize";
+import { useEffect } from "react";
 import { useEventListener } from "../utils/useEventListener";
 
 const REFERENCE_HEIGHT = 1080;
 
-export const InkCanvas = ({ isEnabled, inkingManager, canvasRef }) => {
-    const { ref: resizeRef, width = 1, height = 1 } = useResizeObserver();
-    const videoSize = useVisibleVideoSize(width, height);
-
+export const InkCanvas = ({
+    isEnabled,
+    inkingManager,
+    canvasRef,
+    videoSize,
+}) => {
     const onMouseEvent = (event) => {
         if (isEnabled) {
             event.preventDefault();
@@ -32,11 +31,9 @@ export const InkCanvas = ({ isEnabled, inkingManager, canvasRef }) => {
     useEventListener("mousedown", onMouseEvent, canvasRef.current);
     useEventListener("mouseup", onMouseEvent, canvasRef.current);
     useEventListener("mousemove", onMouseEvent, canvasRef.current);
-    const inkStyles = getInkCanvasStyles();
 
     return (
         <>
-            <div className={inkStyles.root} ref={resizeRef} />
             <div
                 className="noselect"
                 ref={canvasRef}

--- a/samples/javascript/21.react-media-template/src/components/LiveSharePage.jsx
+++ b/samples/javascript/21.react-media-template/src/components/LiveSharePage.jsx
@@ -30,7 +30,6 @@ export const LiveSharePage = ({ children, context, container, started }) => {
                         top: "0px",
                         bottom: "0px",
                         zIndex: 9999,
-                        backgroundColor: "#201F1F",
                     }}
                 >
                     <Spinner />
@@ -44,7 +43,11 @@ export const LiveSharePage = ({ children, context, container, started }) => {
                     </Text>
                 </FlexColumn>
             )}
-            <div style={{ visibility: loadText ? "hidden" : undefined }}>
+            <div
+                style={{
+                    visibility: loadText ? "hidden" : undefined,
+                }}
+            >
                 {children}
             </div>
         </>

--- a/samples/javascript/21.react-media-template/src/components/MediaPlayerContainer.jsx
+++ b/samples/javascript/21.react-media-template/src/components/MediaPlayerContainer.jsx
@@ -157,7 +157,7 @@ export const MediaPlayerContainer = ({
         <div
             className={mergeClasses(
                 flexColumnStyles.root,
-                playerControlStyles.pointerTrackerContainer
+                playerControlStyles.root
             )}
             onMouseMove={() => {
                 setShowControls(true);

--- a/samples/javascript/21.react-media-template/src/components/flex/FlexColumn.jsx
+++ b/samples/javascript/21.react-media-template/src/components/flex/FlexColumn.jsx
@@ -42,14 +42,14 @@ export const FlexColumn = (props) => {
 FlexColumn.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
-    fill: "both" | "height" | "width" | "view",
-    gap: "smaller" | "small" | "medium" | "large",
-    hAlign: "start" | "center" | "end",
+    fill: PropTypes.oneOf(["both", "height", "width", "view"]),
+    gap: PropTypes.oneOf(["smaller" | "small" | "medium" | "large"]),
+    hAlign: PropTypes.oneOf(["start" | "center" | "end"]),
     inline: PropTypes.bool,
     name: PropTypes.string,
     role: PropTypes.string,
     spaceBetween: PropTypes.bool,
     style: PropTypes.object,
     transparent: PropTypes.bool,
-    vAlign: "start" | "center" | "end",
+    vAlign: PropTypes.oneOf(["start" | "center" | "end"]),
 };

--- a/samples/javascript/21.react-media-template/src/components/flex/FlexRow.jsx
+++ b/samples/javascript/21.react-media-template/src/components/flex/FlexRow.jsx
@@ -41,14 +41,14 @@ export const FlexRow = (props) => {
 FlexRow.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
-    fill: "both" | "height" | "width" | "view",
-    gap: "smaller" | "small" | "medium" | "large",
-    hAlign: "start" | "center" | "end",
+    fill: PropTypes.oneOf(["both", "height", "width", "view"]),
+    gap: PropTypes.oneOf(["smaller" | "small" | "medium" | "large"]),
+    hAlign: PropTypes.oneOf(["start" | "center" | "end"]),
     inline: PropTypes.bool,
     name: PropTypes.string,
     role: PropTypes.string,
     spaceBetween: PropTypes.bool,
     style: PropTypes.object,
     transparent: PropTypes.bool,
-    vAlign: "start" | "center" | "end",
+    vAlign: PropTypes.oneOf(["start" | "center" | "end"]),
 };

--- a/samples/javascript/21.react-media-template/src/pages/MeetingStage.jsx
+++ b/samples/javascript/21.react-media-template/src/pages/MeetingStage.jsx
@@ -131,7 +131,7 @@ const MeetingStage = () => {
 
     // Render the media player
     return (
-        <div style={{ backgroundColor: "black" }}>
+        <div>
             {/* Display error if container failed to load */}
             {error && <PageError error={error} />}
             {/* Live Share wrapper to show loading indicator before setup */}

--- a/samples/javascript/21.react-media-template/src/styles/styles.js
+++ b/samples/javascript/21.react-media-template/src/styles/styles.js
@@ -22,7 +22,8 @@ export const getVideoStyle = makeStyles({
 });
 
 export const getPlayerControlStyles = makeStyles({
-    pointerTrackerContainer: {
+    root: {
+        backgroundColor: "black",
         position: "absolute",
         zIndex: 0,
         top: "0",

--- a/samples/javascript/21.react-media-template/src/styles/styles.js
+++ b/samples/javascript/21.react-media-template/src/styles/styles.js
@@ -9,10 +9,6 @@ import { tokens } from "@fluentui/react-theme";
 export const getVideoStyle = makeStyles({
     root: {
         cursor: "pointer",
-        left: "0",
-        top: "0",
-        bottom: "0",
-        right: "0",
         zIndex: 0,
         position: "fixed",
         backgroundColor: "black",
@@ -95,7 +91,7 @@ export const getPillStyles = makeStyles({
     },
 });
 
-export const getInkCanvasStyles = makeStyles({
+export const getResizeReferenceStyles = makeStyles({
     root: {
         position: "absolute",
         zIndex: 0,

--- a/samples/typescript/21.react-media-template/src/components/InkCanvas.tsx
+++ b/samples/typescript/21.react-media-template/src/components/InkCanvas.tsx
@@ -1,20 +1,23 @@
-import React, { FC, MutableRefObject, useEffect } from "react";
-import useResizeObserver from "use-resize-observer";
-import { getInkCanvasStyles } from "../styles/styles";
-import { useVisibleVideoSize } from "../utils/useVisibleVideoSize";
+import { FC, MutableRefObject, useEffect } from "react";
+import { VideoSize } from "../utils/useVisibleVideoSize";
 import { useEventListener } from "../utils/useEventListener";
 import { InkingManager } from "@microsoft/live-share-canvas";
 
 const REFERENCE_HEIGHT = 1080;
 
-export const InkCanvas: FC<{
+interface IInkCanvasProps {
     isEnabled: boolean;
     inkingManager?: InkingManager;
     canvasRef: MutableRefObject<HTMLDivElement | undefined>;
-}> = ({ isEnabled, inkingManager, canvasRef }) => {
-    const { ref: resizeRef, width = 1, height = 1 } = useResizeObserver();
-    const videoSize = useVisibleVideoSize(width, height);
+    videoSize: VideoSize | undefined;
+}
 
+export const InkCanvas: FC<IInkCanvasProps> = ({
+    isEnabled,
+    inkingManager,
+    canvasRef,
+    videoSize,
+}) => {
     const onMouseEvent = (event: Event) => {
         if (isEnabled) {
             event.preventDefault();
@@ -37,11 +40,9 @@ export const InkCanvas: FC<{
     useEventListener("mousedown", onMouseEvent, canvasRef.current);
     useEventListener("mouseup", onMouseEvent, canvasRef.current);
     useEventListener("mousemove", onMouseEvent, canvasRef.current);
-    const inkStyles = getInkCanvasStyles();
 
     return (
         <>
-            <div className={inkStyles.root} ref={resizeRef} />
             <div
                 className="noselect"
                 ref={canvasRef as MutableRefObject<HTMLDivElement>}

--- a/samples/typescript/21.react-media-template/src/components/MediaPlayerContainer.tsx
+++ b/samples/typescript/21.react-media-template/src/components/MediaPlayerContainer.tsx
@@ -11,6 +11,7 @@ import {
     MutableRefObject,
     ReactNode,
 } from "react";
+import useResizeObserver from "use-resize-observer";
 import PlayerProgressBar from "./PlayerProgressBar";
 import { formatTimeValue } from "../utils/format";
 import {
@@ -35,12 +36,16 @@ import {
     getFlexItemStyles,
     getFlexRowStyles,
 } from "../styles/layouts";
-import { getPlayerControlStyles, getVideoStyle } from "../styles/styles";
+import {
+    getPlayerControlStyles,
+    getResizeReferenceStyles,
+    getVideoStyle,
+} from "../styles/styles";
 import { InkCanvas } from "./InkCanvas";
 import { InkingControls } from "./InkingControls";
 import { AzureMediaPlayer } from "../utils/AzureMediaPlayer";
 import { InkingManager } from "@microsoft/live-share-canvas";
-import React from "react";
+import { useVisibleVideoSize } from "../utils/useVisibleVideoSize";
 
 const events = [
     "loadstart",
@@ -111,6 +116,8 @@ export const MediaPlayerContainer: FC<MediaPlayerContainerProps> = ({
         currentHeuristicProfile: undefined,
         resolution: undefined,
     });
+    const { ref: resizeRef, width = 1, height = 1 } = useResizeObserver();
+    const videoSize = useVisibleVideoSize(width, height);
 
     const hideControls = useCallback(() => {
         setShowControls(false);
@@ -187,6 +194,7 @@ export const MediaPlayerContainer: FC<MediaPlayerContainerProps> = ({
     const flexItemStyles = getFlexItemStyles();
     const playerControlStyles = getPlayerControlStyles();
     const videoStyle = getVideoStyle();
+    const resizeReferenceStyles = getResizeReferenceStyles();
 
     return (
         <div
@@ -199,13 +207,24 @@ export const MediaPlayerContainer: FC<MediaPlayerContainerProps> = ({
                 debouncedHideControls();
             }}
         >
-            <div className={videoStyle.root} onClick={togglePlayPause}>
+            <div className={resizeReferenceStyles.root} ref={resizeRef} />
+            <div
+                className={videoStyle.root}
+                onClick={togglePlayPause}
+                style={{
+                    left: `${videoSize?.xOffset || 0}px`,
+                    top: `${videoSize?.yOffset || 0}px`,
+                    width: `${videoSize?.width || 0}px`,
+                    height: `${videoSize?.height || 0}px`,
+                }}
+            >
                 {children}
             </div>
             <InkCanvas
                 canvasRef={canvasRef}
                 isEnabled={inkActive}
                 inkingManager={inkingManager}
+                videoSize={videoSize}
             />
             <div
                 className={flexColumnStyles.root}

--- a/samples/typescript/21.react-media-template/src/components/MediaPlayerContainer.tsx
+++ b/samples/typescript/21.react-media-template/src/components/MediaPlayerContainer.tsx
@@ -200,7 +200,7 @@ export const MediaPlayerContainer: FC<MediaPlayerContainerProps> = ({
         <div
             className={mergeClasses(
                 flexColumnStyles.root,
-                playerControlStyles.pointerTrackerContainer
+                playerControlStyles.root
             )}
             onMouseMove={() => {
                 setShowControls(true);

--- a/samples/typescript/21.react-media-template/src/styles/styles.ts
+++ b/samples/typescript/21.react-media-template/src/styles/styles.ts
@@ -22,7 +22,8 @@ export const getVideoStyle = makeStyles({
 });
 
 export const getPlayerControlStyles = makeStyles({
-    pointerTrackerContainer: {
+    root: {
+        backgroundColor: "black",
         position: "absolute",
         zIndex: 0,
         top: "0",
@@ -107,7 +108,8 @@ export const getResizeReferenceStyles = makeStyles({
 export const getLiveNotificationStyles = makeStyles({
     root: {
         pointerEvents: "none",
-        position: "absolute",
+        position: "fixed",
+        zIndex: 3,
         top: "5px",
         left: "4px",
         right: "4px",

--- a/samples/typescript/21.react-media-template/src/styles/styles.ts
+++ b/samples/typescript/21.react-media-template/src/styles/styles.ts
@@ -9,10 +9,6 @@ import { tokens } from "@fluentui/react-theme";
 export const getVideoStyle = makeStyles({
     root: {
         cursor: "pointer",
-        left: "0",
-        top: "0",
-        bottom: "0",
-        right: "0",
         zIndex: 0,
         position: "fixed",
         backgroundColor: "black",
@@ -95,7 +91,7 @@ export const getPillStyles = makeStyles({
     },
 });
 
-export const getInkCanvasStyles = makeStyles({
+export const getResizeReferenceStyles = makeStyles({
     root: {
         position: "absolute",
         zIndex: 0,


### PR DESCRIPTION
There was a previous bug where at certain aspect ratios would cause Azure Media Player to clip parts of the video, causing ink not to appear in the correct position for some clients. This is now resolved by this PR. Also fixed some assorted lint/console errors that popped up in the process.

![image](https://user-images.githubusercontent.com/11748606/200927217-3077b219-ea1c-4f76-8266-443c63f7b8f9.png)
