### PR TITLE
Removed role check on unrestricted scope in media

### DIFF
--- a/packages/live-share-media/src/LiveMediaSession.ts
+++ b/packages/live-share-media/src/LiveMediaSession.ts
@@ -283,7 +283,7 @@ export class LiveMediaSession extends LiveDataObject {
     private getCurrentPlayerState(): IMediaPlayerState {
         if (!this._requestPlayerStateHandler) {
             throw new Error(
-                `SharedMediaSession: no getPlayerState callback configured.`
+                `LiveMediaSession: no getPlayerState callback configured.`
             );
         }
 

--- a/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
+++ b/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
@@ -533,24 +533,8 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
         }
 
         // Send position update event
-        this.verifyLocalUserRoles()
-            .then((valid) => {
-                const evt = this._groupState!.createPositionUpdateEvent(state);
-                if (!valid) {
-                    // We still need to update _groupState with the local user's position.
-                    // So we do this here rather than on the receiving end.
-                    this._groupState!.handlePositionUpdate(
-                        {
-                            clientId: this._runtime.clientId ?? "",
-                            timestamp: this._liveRuntime.getTimestamp(),
-                            data: evt,
-                        },
-                        true
-                    );
-                    return;
-                }
-                return this._positionUpdateEvent?.sendEvent(evt);
-            })
+        const evt = this._groupState!.createPositionUpdateEvent(state);
+        this._positionUpdateEvent?.sendEvent(evt)
             .catch((err) => {
                 this._logger.sendErrorEvent(
                     TelemetryEvents.SessionCoordinator.PositionUpdateEventError,
@@ -640,13 +624,8 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
                 this.sendPositionUpdate(state);
             }
         );
-
-        this.verifyLocalUserRoles()
-            .then((verified) => {
-                if (!verified) return;
-                // Send initial joined event
-                return this._joinedEvent?.sendEvent(undefined);
-            })
+        // Send initial joined event
+        this._joinedEvent?.sendEvent(undefined)
             .catch((err) => {
                 this._logger.sendErrorEvent(
                     TelemetryEvents.SessionCoordinator.SendJoinedEventError,

--- a/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
+++ b/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
@@ -534,13 +534,12 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
 
         // Send position update event
         const evt = this._groupState!.createPositionUpdateEvent(state);
-        this._positionUpdateEvent?.sendEvent(evt)
-            .catch((err) => {
-                this._logger.sendErrorEvent(
-                    TelemetryEvents.SessionCoordinator.PositionUpdateEventError,
-                    err
-                );
-            });
+        this._positionUpdateEvent?.sendEvent(evt).catch((err) => {
+            this._logger.sendErrorEvent(
+                TelemetryEvents.SessionCoordinator.PositionUpdateEventError,
+                err
+            );
+        });
     }
 
     protected async createChildren(
@@ -625,13 +624,12 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
             }
         );
         // Send initial joined event
-        this._joinedEvent?.sendEvent(undefined)
-            .catch((err) => {
-                this._logger.sendErrorEvent(
-                    TelemetryEvents.SessionCoordinator.SendJoinedEventError,
-                    err
-                );
-            });
+        this._joinedEvent?.sendEvent(undefined).catch((err) => {
+            this._logger.sendErrorEvent(
+                TelemetryEvents.SessionCoordinator.SendJoinedEventError,
+                err
+            );
+        });
     }
 
     private getPlayerPosition(): number {


### PR DESCRIPTION
- Removed role check for position updates
- Removed role check for joined event
- Fix for multiple scopes with different permissions for same dataObject.
- Fix for sending position update on receiving joined event if player is not setup yet.

I had incorrectly understood the reason for why logs were getting flooded with "invalid role" errors on position updates. For now, these role checks are unnecessary. If we want to restrict them in the future, we should just move them into the `restrictedScope`, rather than add redundant role checks in events sent through `unrestrictedScope`.