### PR TITLE
Fixed MediaPlayerSynchronizer returning incorrect metadata

### DIFF
--- a/packages/live-share-media/src/MediaPlayerSynchronizer.ts
+++ b/packages/live-share-media/src/MediaPlayerSynchronizer.ts
@@ -82,6 +82,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
     private _seekSuspension?: MediaSessionCoordinatorSuspension;
     private _viewOnly = false;
     private _expectedPlaybackState: ExtendedMediaSessionPlaybackState = "none";
+    private _metadata: ExtendedMediaMetadata | null = null;
     private _trackData: object | null = null;
 
     /**
@@ -120,8 +121,15 @@ export class MediaPlayerSynchronizer extends EventEmitter {
                 playbackState = "playing";
             }
 
+            // Metadata equality check in `GroupPlaybackTrack` would return false if only providing src.
+            // Use full metadata if this._metadata has same src
+            const metadata =
+                this._metadata && this._metadata.trackIdentifier === src
+                    ? this._metadata
+                    : ({ trackIdentifier: src } as ExtendedMediaMetadata);
+
             const state = {
-                metadata: { trackIdentifier: src } as ExtendedMediaMetadata,
+                metadata: metadata,
                 playbackState: playbackState,
                 positionState: {
                     position: this._player.currentTime,
@@ -301,6 +309,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
                                         .SetTrackAction
                                 );
                                 this._expectedPlaybackState = "none";
+                                this._metadata = details.metadata ?? null;
                                 if (
                                     this._player.src ===
                                     details.metadata?.trackIdentifier

--- a/packages/live-share-media/src/internals/GroupCoordinatorState.ts
+++ b/packages/live-share-media/src/internals/GroupCoordinatorState.ts
@@ -463,7 +463,7 @@ export class GroupCoordinatorState extends EventEmitter {
                 // Ensure local media session is in sync with group
                 if (local && !this.isSuspended) {
                     // Begin a "soft suspension" on select state changes
-                    // - This is needed because the catchup logic can try to sink the client with
+                    // - This is needed because the catchup logic can try to sync the client with
                     //  the rest of the group while the local player is trying to to seek to a
                     //  new position.
                     switch (event.data.playbackState) {

--- a/packages/live-share-media/src/test/LiveMediaSession_ManualActionHandler.spec.ts
+++ b/packages/live-share-media/src/test/LiveMediaSession_ManualActionHandler.spec.ts
@@ -3,15 +3,17 @@
  * Licensed under the Microsoft Live Share SDK License.
  */
 
-import { TestLiveMediaSession, TestMediaPlayer } from "./TestUtils";
+import { TestLiveMediaSession, TestMediaTimeStampProvider } from "./TestUtils";
 import { Deferred } from "@microsoft/live-share/src/internals/Deferred";
 import { strict as assert } from "assert";
 import { requestFluidObject } from "@fluidframework/runtime-utils";
 import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
 import {
+    ITimestampProvider,
     LiveEventScope,
     LiveEventTarget,
+    LocalTimestampProvider,
     UserMeetingRole,
 } from "@microsoft/live-share";
 import { TestLiveShareHost } from "@microsoft/live-share";
@@ -26,11 +28,22 @@ import { IMediaPlayerState } from "../LiveMediaSessionCoordinator";
 
 async function getObjects(
     getTestObjectProvider,
-    updateInterval: number = 10000
+    updateInterval: number = 10000,
+    timestampProvider: ITimestampProvider = new LocalTimestampProvider()
 ) {
     const host = TestLiveShareHost.create();
-    let liveRuntime1 = new MockLiveShareRuntime(false, updateInterval, host);
-    let liveRuntime2 = new MockLiveShareRuntime(false, updateInterval, host);
+    let liveRuntime1 = new MockLiveShareRuntime(
+        false,
+        updateInterval,
+        host,
+        timestampProvider
+    );
+    let liveRuntime2 = new MockLiveShareRuntime(
+        false,
+        updateInterval,
+        host,
+        timestampProvider
+    );
 
     let ObjectProxy1: any = getLiveDataObjectClassProxy<TestLiveMediaSession>(
         TestLiveMediaSession,
@@ -311,7 +324,9 @@ describeNoCompat(
 
         it("should broadcast 'catchup' transport command.", async () => {
             const { object1, object2, dispose } = await getObjects(
-                getTestObjectProvider
+                getTestObjectProvider,
+                10000,
+                new TestMediaTimeStampProvider()
             );
 
             const done = new Deferred();

--- a/packages/live-share-media/src/test/VolumeManager.spec.ts
+++ b/packages/live-share-media/src/test/VolumeManager.spec.ts
@@ -3,8 +3,8 @@ import { IMediaPlayer } from "../IMediaPlayer";
 import { LimitLevelType, VolumeManager } from "../VolumeManager";
 import { Deferred, waitForDelay } from "@microsoft/live-share/src/internals";
 
-// 1ms more than max timeout callback in scheduleAnimationFrame
-const milliTolerance = 21;
+// few millis more than max timeout callback in scheduleAnimationFrame
+const milliTolerance = 25;
 const volumeChangeDuration = 0.1;
 
 describe("VolumeManager", () => {

--- a/packages/live-share/src/test/MockLiveShareRuntime.ts
+++ b/packages/live-share/src/test/MockLiveShareRuntime.ts
@@ -1,17 +1,17 @@
 import { LiveShareRuntime } from "../LiveShareRuntime";
 import { TestLiveShareHost } from "../TestLiveShareHost";
-import { IContainerRuntimeSignaler } from "../interfaces";
+import { IContainerRuntimeSignaler, ITimestampProvider } from "../interfaces";
 import { MockContainerRuntimeSignaler } from "./MockContainerRuntimeSignaler";
-import { MockTimestampProvider } from "./MockTimestampProvider";
 import { LocalTimestampProvider } from "../LocalTimestampProvider";
 
 export class MockLiveShareRuntime extends LiveShareRuntime {
     constructor(
         shouldCreateMockContainer = false,
         private readonly updateInterval = 10000,
-        host = TestLiveShareHost.create()
+        host = TestLiveShareHost.create(),
+        timestampProvider: ITimestampProvider = new LocalTimestampProvider()
     ) {
-        super(host, new LocalTimestampProvider());
+        super(host, timestampProvider);
         if (shouldCreateMockContainer) {
             const localContainer = new MockContainerRuntimeSignaler();
             this.__dangerouslySetContainerRuntime(localContainer);


### PR DESCRIPTION
* Fixed metadata equality check in `GroupPlaybackTrack` failing  from player state returned in synchronizer
* Added catchup test for `MediaPlayerSynchronizer`
* Improved test stability