### PR TITLE
Fixed generic types for Live Share React hooks

### DIFF
--- a/packages/live-share-react/src/live-hooks/useLiveState.ts
+++ b/packages/live-share-react/src/live-hooks/useLiveState.ts
@@ -27,7 +27,7 @@ import {
  * @returns ordered values: first value is the synchronized state value and the second is a setter to change the state value.
  * The setter returns a void promise, which will throw if the user does not have the required roles to set.
  */
-export function useLiveState<TState>(
+export function useLiveState<TState = any>(
     uniqueKey: string,
     initialState: TState,
     allowedRoles?: UserMeetingRole[]

--- a/packages/live-share-react/src/shared-hooks/useSharedMap.ts
+++ b/packages/live-share-react/src/shared-hooks/useSharedMap.ts
@@ -22,14 +22,14 @@ import {
  * directly is that it integrates nicely with React state and automates repetitive tasks.
  * If you want to use `SharedMap` this hook creates directly, you can do that as well.
  *
- * @template TData Optional typing for objects stored in the SharedMap. Default is `object` type.
+ * @template TData Optional typing for objects stored in the SharedMap. Default is `any` type.
  * @param uniqueKey the unique key for the `SharedMap`. If one does not yet exist, a new `SharedMap`
  * will be created, otherwise it will use the existing one.
  * @param initialData a JS Map, entries array, or JSON object to insert into the `SharedMap` when creating
  * the DDS for the first time.
  * @returns stateful `map` entries, `setEntry` callback, `deleteEntry` callback, and the Fluid `sharedMap`.
  */
-export function useSharedMap<TData extends object = object>(
+export function useSharedMap<TData = any>(
     uniqueKey: string,
     initialData?: SharedMapInitialData<TData>
 ): IUseSharedMapResults<TData> {

--- a/packages/live-share-react/src/shared-hooks/useSharedState.ts
+++ b/packages/live-share-react/src/shared-hooks/useSharedState.ts
@@ -23,7 +23,7 @@ import { isPrevStateCallback } from "../internal";
  *
  * @returns a stateful value, the function to update it, and an optional dispose method to delete it from the `SharedMap`.
  */
-export function useSharedState<S>(
+export function useSharedState<S = any>(
     uniqueKey: string,
     initialState: S
 ): [S, SetSharedStateAction<S>, DisposeSharedStateAction] {


### PR DESCRIPTION
- Removed force object type for `useSharedMap`, replaced with `any`
- Added default type of `any` to `useSharedState` and `useLiveState`