### PR TITLE
Made VolumeManager tests less flaky

### DIFF
--- a/packages/live-share-canvas/src/test/Miscellaneous.spec.ts
+++ b/packages/live-share-canvas/src/test/Miscellaneous.spec.ts
@@ -18,7 +18,7 @@ import {
     isPointInsideRectangle,
     isRectangleInsideRectangle,
     segmentsMayIntersect,
-} from "../core/Internals";
+} from "../core/internals";
 
 const testColor: IColor = { r: 193, g: 221, b: 202 };
 const serializedTestColor = "#C1DDCA";

--- a/packages/live-share-media/src/test/VolumeManager.spec.ts
+++ b/packages/live-share-media/src/test/VolumeManager.spec.ts
@@ -5,7 +5,7 @@ import { Deferred, waitForDelay } from "@microsoft/live-share/src/internals";
 
 // few millis more than max timeout callback in scheduleAnimationFrame
 const milliTolerance = 25;
-const volumeChangeDuration = 0.1;
+const volumeChangeDuration = 0.5;
 
 describe("VolumeManager", () => {
     it("should ramp down volume", async () => {


### PR DESCRIPTION
Made VolumeManager tests less flaky. This was due to very small duration for volume change used in test combined with javascript async state machine not handing control back to test fast enough.

also fixed casing issue in import of separate test.