### PR TITLE
Fixed bug with 21 side panel in localhost

### DIFF
--- a/samples/javascript/21.react-media-template/src/pages/SidePanel.jsx
+++ b/samples/javascript/21.react-media-template/src/pages/SidePanel.jsx
@@ -36,7 +36,8 @@ const SidePanel = () => {
         liveShareHooks.usePresence(
             presence,
             ACCEPT_PLAYBACK_CHANGES_FROM,
-            context
+            context,
+            timestampProvider,
         );
 
     // Take control map
@@ -61,7 +62,7 @@ const SidePanel = () => {
     } = liveShareHooks.usePlaylist(playlistMap, sendNotification);
 
     useEffect(() => {
-        if (context && playlistStarted) {
+        if (context && playlistStarted && inTeams()) {
             if (context.page?.frameContext === "meetingStage") {
                 // User shared the app directly to stage, redirect automatically
                 selectMediaId(mediaList[0].id);

--- a/samples/typescript/21.react-media-template/src/pages/SidePanel.tsx
+++ b/samples/typescript/21.react-media-template/src/pages/SidePanel.tsx
@@ -37,7 +37,8 @@ const SidePanel: FC = () => {
         liveShareHooks.usePresence(
             ACCEPT_PLAYBACK_CHANGES_FROM,
             presence,
-            context
+            context,
+            timestampProvider,
         );
 
     const { takeControlStarted, takeControl } = liveShareHooks.useTakeControl(
@@ -58,7 +59,7 @@ const SidePanel: FC = () => {
     } = liveShareHooks.usePlaylist(sendNotification, playlistMap);
 
     useEffect(() => {
-        if (context && playlistStarted) {
+        if (context && playlistStarted && inTeams()) {
             if (context.page?.frameContext === "meetingStage") {
                 // User shared the app directly to stage, redirect automatically
                 selectMediaId(mediaList[0].id);


### PR DESCRIPTION
- Fixed bug where sidepanel would navigate to meeting stage on load on localhost
- Fixed bug where timestamp provider was not passed to `usePresence` in `SidePanel` component

In localhost:
![image](https://github.com/microsoft/live-share-sdk/assets/11748606/cd6fbbe5-b3ca-4c9c-86df-5ab3cc2a6c68)

In Teams:
![image](https://github.com/microsoft/live-share-sdk/assets/11748606/73202f16-63c7-4456-97cb-af8caa3b47b5)
