### PR TITLE
Expose clientId in ExtendedMediaSessionActionDetails for LiveMediaSession

### DIFF
--- a/packages/live-share-media/package.json
+++ b/packages/live-share-media/package.json
@@ -10,7 +10,7 @@
         "clean": "npx shx rm -rf bin",
         "build": "tsc -p tsconfig.build.json",
         "test": "ts-mocha --config ./src/test/.mocharc.js src/**/*.spec.ts --timeout 10000",
-        "test:debug": "ts-mocha src/**/*.spec.ts --inspect-brk",
+        "test:debug": "ts-mocha --config ./src/test/.mocharc.js src/**/*.spec.ts --inspect-brk",
         "test:coverage": "nyc --reporter=html --reporter=text --reporter=text-summary npm test",
         "test:race": "node ./../live-share/test-for-race-conditions.js"
     },

--- a/packages/live-share-media/src/MediaPlayerSynchronizer.ts
+++ b/packages/live-share-media/src/MediaPlayerSynchronizer.ts
@@ -2,7 +2,11 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the Microsoft Live Share SDK License.
  */
-import { LiveTelemetryLogger, ILiveEvent } from "@microsoft/live-share";
+import {
+    LiveTelemetryLogger,
+    ILiveEvent,
+    IRuntimeSignaler,
+} from "@microsoft/live-share";
 import EventEmitter from "events";
 import {
     ExtendedMediaSessionAction,
@@ -17,6 +21,7 @@ import { VolumeManager } from "./VolumeManager";
 import { LiveMediaSession } from "./LiveMediaSession";
 import { IMediaPlayer } from "./IMediaPlayer";
 import { TelemetryEvents } from "./internals";
+import { waitUntilConnected } from "@microsoft/live-share/bin/internals";
 
 /**
  * Event data returned by `MediaPlayerSynchronizer` object.
@@ -76,6 +81,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
     private _logger: LiveTelemetryLogger;
     private _player: IMediaPlayer;
     private _mediaSession: LiveMediaSession;
+    private _runtime: IRuntimeSignaler;
     private _volumeManager: VolumeManager;
     private _onEnd?: () => void;
     private _onPlayerEvent: EventListener;
@@ -94,11 +100,13 @@ export class MediaPlayerSynchronizer extends EventEmitter {
     constructor(
         player: IMediaPlayer,
         mediaSession: LiveMediaSession,
+        runtime: IRuntimeSignaler,
         onEnd: () => void
     ) {
         super();
         this._player = player;
         this._mediaSession = mediaSession;
+        this._runtime = runtime;
         this._logger = mediaSession.logger;
         this._volumeManager = new VolumeManager(player);
         this._onEnd = onEnd;
@@ -513,7 +521,13 @@ export class MediaPlayerSynchronizer extends EventEmitter {
         );
         suspension.end(seekTo);
 
-        this.dispatchUserAction({ action: "seekto", seekTime: seekTo });
+        waitUntilConnected(this._runtime).then((clientId: string) => {
+            this.dispatchUserAction({
+                action: "seekto",
+                clientId,
+                seekTime: seekTo,
+            });
+        });
     }
 
     /**
@@ -532,7 +546,10 @@ export class MediaPlayerSynchronizer extends EventEmitter {
         this._expectedPlaybackState = "playing";
         await this._mediaSession.coordinator.play();
 
-        this.dispatchUserAction({ action: "play" });
+        this.dispatchUserAction({
+            action: "play",
+            clientId: await waitUntilConnected(this._runtime),
+        });
     }
 
     /**
@@ -551,7 +568,10 @@ export class MediaPlayerSynchronizer extends EventEmitter {
         this._expectedPlaybackState = "paused";
         await this._mediaSession.coordinator.pause();
 
-        this.dispatchUserAction({ action: "pause" });
+        this.dispatchUserAction({
+            action: "pause",
+            clientId: await waitUntilConnected(this._runtime),
+        });
     }
 
     /**
@@ -576,7 +596,11 @@ export class MediaPlayerSynchronizer extends EventEmitter {
         );
         await this._mediaSession.coordinator.seekTo(time);
 
-        this.dispatchUserAction({ action: "seekto", seekTime: time });
+        this.dispatchUserAction({
+            action: "seekto",
+            clientId: await waitUntilConnected(this._runtime),
+            seekTime: time,
+        });
     }
 
     /**
@@ -597,7 +621,11 @@ export class MediaPlayerSynchronizer extends EventEmitter {
         );
         await this._mediaSession.coordinator.setTrack(track, waitPoints);
 
-        this.dispatchUserAction({ action: "settrack", metadata: track });
+        this.dispatchUserAction({
+            action: "settrack",
+            clientId: await waitUntilConnected(this._runtime),
+            metadata: track,
+        });
     }
 
     /**
@@ -616,9 +644,14 @@ export class MediaPlayerSynchronizer extends EventEmitter {
         this._trackData = data;
         await this._mediaSession.coordinator.setTrackData(data);
 
-        this.dispatchUserAction({ action: "datachange", data: data });
+        this.dispatchUserAction({
+            action: "datachange",
+            clientId: await waitUntilConnected(this._runtime),
+            data: data,
+        });
     }
 
+    // TODO: what is delay useful for? we do not use, delete?
     private dispatchGroupAction(
         details: ExtendedMediaSessionActionDetails,
         delay = false,
@@ -630,7 +663,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
                     this.emit(MediaPlayerSynchronizerEvents.groupaction, {
                         type: MediaPlayerSynchronizerEvents.groupaction,
                         details: details,
-                        playerError: error,
+                        error,
                     }),
                 50
             );
@@ -643,6 +676,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
         }
     }
 
+    // TODO: what is delay useful for? we do not use, delete?
     private dispatchUserAction(
         details: ExtendedMediaSessionActionDetails,
         delay = false

--- a/packages/live-share-media/src/MediaPlayerSynchronizer.ts
+++ b/packages/live-share-media/src/MediaPlayerSynchronizer.ts
@@ -360,7 +360,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
                         }
                     }
 
-                    this.dispatchGroupAction(details, false, error);
+                    this.dispatchGroupAction(details, error);
                 }
             );
         }
@@ -654,48 +654,22 @@ export class MediaPlayerSynchronizer extends EventEmitter {
     // TODO: what is delay useful for? we do not use, delete?
     private dispatchGroupAction(
         details: ExtendedMediaSessionActionDetails,
-        delay = false,
         error: Error | undefined
     ): void {
-        if (delay) {
-            setTimeout(
-                () =>
-                    this.emit(MediaPlayerSynchronizerEvents.groupaction, {
-                        type: MediaPlayerSynchronizerEvents.groupaction,
-                        details: details,
-                        error,
-                    }),
-                50
-            );
-        } else {
-            this.emit(MediaPlayerSynchronizerEvents.groupaction, {
-                type: MediaPlayerSynchronizerEvents.groupaction,
-                details: details,
-                error,
-            });
-        }
+        this.emit(MediaPlayerSynchronizerEvents.groupaction, {
+            type: MediaPlayerSynchronizerEvents.groupaction,
+            details: details,
+            error,
+        });
     }
 
-    // TODO: what is delay useful for? we do not use, delete?
     private dispatchUserAction(
-        details: ExtendedMediaSessionActionDetails,
-        delay = false
+        details: ExtendedMediaSessionActionDetails
     ): void {
-        if (delay) {
-            setTimeout(
-                () =>
-                    this.emit(MediaPlayerSynchronizerEvents.useraction, {
-                        type: MediaPlayerSynchronizerEvents.useraction,
-                        details: details,
-                    }),
-                50
-            );
-        } else {
-            this.emit(MediaPlayerSynchronizerEvents.useraction, {
-                type: MediaPlayerSynchronizerEvents.useraction,
-                details: details,
-            });
-        }
+        this.emit(MediaPlayerSynchronizerEvents.useraction, {
+            type: MediaPlayerSynchronizerEvents.useraction,
+            details: details,
+        });
     }
 
     private async catchupPlayer(time: number): Promise<void> {

--- a/packages/live-share-media/src/MediaSessionActionThrottler.ts
+++ b/packages/live-share-media/src/MediaSessionActionThrottler.ts
@@ -3,14 +3,17 @@
  * Licensed under the Microsoft Live Share SDK License.
  */
 
-import { ExtendedMediaSessionActionDetails } from "./MediaSessionExtensions";
+import {
+    ExtendedMediaSessionActionDetails,
+    ExtendedMediaSessionActionHandler,
+} from "./MediaSessionExtensions";
 
 /**
  * Base class for action throttlers.
  */
 export abstract class MediaSessionActionThrottler {
     public abstract throttled(
-        details: ExtendedMediaSessionActionDetails,
-        handler?: MediaSessionActionHandler
+        details: MediaSessionActionDetails | ExtendedMediaSessionActionDetails,
+        handler?: MediaSessionActionHandler | ExtendedMediaSessionActionHandler
     ): void;
 }

--- a/packages/live-share-media/src/MediaSessionExtensions.ts
+++ b/packages/live-share-media/src/MediaSessionExtensions.ts
@@ -42,6 +42,7 @@ export interface CoordinationWaitPoint {
 
 export interface ExtendedMediaSessionActionDetails {
     action: ExtendedMediaSessionAction;
+    clientId: string;
     fastSeek?: boolean | null;
     seekOffset?: number | null;
     seekTime?: number | null;
@@ -49,4 +50,8 @@ export interface ExtendedMediaSessionActionDetails {
     suspension?: MediaSessionCoordinatorSuspension | null;
     data?: object | null;
     blocked?: ExtendedMediaSessionAction | null;
+}
+
+export interface ExtendedMediaSessionActionHandler {
+    (details: ExtendedMediaSessionActionDetails): void;
 }

--- a/packages/live-share-media/src/RepeatedActionThrottler.ts
+++ b/packages/live-share-media/src/RepeatedActionThrottler.ts
@@ -33,7 +33,7 @@ export class RepeatedActionThrottler extends MediaSessionActionThrottler {
     }
 
     public throttled(
-        details: ExtendedMediaSessionActionDetails,
+        details: MediaSessionActionDetails | ExtendedMediaSessionActionDetails,
         handler?: MediaSessionActionHandler
     ): void {
         if (handler) {
@@ -63,7 +63,9 @@ export class RepeatedActionThrottler extends MediaSessionActionThrottler {
         }
     }
 
-    private getChangeKey(details: ExtendedMediaSessionActionDetails): string {
+    private getChangeKey(
+        details: MediaSessionActionDetails | ExtendedMediaSessionActionDetails
+    ): string {
         switch (details.action) {
             case "seekto":
                 return `seekto:${details.seekTime}`;

--- a/packages/live-share-media/src/internals/GroupPlaybackTrack.ts
+++ b/packages/live-share-media/src/internals/GroupPlaybackTrack.ts
@@ -147,6 +147,7 @@ export class GroupPlaybackTrack extends EventEmitter {
         // Notify listeners
         this.emit(GroupPlaybackTrackEvents.trackChange, {
             name: GroupPlaybackTrackEvents.trackChange,
+            clientId: track.clientId,
             metadata: track.metadata,
         });
 

--- a/packages/live-share-media/src/internals/GroupPlaybackTrackData.ts
+++ b/packages/live-share-media/src/internals/GroupPlaybackTrackData.ts
@@ -90,6 +90,7 @@ export class GroupPlaybackTrackData extends EventEmitter {
         // Notify listeners
         this.emit(PlaybackTrackDataEvents.dataChange, {
             type: PlaybackTrackDataEvents.dataChange,
+            clientId: event.clientId,
             data: event.data,
         });
 

--- a/packages/live-share-media/src/internals/GroupTransportState.ts
+++ b/packages/live-share-media/src/internals/GroupTransportState.ts
@@ -3,11 +3,7 @@
  * Licensed under the Microsoft Live Share SDK License.
  */
 
-import {
-    ILiveEvent,
-    LiveShareRuntime,
-    LiveShareClient,
-} from "@microsoft/live-share";
+import { ILiveEvent, LiveShareRuntime } from "@microsoft/live-share";
 import EventEmitter from "events";
 import { IMediaPlayerState } from "../LiveMediaSessionCoordinator";
 import {
@@ -140,6 +136,7 @@ export class GroupTransportState extends EventEmitter {
             this.emit(GroupTransportStateEvents.transportStateChange, {
                 type: GroupTransportStateEvents.transportStateChange,
                 action: "seekto",
+                clientId: state.clientId,
                 seekTime: state.startPosition,
             });
         } else if (state.playbackState == "playing") {
@@ -149,12 +146,14 @@ export class GroupTransportState extends EventEmitter {
             this.emit(GroupTransportStateEvents.transportStateChange, {
                 type: GroupTransportStateEvents.transportStateChange,
                 action: "play",
+                clientId: state.clientId,
                 seekTime: projectedPosition,
             });
         } else {
             this.emit(GroupTransportStateEvents.transportStateChange, {
                 type: GroupTransportStateEvents.transportStateChange,
                 action: "pause",
+                clientId: state.clientId,
                 seekTime: state.startPosition,
             });
         }


### PR DESCRIPTION
Implements #712

Enables developers to get clientId from LiveMediaSession events, which can be used to do lookups for specific clients with `getClientInfo`.