### PR TITLE
Add export/import support to InkingManager

### DIFF
--- a/lerna-package-lock.json
+++ b/lerna-package-lock.json
@@ -16,6 +16,7 @@
                 "@fluid-experimental/task-manager": "~1.2.3",
                 "@fluidframework/azure-client": "~1.0.2",
                 "@fluidframework/azure-local-service": "^1.1.0",
+                "@fluidframework/register-collection": "~1.2.3",
                 "@fluidframework/test-client-utils": "~1.2.3",
                 "@fluidframework/test-runtime-utils": "~1.2.3",
                 "@fluidframework/test-utils": "~1.2.3",
@@ -2170,17 +2171,17 @@
             }
         },
         "node_modules/@fluidframework/register-collection": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.3.5.tgz",
-            "integrity": "sha512-RTSLIkf43HjDllBIRzB2e1969AYR0aaHFoYErO++UunfVatR7y8kFpKB8mfyNkChQbAKKGqiUHCnobnJeUppkQ==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.8.tgz",
+            "integrity": "sha512-RJKt2ZA9Etd10gbq5hrqch6dUf3BYplDwqOgCB9s/5m2yqQaWHdjSLONc6wl10+L2fB9h6tnDBlLa9dWPmTNqw==",
             "dependencies": {
-                "@fluidframework/common-utils": "^0.32.2",
-                "@fluidframework/core-interfaces": "^1.3.5",
-                "@fluidframework/datastore-definitions": "^1.3.5",
-                "@fluidframework/protocol-base": "^0.1036.5001",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/core-interfaces": "^1.2.8",
+                "@fluidframework/datastore-definitions": "^1.2.8",
+                "@fluidframework/protocol-base": "^0.1036.5000",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/runtime-definitions": "^1.3.5",
-                "@fluidframework/shared-object-base": "^1.3.5"
+                "@fluidframework/runtime-definitions": "^1.2.8",
+                "@fluidframework/shared-object-base": "^1.2.8"
             }
         },
         "node_modules/@fluidframework/request-handler": {
@@ -23679,17 +23680,17 @@
             }
         },
         "@fluidframework/register-collection": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.3.5.tgz",
-            "integrity": "sha512-RTSLIkf43HjDllBIRzB2e1969AYR0aaHFoYErO++UunfVatR7y8kFpKB8mfyNkChQbAKKGqiUHCnobnJeUppkQ==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-1.2.8.tgz",
+            "integrity": "sha512-RJKt2ZA9Etd10gbq5hrqch6dUf3BYplDwqOgCB9s/5m2yqQaWHdjSLONc6wl10+L2fB9h6tnDBlLa9dWPmTNqw==",
             "requires": {
-                "@fluidframework/common-utils": "^0.32.2",
-                "@fluidframework/core-interfaces": "^1.3.5",
-                "@fluidframework/datastore-definitions": "^1.3.5",
-                "@fluidframework/protocol-base": "^0.1036.5001",
+                "@fluidframework/common-utils": "^0.32.1",
+                "@fluidframework/core-interfaces": "^1.2.8",
+                "@fluidframework/datastore-definitions": "^1.2.8",
+                "@fluidframework/protocol-base": "^0.1036.5000",
                 "@fluidframework/protocol-definitions": "^0.1028.2000",
-                "@fluidframework/runtime-definitions": "^1.3.5",
-                "@fluidframework/shared-object-base": "^1.3.5"
+                "@fluidframework/runtime-definitions": "^1.2.8",
+                "@fluidframework/shared-object-base": "^1.2.8"
             }
         },
         "@fluidframework/request-handler": {

--- a/packages/live-share-canvas/README.md
+++ b/packages/live-share-canvas/README.md
@@ -4,7 +4,7 @@ Easily add collaborative inking to your Teams meeting app, powered by [Fluid Fra
 
 This package is an extension of Microsoft Live Share, and requires the `@microsoft/live-share` package. You can find it on [NPM](https://www.npmjs.com/package/@microsoft/live-share).
 
-You can find our API reference documentation at [aka.ms/livesharedocs](https://aka.ms/livesharedocs).
+You can find our documentation at [aka.ms/livesharecanvas](https://aka.ms/livesharecanvas).
 
 ## Installing
 
@@ -84,7 +84,7 @@ document.getElementById("btnPenBrushBlue").onclick = () => {
     inkingManager.penBrush.color = { r: 0, g: 0, b: 255, a: 1};
 }
 
-// Other tools and brush settings are available, please refer to the documentation
+// Other tools and brush settings are available, please refer to the documentation at https://aka.ms/livesharecanvas
 ```
 
 ## Code sample

--- a/packages/live-share-canvas/src/core/Geometry.ts
+++ b/packages/live-share-canvas/src/core/Geometry.ts
@@ -64,6 +64,15 @@ export function expandRect(rect: IRect, point: IPoint): IRect {
     };
 }
 
+export function combineRects(rect1: IRect, rect2: IRect): IRect {
+    return {
+        left: Math.min(rect1.left, rect2.left),
+        top: Math.min(rect1.top, rect2.top),
+        right: Math.max(rect1.right, rect2.right),
+        bottom: Math.max(rect1.bottom, rect2.bottom),
+    };
+}
+
 /**
  * Computes the distance between two points.
  * @param p1 The first point.

--- a/packages/live-share-canvas/src/core/InkingManager.ts
+++ b/packages/live-share-canvas/src/core/InkingManager.ts
@@ -1080,7 +1080,6 @@ export class InkingManager extends EventEmitter {
         this._strokes.forEach((stroke: IStroke) => {
             result.push({
                 points: stroke.getAllPoints(),
-                timeStamp: stroke.timeStamp,
                 brush: { ...stroke.brush },
             });
         });
@@ -1155,7 +1154,6 @@ export class InkingManager extends EventEmitter {
         for (const rawStroke of rawStrokes) {
             const stroke = new Stroke({
                 brush: rawStroke.brush,
-                timeStamp: rawStroke.timeStamp,
                 points: rawStroke.points,
                 clientId: InkingManager.localClientId,
             });
@@ -1186,6 +1184,7 @@ export class InkingManager extends EventEmitter {
         canvas.resize(this.clientWidth, this.clientHeight);
         canvas.offset = this.offset;
         canvas.scale = this.scale;
+        canvas.referencePoint = this.referencePoint;
 
         let stroke: WetStroke;
 
@@ -1498,6 +1497,8 @@ export class InkingManager extends EventEmitter {
     set referencePoint(value: CanvasReferencePoint) {
         if (this._referencePoint !== value) {
             this._referencePoint = value;
+
+            this._dryCanvas.referencePoint = value;
 
             this.reRender();
         }

--- a/packages/live-share-canvas/src/core/Stroke.ts
+++ b/packages/live-share-canvas/src/core/Stroke.ts
@@ -88,6 +88,24 @@ export enum StrokeType {
 }
 
 /**
+ * Represents the raw data of a stroke.
+ */
+export interface IRawStroke {
+    /**
+     * The stroke's points.
+     */
+    readonly points: IPointerPoint[];
+    /**
+     * The timestamp when the stroke was created.
+     */
+    readonly timeStamp: number;
+    /**
+     * The brush used to draw the stroke.
+     */
+    readonly brush: IBrush;
+}
+
+/**
  * Defines a stroke, i.e. a collection of points that can
  * be rendered on a canvas.
  */
@@ -118,6 +136,10 @@ export interface IStroke {
      * Computes the stroke's bounding rectangle.
      */
     getBoundingRect(): IRect;
+    /**
+     * Gets a copy of all the points in the stroke.
+     */
+    getAllPoints(): IPointerPoint[];
     /**
      * Splits this stroke into several other ones by "erasing"
      * the portions that are within the eraser rectangle.
@@ -427,6 +449,20 @@ export class Stroke implements IStroke, Iterable<IPointerPoint> {
      */
     getPointAt(index: number): IPointerPoint {
         return this._points[index];
+    }
+
+    /**
+     * Gets a copy of all the points in the stroke.
+     * @returns A collection of points.
+     */
+    getAllPoints(): IPointerPoint[] {
+        const result: IPointerPoint[] = [];
+
+        for (const p of this._points) {
+            result.push({ ...p });
+        }
+
+        return result;
     }
 
     /**

--- a/packages/live-share-canvas/src/core/Stroke.ts
+++ b/packages/live-share-canvas/src/core/Stroke.ts
@@ -96,10 +96,6 @@ export interface IRawStroke {
      */
     readonly points: IPointerPoint[];
     /**
-     * The timestamp when the stroke was created.
-     */
-    readonly timeStamp: number;
-    /**
      * The brush used to draw the stroke.
      */
     readonly brush: IBrush;

--- a/samples/javascript/03.live-canvas-demo/package.json
+++ b/samples/javascript/03.live-canvas-demo/package.json
@@ -10,7 +10,7 @@
         "start:client": "vite",
         "start:https": "vite --config vite.https-config.js",
         "start:server": "npx @fluidframework/azure-local-service@latest",
-        "start": "start-server-and-test start:server 7070 start:client",
+        "start": "npx tinylicious@0.7.2 7070",
         "doctor": "eslint src/**/*.{j,t}s{,x} --fix --no-error-on-unmatched-pattern"
     },
     "dependencies": {

--- a/samples/javascript/03.live-canvas-demo/src/stage-view.ts
+++ b/samples/javascript/03.live-canvas-demo/src/stage-view.ts
@@ -107,7 +107,6 @@ export class StageView extends View {
             };
 
             this._inkingManager = new InkingManager(inkingHost);
-            this._inkingManager.referencePoint = "topLeft";
 
             await liveCanvas.initialize(this._inkingManager);
 

--- a/samples/javascript/03.live-canvas-demo/src/stage-view.ts
+++ b/samples/javascript/03.live-canvas-demo/src/stage-view.ts
@@ -55,8 +55,8 @@ const appTemplate = `
                 <button id="btnOffsetRight">Offset right</button>
                 <button id="btnOffsetDown">Offset down</button>
                 <button id="btnResetView" style="margin-left: 20px;">Reset view</button>
-                <button id="btnImportRaw" style="margin-left: 20px;">Import raw strokes</button>
-                <button id="btnExportRaw">Export raw strokes</button>
+                <button id="btnExportRaw" style="margin-left: 20px;">Export raw strokes</button>
+                <button id="btnImportRaw">Import raw strokes</button>
                 <button id="btnExportSVG" style="margin-left: 20px;">Export SVG</button>
             </div>
         </div>
@@ -288,19 +288,6 @@ export class StageView extends View {
             }
         });
 
-        setupButton("btnImportRaw", async () => {
-            try {
-                const strokes = await Utils.parseStrokesFromClipboard();
-                this._inkingManager.importRaw(strokes);
-            } catch (error: any) {
-                console.error(error);
-                alert(
-                    "Unable to strokes from clipboard.\nError: " +
-                        error?.message
-                );
-            }
-        });
-
         setupButton("btnExportRaw", () => {
             const exportedStrokes = this._inkingManager.exportRaw();
 
@@ -308,6 +295,19 @@ export class StageView extends View {
                 JSON.stringify(exportedStrokes),
                 "Exported strokes have been copied to the clipboard."
             );
+        });
+
+        setupButton("btnImportRaw", async () => {
+            try {
+                const strokes = await Utils.parseStrokesFromClipboard();
+                this._inkingManager.importRaw(strokes);
+            } catch (error: any) {
+                console.error(error);
+                alert(
+                    "Unable to parse strokes from clipboard.\nError: " +
+                        error?.message
+                );
+            }
         });
 
         setupButton("btnExportSVG", () => {

--- a/samples/javascript/03.live-canvas-demo/src/stage-view.ts
+++ b/samples/javascript/03.live-canvas-demo/src/stage-view.ts
@@ -55,6 +55,8 @@ const appTemplate = `
                 <button id="btnOffsetRight">Offset right</button>
                 <button id="btnOffsetDown">Offset down</button>
                 <button id="btnResetView" style="margin-left: 20px;">Reset view</button>
+                <button id="btnExportRaw" style="margin-left: 20px;">Export raw strokes</button>
+                <button id="btnExportSVG">Export SVG</button>
             </div>
         </div>
     </div>`;
@@ -283,6 +285,24 @@ export class StageView extends View {
                     ? "Stop sharing cursor"
                     : "Share cursor";
             }
+        });
+
+        setupButton("btnExportRaw", () => {
+            const exportedStrokes = this._inkingManager.exportRaw();
+
+            Utils.writeTextToClipboard(
+                JSON.stringify(exportedStrokes),
+                "Exported strokes have been copied to the clipboard."
+            );
+        });
+
+        setupButton("btnExportSVG", () => {
+            const svg = this._inkingManager.exportSVG();
+
+            Utils.writeTextToClipboard(
+                svg,
+                "The SVG has been copied to the clipboard."
+            );
         });
     }
 

--- a/samples/javascript/03.live-canvas-demo/src/stage-view.ts
+++ b/samples/javascript/03.live-canvas-demo/src/stage-view.ts
@@ -107,6 +107,7 @@ export class StageView extends View {
             };
 
             this._inkingManager = new InkingManager(inkingHost);
+            this._inkingManager.referencePoint = "topLeft";
 
             await liveCanvas.initialize(this._inkingManager);
 
@@ -294,7 +295,10 @@ export class StageView extends View {
                 this._inkingManager.importRaw(strokes);
             } catch (error: any) {
                 console.error(error);
-                alert("Unable to strokes from clipboard.\nError: " + error?.message);
+                alert(
+                    "Unable to strokes from clipboard.\nError: " +
+                        error?.message
+                );
             }
         });
 

--- a/samples/javascript/03.live-canvas-demo/src/stage-view.ts
+++ b/samples/javascript/03.live-canvas-demo/src/stage-view.ts
@@ -55,8 +55,9 @@ const appTemplate = `
                 <button id="btnOffsetRight">Offset right</button>
                 <button id="btnOffsetDown">Offset down</button>
                 <button id="btnResetView" style="margin-left: 20px;">Reset view</button>
-                <button id="btnExportRaw" style="margin-left: 20px;">Export raw strokes</button>
-                <button id="btnExportSVG">Export SVG</button>
+                <button id="btnImportRaw" style="margin-left: 20px;">Import raw strokes</button>
+                <button id="btnExportRaw">Export raw strokes</button>
+                <button id="btnExportSVG" style="margin-left: 20px;">Export SVG</button>
             </div>
         </div>
     </div>`;
@@ -284,6 +285,16 @@ export class StageView extends View {
                 button.innerText = liveCanvas.isCursorShared
                     ? "Stop sharing cursor"
                     : "Share cursor";
+            }
+        });
+
+        setupButton("btnImportRaw", async () => {
+            try {
+                const strokes = await Utils.parseStrokesFromClipboard();
+                this._inkingManager.importRaw(strokes);
+            } catch (error: any) {
+                console.error(error);
+                alert("Unable to strokes from clipboard.\nError: " + error?.message);
             }
         });
 

--- a/samples/javascript/03.live-canvas-demo/src/utils.ts
+++ b/samples/javascript/03.live-canvas-demo/src/utils.ts
@@ -60,7 +60,6 @@ function isStroke(value: unknown): value is IRawStroke {
         typeof value === "object" &&
         !!value &&
         Array.isArray((value as any).points) &&
-        typeof (value as any).timeStamp === "number" &&
         typeof (value as any).brush === "object"
     );
 }

--- a/samples/javascript/03.live-canvas-demo/src/utils.ts
+++ b/samples/javascript/03.live-canvas-demo/src/utils.ts
@@ -42,8 +42,12 @@ export function writeTextToClipboard(text: string, message: string) {
 }
 
 export async function parseStrokesFromClipboard(): Promise<IRawStroke[]> {
-    // this will prompt user to consent to read from clipboard
+    // this will prompt user to consent to read from clipboard. if user denies, this will throw.
     const text = await navigator.clipboard.readText();
+    return parseStrokesFromText(text);
+}
+
+function parseStrokesFromText(text: string): IRawStroke[] {
     const rawJson: unknown = JSON.parse(text);
     if (isStrokeList(rawJson)) {
         return rawJson;

--- a/samples/javascript/03.live-canvas-demo/src/utils.ts
+++ b/samples/javascript/03.live-canvas-demo/src/utils.ts
@@ -3,6 +3,8 @@
  * Licensed under the Microsoft Live Share SDK License.
  */
 
+import { IRawStroke } from "@microsoft/live-share-canvas";
+
 export function runningInTeams(): boolean {
     const params = new URLSearchParams(window.location.search);
     const config = params.get("inTeams");
@@ -36,5 +38,29 @@ export function writeTextToClipboard(text: string, message: string) {
                 "The exported data couldn't be copied to the clipboard because permission to do so wasn't granted by the user."
             );
         }
+    );
+}
+
+export async function parseStrokesFromClipboard(): Promise<IRawStroke[]> {
+    // this will prompt user to consent to read from clipboard
+    const text = await navigator.clipboard.readText();
+    const rawJson: unknown = JSON.parse(text);
+    if (isStrokeList(rawJson)) {
+        return rawJson;
+    }
+    throw Error("Invalid JSON value in clipboard.");
+}
+
+function isStrokeList(value: unknown): value is IRawStroke[] {
+    return Array.isArray(value) && value.every(isStroke);
+}
+
+function isStroke(value: unknown): value is IRawStroke {
+    return (
+        typeof value === "object" &&
+        !!value &&
+        Array.isArray((value as any).points) &&
+        typeof (value as any).timeStamp === "number" &&
+        typeof (value as any).brush === "object"
     );
 }

--- a/samples/javascript/03.live-canvas-demo/src/utils.ts
+++ b/samples/javascript/03.live-canvas-demo/src/utils.ts
@@ -25,3 +25,16 @@ export function toggleElementVisibility(elementId: string, isVisible: boolean) {
         element.style.visibility = isVisible ? "visible" : "hidden";
     }
 }
+
+export function writeTextToClipboard(text: string, message: string) {
+    navigator.clipboard.writeText(text).then(
+        () => {
+            alert(message);
+        },
+        () => {
+            alert(
+                "The exported data couldn't be copied to the clipboard because permission to do so wasn't granted by the user."
+            );
+        }
+    );
+}


### PR DESCRIPTION
This PR adds the following features:
- `InkingManager.exportRaw()` exports a collection of "raw strokes"
- `InkingManager.importRaw(strokes)` Imports a collection of raw strokes. Note that importing **adds** the strokes to the drawing; to replace the existing strokes, an app should first call `InkingManager.clear()`
- `InkingManager.exportSVG()` exports the drawing as a serialized SVG

This PR also fixes a bug that caused shared cursors to move in a "stuttery" way.