### PR TITLE
Fixed Media syncing when pause event is emitted by a player immediately before ended

### DIFF
--- a/packages/live-share-media/src/IMediaPlayer.ts
+++ b/packages/live-share-media/src/IMediaPlayer.ts
@@ -7,6 +7,7 @@ export interface IMediaPlayer {
     readonly currentSrc: string;
     currentTime: number;
     readonly duration: number;
+    // it is important that ended is reported properly. Some players like to reset at the end of playback and set ended to false
     readonly ended: boolean;
     muted: boolean;
     readonly paused: boolean;

--- a/packages/live-share-media/src/IMediaPlayer.ts
+++ b/packages/live-share-media/src/IMediaPlayer.ts
@@ -7,7 +7,6 @@ export interface IMediaPlayer {
     readonly currentSrc: string;
     currentTime: number;
     readonly duration: number;
-    // it is important that ended is reported properly. Some players like to reset at the end of playback and set ended to false
     readonly ended: boolean;
     muted: boolean;
     readonly paused: boolean;

--- a/packages/live-share-media/src/MediaPlayerSynchronizer.ts
+++ b/packages/live-share-media/src/MediaPlayerSynchronizer.ts
@@ -205,7 +205,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
                     if (
                         this._expectedPlaybackState === "playing" &&
                         !this._mediaSession.coordinator.isSuspended &&
-                        // some players have ended, but emit a pause event immediately before ended event. Do no play is ended
+                        // some players have ended, but emit a pause event immediately before ended event. Do not play if ended
                         !this._player.ended
                     ) {
                         this._player.play();

--- a/packages/live-share-media/src/MediaPlayerSynchronizer.ts
+++ b/packages/live-share-media/src/MediaPlayerSynchronizer.ts
@@ -204,7 +204,9 @@ export class MediaPlayerSynchronizer extends EventEmitter {
                     // needed because cannot tell if its a user initiated event, so disallow pause
                     if (
                         this._expectedPlaybackState === "playing" &&
-                        !this._mediaSession.coordinator.isSuspended
+                        !this._mediaSession.coordinator.isSuspended &&
+                        // some players have ended, but emit a pause event immediately before ended event. Do no play is ended
+                        !this._player.ended
                     ) {
                         this._player.play();
                     }

--- a/samples/javascript/21.react-media-template/src/utils/AzureMediaPlayer.js
+++ b/samples/javascript/21.react-media-template/src/utils/AzureMediaPlayer.js
@@ -163,7 +163,9 @@ export class AzureMediaPlayer extends EventTarget {
     }
 
     get ended() {
-        return this._player.ended();
+        // It is important that ended is reported properly.
+        // Some players like to reset at the end of playback and set ended to false.
+        return this._player.ended() || this._track.ended;
     }
 
     get autoplay() {
@@ -357,9 +359,6 @@ export class AzureMediaPlayer extends EventTarget {
                 this._applySkipTo(false);
                 break;
             case PlayerEvent.ended:
-                this.load();
-                this.play();
-                this.pause();
                 this._stopPositionTracker();
                 this._track.ended = true;
                 this._track.playing = false;

--- a/samples/typescript/21.react-media-template/src/utils/AzureMediaPlayer.ts
+++ b/samples/typescript/21.react-media-template/src/utils/AzureMediaPlayer.ts
@@ -178,7 +178,8 @@ export class AzureMediaPlayer extends EventTarget {
     }
 
     get ended(): boolean {
-        // it is important that ended is reported properly. Some players like to reset at the end of playback and set ended to false
+        // It is important that ended is reported properly.
+        // Some players like to reset at the end of playback and set ended to false.
         return this._player.ended() || this._track.ended;
     }
 

--- a/samples/typescript/21.react-media-template/src/utils/AzureMediaPlayer.ts
+++ b/samples/typescript/21.react-media-template/src/utils/AzureMediaPlayer.ts
@@ -178,7 +178,8 @@ export class AzureMediaPlayer extends EventTarget {
     }
 
     get ended(): boolean {
-        return this._player.ended();
+        // it is important that ended is reported properly. Some players like to reset at the end of playback and set ended to false
+        return this._player.ended() || this._track.ended;
     }
 
     get autoplay(): boolean {
@@ -372,9 +373,6 @@ export class AzureMediaPlayer extends EventTarget {
                 // this._applySkipTo(false);
                 break;
             case PlayerEvent.ended:
-                this.load();
-                this.play();
-                this.pause();
                 this._stopPositionTracker();
                 this._track.ended = true;
                 this._track.playing = false;


### PR DESCRIPTION
* Fix bug when paused event if fired immediately before ended event in synced player, with synchronizer attempting to play again since not in expected state.
* Report ended state properly in sample