### PR TITLE
Make legacy endpoints optional

### DIFF
--- a/packages/live-share/src/TestLiveShareHost.ts
+++ b/packages/live-share/src/TestLiveShareHost.ts
@@ -51,8 +51,6 @@ export class TestLiveShareHost implements ILiveShareHost {
     public getFluidTenantInfo(): Promise<IFluidTenantInfo> {
         return Promise.resolve({
             tenantId: "local",
-            ordererEndpoint: "http://localhost:7070",
-            storageEndpoint: "http://localhost:7070",
             serviceEndpoint: "http://localhost:7070",
         });
     }

--- a/packages/live-share/src/interfaces.ts
+++ b/packages/live-share/src/interfaces.ts
@@ -213,14 +213,14 @@ export interface IFluidTenantInfo {
      * As of Fluid 1.0 this configuration information has been deprecated in favor of
      * `serviceEndpoint`.
      */
-    ordererEndpoint: string;
+    ordererEndpoint?: string;
 
     /**
      * @deprecated
      * As of Fluid 1.0 this configuration information has been deprecated in favor of
      * `serviceEndpoint`.
      */
-    storageEndpoint: string;
+    storageEndpoint?: string;
 }
 
 /**


### PR DESCRIPTION
Make legacy endpoints optional

Simple change to make AFR legacy endpoints optional in `IFluidTenantInfo`