### PR TITLE
Fixed bug with cursor user info not being set in useLivePresence

### DIFF
--- a/packages/live-share-react/src/live-hooks/useLiveCanvas.ts
+++ b/packages/live-share-react/src/live-hooks/useLiveCanvas.ts
@@ -163,18 +163,18 @@ export function useLiveCanvas(
      */
     React.useEffect(() => {
         if (
-            liveCanvas?.isCursorShared !== undefined &&
+            liveCanvas &&
             isCursorShared !== undefined
         ) {
             liveCanvas.isCursorShared = isCursorShared;
         }
-    }, [isCursorShared, liveCanvas?.isCursorShared]);
+    }, [isCursorShared, liveCanvas]);
 
     /**
      * Sets the onGetLocalUserInfo method of the liveCanvas based on the 'localUserCursor' prop
      */
     React.useEffect(() => {
-        if (liveCanvas?.onGetLocalUserInfo !== undefined && localUserCursor) {
+        if (liveCanvas && localUserCursor) {
             liveCanvas.onGetLocalUserInfo = (): IUserInfo | undefined => {
                 return {
                     displayName: localUserCursor.displayName,
@@ -185,7 +185,7 @@ export function useLiveCanvas(
     }, [
         localUserCursor?.displayName,
         localUserCursor?.pictureUri,
-        liveCanvas?.onGetLocalUserInfo,
+        liveCanvas,
     ]);
 
     /**


### PR DESCRIPTION
There was a bug where the `useLivePresence` prop for user cursor was not actually updating the setter in `LiveCanvas`, causing `displayName` to not be settable. This fixes this.

![image](https://user-images.githubusercontent.com/11748606/233747138-2e9337d8-4ee0-471b-ac6f-f64841bbd389.png)
