### PR TITLE
Add note for Teams testing that ngrok requires an account

### DIFF
--- a/samples/javascript/01.dice-roller/README.md
+++ b/samples/javascript/01.dice-roller/README.md
@@ -25,7 +25,7 @@ npm start
 
 1. [Download ngrok](https://ngrok.com/download).
 2. Launch ngrok with port 3000.
-   `ngrok http 3000 --host-header=localhost`
+   `ngrok http 3000 --host-header=localhost` (You will need an ngrok account to use host-header)
 3. In a second terminal, run `npm run start-https` (rather than the traditional `npm run start`)
 
 ### Create the app package to sideload into Teams

--- a/samples/javascript/02.react-video/README.md
+++ b/samples/javascript/02.react-video/README.md
@@ -40,7 +40,7 @@ Tab configuration page doesn't do anything in browser.
 
 1. [Download ngrok](https://ngrok.com/download).
 2. Launch ngrok with port 3000.
-   `ngrok http 3000 --host-header=localhost`
+   `ngrok http 3000 --host-header=localhost` (You will need an ngrok account to use host-header)
 3. In a second terminal, run `npm run start-https` (rather than the traditional `npm run start`)
 
 ### Create the app package to sideload into Teams

--- a/samples/javascript/03.live-canvas-demo/README.md
+++ b/samples/javascript/03.live-canvas-demo/README.md
@@ -32,7 +32,7 @@ You can copy this URL and paste it into new browser tabs to test Live Share usin
 
 1. [Download ngrok](https://ngrok.com/download).
 2. Launch ngrok with port 3000.
-   `ngrok http 3000 --host-header=localhost`
+   `ngrok http 3000 --host-header=localhost` (You will need an ngrok account to use host-header)
 3. In a second terminal, run `npm run start-https` (rather than the traditional `npm run start`)
 
 ### Create the app package to sideload into Teams

--- a/samples/javascript/21.react-media-template/README.md
+++ b/samples/javascript/21.react-media-template/README.md
@@ -51,7 +51,7 @@ Alternatively, you can use our ready-to-use [demo app package](../demo-manifests
 
 1. [Download ngrok](https://ngrok.com/download).
 2. Launch ngrok with port 3000.
-   `ngrok http 3000 --host-header=localhost`
+   `ngrok http 3000 --host-header=localhost` (You will need an ngrok account to use host-header)
 3. In a second terminal, run `npm run start-https` (rather than the traditional `npm run start`)
 
 ### Create the app package to sideload into Teams

--- a/samples/javascript/22.react-agile-poker/README.md
+++ b/samples/javascript/22.react-agile-poker/README.md
@@ -49,7 +49,7 @@ Alternatively, you can use our ready-to-use [demo app package](../demo-manifests
 
 1. [Download ngrok](https://ngrok.com/download).
 2. Launch ngrok with port 3000.
-   `ngrok http 3000 --host-header=localhost`
+   `ngrok http 3000 --host-header=localhost` (You will need an ngrok account to use host-header)
 3. In a second terminal, run `npm run start-https` (rather than the traditional `npm run start`)
 
 ### Create the app package to sideload into Teams

--- a/samples/javascript/23.react-live-canvas/README.md
+++ b/samples/javascript/23.react-live-canvas/README.md
@@ -51,7 +51,7 @@ Tab configuration page doesn't do anything in browser.
 
 1. [Download ngrok](https://ngrok.com/download).
 2. Launch ngrok with port 3000.
-   `ngrok http 3000 --host-header=localhost`
+   `ngrok http 3000 --host-header=localhost` (You will need an ngrok account to use host-header)
 3. In a second terminal, run `npm run start-https` (rather than the traditional `npm run start`)
 
 ### Create the app package to sideload into Teams

--- a/samples/typescript/21.react-media-template/README.md
+++ b/samples/typescript/21.react-media-template/README.md
@@ -50,7 +50,7 @@ Alternatively, you can use our ready-to-use [demo app package](../demo-manifests
 
 1. [Download ngrok](https://ngrok.com/download).
 2. Launch ngrok with port 3000.
-   `ngrok http 3000 --host-header=localhost`
+   `ngrok http 3000 --host-header=localhost` (You will need an ngrok account to use host-header)
 3. In a second terminal, run `npm run start-https` (rather than the traditional `npm run start`)
 
 ### Create the app package to sideload into Teams


### PR DESCRIPTION
Resolves #234 

README fix only -- clarifies to user that for `ngrok ... --host-header...`, an ngrok account is required. 