### PR TITLE
Handle android bug by checking types instead of keys

### DIFF
--- a/packages/live-share/src/internals/FormatFixHostDecorator.ts
+++ b/packages/live-share/src/internals/FormatFixHostDecorator.ts
@@ -5,6 +5,8 @@ import { isClientRolesResponse, isIClientInfo } from "./type-guards";
 
 /**
  * @hidden
+ * Temporary fix for android bug which causes IClientInfo to come back with the keys modified
+ * Delete in November 2023
  */
 export class FormatFixHostDecorator extends BaseHostDecorator {
     public async getClientInfo(

--- a/packages/live-share/src/internals/test/FormatFixHostDecorator.spec.ts
+++ b/packages/live-share/src/internals/test/FormatFixHostDecorator.spec.ts
@@ -12,7 +12,7 @@ class HostWithAndroidBug {
 }
 
 describe("FormatFixHostDecorator tests", function () {
-    it("should map android bug format to expected format", async () => {
+    it("should map android bug format to expected format 1", async () => {
         const hostResponse = {
             lock: "972ea631-abc8-4056-ae0e-f4dc7427c4ef",
             _loadStates: [UserMeetingRole.organizer],
@@ -34,9 +34,30 @@ describe("FormatFixHostDecorator tests", function () {
         );
     });
 
+    it("should map android bug format to expected format 2", async () => {
+        const hostResponse = {
+            sup: "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF",
+            blah: [UserMeetingRole.organizer],
+        };
+        const host = new HostWithAndroidBug(
+            hostResponse
+        ) as unknown as ILiveShareHost;
+        const hostWithMapper = new FormatFixHostDecorator(host);
+        const expectedResult = {
+            userId: "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF",
+            roles: [UserMeetingRole.organizer],
+            displayName: undefined,
+        };
+        const result = await hostWithMapper.getClientInfo("test");
+        assert(
+            JSON.stringify(result) === JSON.stringify(expectedResult),
+            `unexpected result: ${JSON.stringify(result)}`
+        );
+    });
+
     it("should not map if already expected format", async () => {
         const hostResponse = {
-            userId: "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF",
+            userId: "userId",
             roles: [UserMeetingRole.organizer],
             displayName: "displayName",
         };

--- a/packages/live-share/src/internals/test/FormatFixHostDecorator.spec.ts
+++ b/packages/live-share/src/internals/test/FormatFixHostDecorator.spec.ts
@@ -14,7 +14,7 @@ class HostWithAndroidBug {
 describe("FormatFixHostDecorator tests", function () {
     it("should map android bug format to expected format", async () => {
         const hostResponse = {
-            lock: "userId",
+            lock: "972ea631-abc8-4056-ae0e-f4dc7427c4ef",
             _loadStates: [UserMeetingRole.organizer],
             internalState: "displayName",
         };
@@ -23,7 +23,7 @@ describe("FormatFixHostDecorator tests", function () {
         ) as unknown as ILiveShareHost;
         const hostWithMapper = new FormatFixHostDecorator(host);
         const expectedResult = {
-            userId: "userId",
+            userId: "972ea631-abc8-4056-ae0e-f4dc7427c4ef",
             roles: [UserMeetingRole.organizer],
             displayName: "displayName",
         };
@@ -36,7 +36,7 @@ describe("FormatFixHostDecorator tests", function () {
 
     it("should not map if already expected format", async () => {
         const hostResponse = {
-            userId: "userId",
+            userId: "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF",
             roles: [UserMeetingRole.organizer],
             displayName: "displayName",
         };


### PR DESCRIPTION
fixes #647.

Keys of ClientInfo objects would change between different android builds due to an issue with obfuscation. Fix for android will be rolled out in a few weeks, but this fixes it in the meantime and provides support for older clients.

To fix, we assume we don't know what keys will contain what data. Every value in ClientInfo has a unique type, so we are able to create a ClientInfo object from the types.