### PR TITLE
Updated LiveState per developer feedback

### DIFF
--- a/packages/live-share-react/README.md
+++ b/packages/live-share-react/README.md
@@ -223,7 +223,7 @@ import { UserMeetingRole } from "@microsoft/live-share";
 const ALLOWED_ROLES = [UserMeetingRole.organizer, UserMeetingRole.presenter ];
 
 export function AppState() {
-  const [state, data, setState] = useLiveState("CUSTOM-STATE-ID", ALLOWED_ROLES, ExampleAppState.WAITING);
+  const [state, setState] = useLiveState("CUSTOM-STATE-ID", ExampleAppState.WAITING, ALLOWED_ROLES);
 
   if (state === ExampleAppState.WAITING) {
     return (

--- a/packages/live-share-react/src/live-hooks/useLiveState.ts
+++ b/packages/live-share-react/src/live-hooks/useLiveState.ts
@@ -20,7 +20,7 @@ import { useDynamicDDS } from "../shared-hooks";
  * @returns ordered values: first value is the synchronized state value and the second is a setter to change the state value.
  */
 export function useLiveState<
-    TState = undefined,
+    TState = any,
 >(
     uniqueKey: string,
     initialState: TState,
@@ -72,11 +72,9 @@ export function useLiveState<
         };
         liveState.on("stateChanged", onStateChanged);
         if (!liveState.isInitialized) {
-            liveState.initialize(allowedRoles, initialState);
-            if (liveState.state) {
-                onStateChanged(liveState.state);
-            }
-        } else if (liveState.state) {
+            liveState.initialize(initialState, allowedRoles);
+        }
+        if (JSON.stringify(liveState.state) !== JSON.stringify(initialState)) {
             onStateChanged(liveState.state);
         }
 

--- a/packages/live-share-react/src/types/ActionTypes.ts
+++ b/packages/live-share-react/src/types/ActionTypes.ts
@@ -44,9 +44,8 @@ export type DisposeSharedStateAction = () => void;
 
 // Live Share actions
 
-export type SetLiveStateAction<TState, TData> = (
+export type SetLiveStateAction<TState = undefined> = (
     state: TState,
-    value?: TData | undefined
 ) => void;
 
 export type SendLiveEventAction<TEvent> = (event: TEvent) => void;

--- a/packages/live-share/src/test/LiveState.spec.ts
+++ b/packages/live-share/src/test/LiveState.spec.ts
@@ -21,6 +21,11 @@ describeNoCompat("LiveState", (getTestObjectProvider) => {
     let object1: LiveState<TestStateData>;
     let object2: LiveState<TestStateData>;
 
+    const mockDefaultValue: TestStateData = {
+        status: "defaultState",
+        value: "defaultValue",
+    };
+
     // Temporarily change update interval
     before(() => (LiveObjectSynchronizer.updateInterval = 20));
     after(() => (LiveObjectSynchronizer.updateInterval = 15000));
@@ -69,7 +74,11 @@ describeNoCompat("LiveState", (getTestObjectProvider) => {
                 object1done.reject(err);
             }
         });
-        await object1.initialize();
+        await object1.initialize(mockDefaultValue);
+        assert(
+            object1.state.status == mockDefaultValue.status,
+            `object2: status == '${object1.state.status}'`
+        );
 
         const object2done = new Deferred();
         object2.on("stateChanged", (state, local) => {
@@ -87,7 +96,7 @@ describeNoCompat("LiveState", (getTestObjectProvider) => {
                 object2done.reject(err);
             }
         });
-        await object2.initialize();
+        await object2.initialize(mockDefaultValue);
 
         object1.set({ status: "newState", value: "newValue" });
 
@@ -115,7 +124,7 @@ describeNoCompat("LiveState", (getTestObjectProvider) => {
                 done.reject(err);
             }
         });
-        await object1.initialize();
+        await object1.initialize(mockDefaultValue);
 
         object2.on("stateChanged", (state, local) => {
             try {
@@ -135,7 +144,7 @@ describeNoCompat("LiveState", (getTestObjectProvider) => {
                 done.reject(err);
             }
         });
-        await object2.initialize();
+        await object2.initialize(mockDefaultValue);
 
         object1.set({ status: "testState", value: "firstValue" });
 

--- a/samples/javascript/01.dice-roller/src/app.js
+++ b/samples/javascript/01.dice-roller/src/app.js
@@ -55,7 +55,8 @@ async function start() {
                 const diceState = container.initialObjects.diceState;
                 // You can optionally declare what roles you want to be able to change state
                 const allowedRoles = [UserMeetingRole.organizer, UserMeetingRole.presenter];
-                await diceState.initialize(allowedRoles);
+                // Initialize diceState with allowed roles and initial state of 1
+                await diceState.initialize(allowedRoles, 1);
                 renderStage(diceState, root);
             } catch (error) {
                 renderError(root, error);
@@ -101,12 +102,11 @@ function renderStage(diceState, elem) {
 
     // Set the value at our dataKey with a random number between 1 and 6.
     rollButton.onclick = () =>
-        diceState.changeState(`${Math.floor(Math.random() * 6) + 1}`);
+        diceState.set(Math.floor(Math.random() * 6) + 1);
 
     // Get the current value of the shared data to update the view whenever it changes.
     const updateDice = () => {
-        // If diceState.state is not already set, we use a default value of 1
-        const diceValue = diceState.state ? parseInt(diceState.state) : 1;
+        const diceValue = diceState.state;
         // Unicode 0x2680-0x2685 are the sides of a dice (⚀⚁⚂⚃⚄⚅)
         dice.textContent = String.fromCodePoint(0x267f + diceValue);
         dice.style.color = `hsl(${diceValue * 60}, 70%, 30%)`;

--- a/samples/javascript/01.dice-roller/src/app.js
+++ b/samples/javascript/01.dice-roller/src/app.js
@@ -55,8 +55,8 @@ async function start() {
                 const diceState = container.initialObjects.diceState;
                 // You can optionally declare what roles you want to be able to change state
                 const allowedRoles = [UserMeetingRole.organizer, UserMeetingRole.presenter];
-                // Initialize diceState with allowed roles and initial state of 1
-                await diceState.initialize(allowedRoles, 1);
+                // Initialize diceState with initial state of 1 and allowed roles 
+                await diceState.initialize(1, allowedRoles);
                 renderStage(diceState, root);
             } catch (error) {
                 renderError(root, error);

--- a/samples/javascript/01.dice-roller/vite.config.js
+++ b/samples/javascript/01.dice-roller/vite.config.js
@@ -11,5 +11,9 @@ export default defineConfig({
     root: "./src",
     server: {
         port: 3000,
+        open: true,
+    },
+    optimizeDeps: {
+        force: true,
     },
 });

--- a/samples/javascript/04.live-share-react/src/components/ExampleLiveState.jsx
+++ b/samples/javascript/04.live-share-react/src/components/ExampleLiveState.jsx
@@ -9,25 +9,27 @@ const ExampleAppState = {
 const ALLOWED_ROLES = [
     UserMeetingRole.organizer,
     UserMeetingRole.presenter,
-    UserMeetingRole.attendee,
 ];
+const INITIAL_STATE = {
+    status: ExampleAppState.WAITING,
+};
 
 export const ExampleLiveState = (props) => {
-    const [state, data, setState] = useLiveState(
+    const [state, setState] = useLiveState(
         "CUSTOM-STATE-ID",
-        ExampleAppState.WAITING,
-        undefined,
+        INITIAL_STATE,
         ALLOWED_ROLES,
     );
 
-    if (state === ExampleAppState.WAITING) {
+    if (state.status === ExampleAppState.WAITING) {
         return (
             <div style={{ padding: "12px 12px" }}>
                 <div className="flex row">
                     <h2>{`Start round:`}</h2>
                     <button
                         onClick={() => {
-                            setState(ExampleAppState.START, {
+                            setState({
+                                status: ExampleAppState.START,
                                 timeStarted: LiveEvent.getTimestamp(),
                             });
                         }}
@@ -43,10 +45,12 @@ export const ExampleLiveState = (props) => {
     return (
         <div style={{ padding: "12px 12px" }}>
             <div className="flex row">
-                <h2>{`Time started: ${data.timeStarted}`}</h2>
+                <h2>{`Time started: ${state.timeStarted}`}</h2>
                 <button
                     onClick={() => {
-                        setState(ExampleAppState.WAITING, undefined);
+                        setState({
+                            status: ExampleAppState.WAITING,
+                        });
                     }}
                 >
                     {"End"}

--- a/samples/javascript/22.react-agile-poker/src/live-share-hooks/usePokerState.js
+++ b/samples/javascript/22.react-agile-poker/src/live-share-hooks/usePokerState.js
@@ -5,19 +5,33 @@
 
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useStateRef } from "../utils/useStateRef";
+import { LiveState } from "@microsoft/live-share";
 
-const availableStates = ["waiting", "costing", "discussion"];
+const AVAILABLE_STATES = ["waiting", "costing", "discussion"];
+const INITIAL_STATE = {
+    state: "waiting",
+    value: null,
+};
 
+/**
+ * 
+ * @param {LiveState<object>} pokerState LiveState object
+ * @returns pokerStateStarted, state, userStoryId, onStartWaiting, onStartCosting, onStartDiscussion
+ */
 export const usePokerState = (pokerState) => {
     const initializeStartedRef = useRef(false);
     const [pokerStateStarted, setStarted] = useState(false);
-    const [state, stateRef, setState] = useStateRef();
+    const [state, stateRef, setState] = useStateRef(INITIAL_STATE);
 
     const changePokerState = useCallback(
-        (state, value) => {
-            if (availableStates.includes(state)) {
-                pokerState?.changeState(state, value);
-            }
+        (newState, newValue) => {
+            if (!pokerState) return;
+            if (!AVAILABLE_STATES.includes(newState)) return;
+            console.log("changing to", newState, newValue)
+            pokerState.set({
+                state: newState,
+                value: newValue,
+            });
         },
         [pokerState]
     );
@@ -42,22 +56,23 @@ export const usePokerState = (pokerState) => {
         if (!pokerState || pokerState.isInitialized || initializeStartedRef.current) return;
         console.log("usePokerState: initializing poker state");
         initializeStartedRef.current = true;
-        pokerState.on("stateChanged", (state, value, local) => {
-            if (availableStates.includes(state)) {
-                setState({
-                    state,
-                    value,
-                });
-            }
+        pokerState.on("stateChanged", (state) => {
+            if (state.state === stateRef.current.state) return;
+            if (!AVAILABLE_STATES.includes(state.state)) return;
+            console.log("stateChanged", state);
+            setState({
+                state: state.state,
+                value: state.value,
+            });
         });
         const allowedRoles = ["Organizer"];
         pokerState
-            .initialize(allowedRoles)
+            .initialize(allowedRoles, INITIAL_STATE)
             .then(() => {
                 setStarted(true);
             })
             .catch((error) => console.error(error));
-    }, [pokerState, setStarted, setState]);
+    }, [pokerState]);
 
     return {
         pokerStateStarted,

--- a/samples/javascript/22.react-agile-poker/src/live-share-hooks/usePokerState.js
+++ b/samples/javascript/22.react-agile-poker/src/live-share-hooks/usePokerState.js
@@ -27,7 +27,7 @@ export const usePokerState = (pokerState) => {
         (newState, newValue) => {
             if (!pokerState) return;
             if (!AVAILABLE_STATES.includes(newState)) return;
-            console.log("changing to", newState, newValue)
+            console.log("usePokerState: changing state to", newState, newValue);
             pokerState.set({
                 state: newState,
                 value: newValue,
@@ -42,7 +42,7 @@ export const usePokerState = (pokerState) => {
 
     const onStartCosting = useCallback(
         (userStory) => {
-            console.log("changing to userStory", userStory);
+            console.log("usePokerState: changing to userStory", userStory);
             changePokerState("costing", userStory);
         },
         [changePokerState]
@@ -59,7 +59,6 @@ export const usePokerState = (pokerState) => {
         pokerState.on("stateChanged", (state) => {
             if (state.state === stateRef.current.state) return;
             if (!AVAILABLE_STATES.includes(state.state)) return;
-            console.log("stateChanged", state);
             setState({
                 state: state.state,
                 value: state.value,
@@ -67,7 +66,7 @@ export const usePokerState = (pokerState) => {
         });
         const allowedRoles = ["Organizer"];
         pokerState
-            .initialize(allowedRoles, INITIAL_STATE)
+            .initialize(INITIAL_STATE, allowedRoles)
             .then(() => {
                 setStarted(true);
             })

--- a/samples/javascript/22.react-agile-poker/src/live-share-hooks/useTimer.js
+++ b/samples/javascript/22.react-agile-poker/src/live-share-hooks/useTimer.js
@@ -30,7 +30,6 @@ export const useTimer = (timer, onTimerEnd) => {
         });
 
         timer.on("onTick", (milliRemaining) => {
-            console.log("tick");
             setTimerMilliRemaining(milliRemaining);
         });
 

--- a/samples/javascript/22.react-agile-poker/src/pages/MeetingStage.jsx
+++ b/samples/javascript/22.react-agile-poker/src/pages/MeetingStage.jsx
@@ -133,14 +133,15 @@ const MeetingStage = () => {
                 {/* Display error if failed to join space */}
                 {error && <UI.ErrorPane error={error} />}
 
-                {(!state || state === "waiting") && (
+                {(state === "waiting") && (
                     <UI.WaitingRoom
                         localUserId={context?.user?.id}
                         users={users}
                         userStory={userStory}
                         onStartCosting={() => {
                             beginTimer();
-                            onStartCosting();
+                            const url = new URL(window.location);
+                            onStartCosting(url.searchParams.get("userStoryId") || "0");
                         }}
                     />
                 )}
@@ -164,7 +165,8 @@ const MeetingStage = () => {
                         userStory={userStory}
                         onStartCosting={() => {
                             beginTimer();
-                            onStartCosting();
+                            const url = new URL(window.location);
+                            onStartCosting(url.searchParams.get("userStoryId") || "0");
                         }}
                         onStartWaiting={onStartWaiting}
                     />

--- a/samples/javascript/22.react-agile-poker/src/utils/useStateRef.jsx
+++ b/samples/javascript/22.react-agile-poker/src/utils/useStateRef.jsx
@@ -14,7 +14,7 @@ export const useStateRef = (initialValue) => {
             reference.current = value;
             setState(reference.current);
         },
-        [reference, setState]
+        []
     );
 
     return [state, reference, setValue];


### PR DESCRIPTION
- Updated `LiveState` to just have a single state value, rather than separate state and data values
- Require initial state value in `liveState.initialize()` for better TS typing (another developer complaint)
- Changed `changeState` to `set`
- Updated `useLiveState` hook to correspond to new changes
- Updated `README` for Live Share React package with latest changes
- Updated samples that use `LiveState` and `useLiveState` to match changes