### PR TITLE
Update dependabot to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,61 +1,23 @@
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+  # Only specify the root so dependabot will update all manifests once per package
+  # See https://github.com/dependabot/dependabot-core/issues/5226#issuecomment-1179434437
+    directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/packages/live-share"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/packages/live-share-canvas"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/packages/live-share-media"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/samples/javascript/01.dice-roller"
-    schedule:
-      interval: "monthly"
-      day: "monday"
-      time: "09:00"
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/samples/javascript/02.react-video"
-    schedule:
-      interval: "monthly"
-      day: "monday"
-      time: "09:00"
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/samples/javascript/03.live-canvas-demo"
-    schedule:
-      interval: "monthly"
-      day: "monday"
-      time: "09:00"
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/samples/javascript/21.react-media-template"
-    schedule:
-      interval: "monthly"
-      day: "monday"
-      time: "09:00"
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/samples/typescript/21.react-media-template"
-    schedule:
-      interval: "monthly"
-      day: "monday"
-      time: "09:00"
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/samples/javascript/22.react-agile-poker"
-    schedule:
-      interval: "monthly"
-      day: "monday"
-      time: "09:00"
+      # temporarily changing to daily in order to test changes.
+      interval: "daily"
+      #interval: "weekly"
+      #day: "monday"
+    # Ignore the following packages because
+    # 1. Semver for these packages is not always followed
+    # 1. These packages MUST be updated all at the same time (same PR)
+    ignore:
+      - "fluid-framework",
+      - "@fluidframework/test-client-utils"
+      - "@fluidframework/test-utils"
+      - "@fluidframework/test-runtime-utils"
+      - "@fluidframework/azure-client",
+      - "@microsoft/teams-js"
+    # Updates both the package-lock and package.json, not just package-lock
+    versioning-strategy: increase

--- a/package-lock.json
+++ b/package-lock.json
@@ -10268,8 +10268,7 @@
         "@octokit/plugin-request-log": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-            "requires": {}
+            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA=="
         },
         "@octokit/plugin-rest-endpoint-methods": {
             "version": "6.6.2",
@@ -10515,8 +10514,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "add-stream": {
             "version": "1.0.0",
@@ -11635,8 +11633,7 @@
             "version": "8.5.0",
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
             "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-plugin-prettier": {
             "version": "3.4.1",
@@ -11690,8 +11687,7 @@
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
             "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-scope": {
             "version": "5.1.1",


### PR DESCRIPTION
Updating `dependabot.yml` to reduce noise 

- frequency "daily" is temporary while I test out the change
- packages that historically do not follow semver are ignored and will have to be updated manually
- versioning-strategy "increase" will update all `package.json` and `package-lock.json`s 🤞🏼 
    - instead of one PR per package per dependency, in one PR per dependency  🤞🏼 