### PR TITLE
Cache dynamic DDS in memory in Turbo

### DIFF
--- a/packages/live-share-canvas/src/core/LiveCanvas.ts
+++ b/packages/live-share-canvas/src/core/LiveCanvas.ts
@@ -38,6 +38,7 @@ import {
     LiveDataObject,
     LiveTelemetryLogger,
     ILiveEvent,
+    LiveDataObjectInitializeState,
 } from "@microsoft/live-share";
 import { IBrush } from "./Brush";
 import { BasicColors, IColor, lightenColor, toCssRgbaColor } from "./Colors";
@@ -880,13 +881,18 @@ export class LiveCanvas extends LiveDataObject {
 
     /**
      * Initializes the live inking session.
-     * @param inkingManager The InkingManager instance providing the drawing and events
-     * that will be synchronized across clients.
+     * 
+     * @param inkingManager The InkingManager instance providing the drawing and events that will be synchronized across clients.
+     * 
+     * @returns a void promise that resolves once complete.
      */
     async initialize(
         inkingManager: InkingManager,
         allowedRoles?: UserMeetingRole[]
     ) {
+        // Update initialize state as pending
+        this.initializeState = LiveDataObjectInitializeState.pending;
+
         this._inkingManager = inkingManager;
         if (allowedRoles) {
             this._allowedRoles = allowedRoles;
@@ -908,6 +914,9 @@ export class LiveCanvas extends LiveDataObject {
         this._liveCursorsHost.style.overflow = "hidden";
 
         inkingManager.hostElement.appendChild(this._liveCursorsHost);
+
+        // Update initialize state as succeeded
+        this.initializeState = LiveDataObjectInitializeState.succeeded;
     }
 
     /**

--- a/packages/live-share-media/src/test/LiveMediaSession_ManualActionHandler.spec.ts
+++ b/packages/live-share-media/src/test/LiveMediaSession_ManualActionHandler.spec.ts
@@ -128,6 +128,8 @@ describeNoCompat(
             );
 
             await object1.initialize();
+            assert(object1.isInitialized, "LiveMediaSession objects not initialized");
+            assert(object1.coordinator.isInitialized, "LiveMediaSessionCoordinator objects not initialized");
             // wait for next event loop, simulate existing user waiting for other people to join.
             // otherwise joined event will fire for both users
             await waitForDelay(1);
@@ -226,9 +228,6 @@ describeNoCompat(
                 getTestObjectProvider
             );
 
-            await object1.initialize();
-            await object2.initialize();
-
             // create a duplicate scope/target with same event name as one declared in coordinator
             const scope1 = new LiveEventScope(
                 object1.runtimeForTesting(),
@@ -246,9 +245,13 @@ describeNoCompat(
                 }
             });
 
+            await object1.initialize();
+            await object2.initialize();
+
             await waitForDelay(1);
             await object2.coordinator.play();
             await done.promise;
+            assert(posUpdateCount > 1, `pos update should be > 1, instead is ${posUpdateCount}`);
 
             dispose();
         });

--- a/packages/live-share-react/src/live-hooks/useLiveEvent.ts
+++ b/packages/live-share-react/src/live-hooks/useLiveEvent.ts
@@ -7,6 +7,7 @@ import {
     LiveEventEvents,
     UserMeetingRole,
     LiveEvent,
+    LiveDataObjectInitializeState,
 } from "@microsoft/live-share";
 import React from "react";
 import {
@@ -116,7 +117,7 @@ export function useLiveEvent<TEvent = any>(
             setLatestReceived(received);
         };
         liveEvent.on(LiveEventEvents.received, onEventReceived);
-        if (!liveEvent.isInitialized) {
+        if (liveEvent.initializeState === LiveDataObjectInitializeState.needed) {
             // Start live event
             liveEvent.initialize(allowedRoles);
         }

--- a/packages/live-share-react/src/live-hooks/useLivePresence.ts
+++ b/packages/live-share-react/src/live-hooks/useLivePresence.ts
@@ -8,6 +8,7 @@ import {
     PresenceState,
     LivePresence,
     UserMeetingRole,
+    LiveDataObjectInitializeState,
 } from "@microsoft/live-share";
 import React from "react";
 import { IUseLivePresenceResults, OnUpdateLivePresenceAction } from "../types";
@@ -112,7 +113,7 @@ export function useLivePresence<TData extends object = object>(
         };
         livePresence.on("presenceChanged", onPresenceChanged);
 
-        if (!livePresence.isInitialized) {
+        if (livePresence.initializeState === LiveDataObjectInitializeState.needed) {
             livePresence.initialize(
                 isInitialDataCallback<TData>(initialData)
                     ? initialData()

--- a/packages/live-share-react/src/live-hooks/useLiveState.ts
+++ b/packages/live-share-react/src/live-hooks/useLiveState.ts
@@ -3,7 +3,7 @@
  * Licensed under the Microsoft Live Share SDK License.
  */
 
-import { LiveState, UserMeetingRole } from "@microsoft/live-share";
+import { LiveDataObjectInitializeState, LiveState, UserMeetingRole } from "@microsoft/live-share";
 import React from "react";
 import { SetLiveStateAction } from "../types";
 import { useDynamicDDS } from "../shared-hooks";
@@ -84,10 +84,11 @@ export function useLiveState<TState = any>(
         if (liveState === undefined) return;
 
         const onStateChanged = (state: TState) => {
+            console.log(state);
             setCurrentState(state);
         };
         liveState.on("stateChanged", onStateChanged);
-        if (!liveState.isInitialized) {
+        if (liveState.initializeState === LiveDataObjectInitializeState.needed) {
             liveState.initialize(initialState, allowedRoles);
         }
         if (JSON.stringify(liveState.state) !== JSON.stringify(initialState)) {

--- a/packages/live-share-react/src/live-hooks/useLiveTimer.ts
+++ b/packages/live-share-react/src/live-hooks/useLiveTimer.ts
@@ -8,6 +8,7 @@ import {
     LiveTimerEvents,
     UserMeetingRole,
     LiveTimer,
+    LiveDataObjectInitializeState,
 } from "@microsoft/live-share";
 import React from "react";
 import {
@@ -154,7 +155,7 @@ export function useLiveTimer(
         liveTimer.on(LiveTimerEvents.played, onDidPlay);
         liveTimer.on(LiveTimerEvents.paused, onDidPause);
         liveTimer.on(LiveTimerEvents.onTick, onDidTick);
-        if (!liveTimer.isInitialized) {
+        if (liveTimer.initializeState === LiveDataObjectInitializeState.needed) {
             // Start live event
             liveTimer.initialize(allowedRoles);
         }

--- a/packages/live-share-react/src/live-hooks/useMediaSynchronizer.ts
+++ b/packages/live-share-react/src/live-hooks/useMediaSynchronizer.ts
@@ -3,7 +3,7 @@
  * Licensed under the Microsoft Live Share SDK License.
  */
 
-import { UserMeetingRole } from "@microsoft/live-share";
+import { LiveDataObjectInitializeState, UserMeetingRole } from "@microsoft/live-share";
 import React from "react";
 import {
     CoordinationWaitPoint,
@@ -211,7 +211,7 @@ export function useMediaSynchronizer(
             synchronizer.viewOnly = viewOnly;
         }
 
-        if (!mediaSession.isInitialized) {
+        if (mediaSession.initializeState === LiveDataObjectInitializeState.needed) {
             // Start synchronizing the media session
             mediaSession.initialize(allowedRoles ?? []);
         } else if (initialTrack) {

--- a/packages/live-share/src/LiveDataObject.ts
+++ b/packages/live-share/src/LiveDataObject.ts
@@ -66,6 +66,10 @@ export abstract class LiveDataObject<
         return this._initializeState;
     }
 
+    protected set initializeState(value: LiveDataObjectInitializeState) {
+        this._initializeState = value;
+    }
+
     public constructor(props: IDataObjectProps<I>) {
         super(props);
     }

--- a/packages/live-share/src/LiveDataObject.ts
+++ b/packages/live-share/src/LiveDataObject.ts
@@ -51,6 +51,12 @@ export abstract class LiveDataObject<
         return this._liveRuntime;
     }
 
+    /**
+     * Flag that indicates whether initialization has succeeded or not.
+     * 
+     * @remarks
+     * This field is true when {@link initializeState} is `succeeded`, or false when {@link initializeState} is any other value.
+     */
     public get isInitialized(): boolean {
         return this.initializeState === LiveDataObjectInitializeState.succeeded;
     }

--- a/packages/live-share/src/LiveDataObject.ts
+++ b/packages/live-share/src/LiveDataObject.ts
@@ -19,13 +19,8 @@ export abstract class LiveDataObject<
      */
     public static LiveEnabled = true;
 
-    /**
-     * The initialization status of the data object.
-     * 
-     * @remarks
-     * Used to know whether it is safe to call `.initialize()`
-     */
-    public initializeState: LiveDataObjectInitializeState = LiveDataObjectInitializeState.needed;
+    
+    private _initializeState: LiveDataObjectInitializeState = LiveDataObjectInitializeState.needed;
 
     /**
      * @hidden
@@ -59,6 +54,16 @@ export abstract class LiveDataObject<
      */
     public get isInitialized(): boolean {
         return this.initializeState === LiveDataObjectInitializeState.succeeded;
+    }
+
+    /**
+     * The initialization status of the data object.
+     * 
+     * @remarks
+     * Used to know whether it is safe to call `.initialize()`
+     */
+    public get initializeState(): LiveDataObjectInitializeState {
+        return this._initializeState;
     }
 
     public constructor(props: IDataObjectProps<I>) {

--- a/packages/live-share/src/LiveDataObject.ts
+++ b/packages/live-share/src/LiveDataObject.ts
@@ -5,7 +5,7 @@ import {
 } from "@fluidframework/aqueduct";
 import { LiveShareRuntime } from "./LiveShareRuntime";
 import { assert } from "@fluidframework/common-utils";
-import { UserMeetingRole } from "./interfaces";
+import { LiveDataObjectInitializeState, UserMeetingRole } from "./interfaces";
 import { waitUntilConnected } from "./internals";
 
 /**
@@ -18,6 +18,14 @@ export abstract class LiveDataObject<
      * @hidden
      */
     public static LiveEnabled = true;
+
+    /**
+     * The initialization status of the data object.
+     * 
+     * @remarks
+     * Used to know whether it is safe to call `.initialize()`
+     */
+    public initializeState: LiveDataObjectInitializeState = LiveDataObjectInitializeState.needed;
 
     /**
      * @hidden
@@ -41,6 +49,10 @@ export abstract class LiveDataObject<
             "LiveShareRuntime not initialized. Ensure your Fluid `ContainerSchema` was first wrapped inside of `getLiveShareSchema`, or use `.joinContainer()` in `LiveShareClient`."
         );
         return this._liveRuntime;
+    }
+
+    public get isInitialized(): boolean {
+        return this.initializeState === LiveDataObjectInitializeState.succeeded;
     }
 
     public constructor(props: IDataObjectProps<I>) {

--- a/packages/live-share/src/LiveEvent.ts
+++ b/packages/live-share/src/LiveEvent.ts
@@ -5,7 +5,7 @@
 
 import { DataObjectFactory } from "@fluidframework/aqueduct";
 import { IEvent } from "@fluidframework/common-definitions";
-import { UserMeetingRole, IClientTimestamp, ILiveEvent } from "./interfaces";
+import { UserMeetingRole, IClientTimestamp, ILiveEvent, LiveDataObjectInitializeState } from "./interfaces";
 import { LiveEventScope } from "./LiveEventScope";
 import { LiveEventTarget } from "./LiveEventTarget";
 import { DynamicObjectRegistry } from "./DynamicObjectRegistry";
@@ -79,20 +79,23 @@ export class LiveEvent<TEvent = any> extends LiveDataObject<{
     );
 
     /**
-     * Returns true if the object has been initialized.
-     */
-    public get isInitialized(): boolean {
-        return !!this._eventTarget;
-    }
-
-    /**
-     * initialize the object.
+     * Initialize the object to begin sending/receiving events through this DDS.
+     * 
+     * @remarks
+     * You should register `received` event listeners before calling this function to ensure no incoming events are missed.
+     * `received` events will not be emitted until after this function is called.
+     * 
      * @param allowedRoles Optional. List of roles allowed to send events.
+     * 
+     * @returns a void promise that resolves once complete.
+     * 
+     * @throws error when `.initialize()` has already been called for this class instance.
      */
     public initialize(allowedRoles?: UserMeetingRole[]): Promise<void> {
-        if (this._eventTarget) {
+        if (this.initializeState !== LiveDataObjectInitializeState.needed) {
             throw new Error(`LiveEvent already started.`);
         }
+        this.initializeState = LiveDataObjectInitializeState.pending;
 
         this._allowedRoles = allowedRoles ?? [];
 
@@ -115,23 +118,30 @@ export class LiveEvent<TEvent = any> extends LiveDataObject<{
             }
         );
 
+        this.initializeState = LiveDataObjectInitializeState.succeeded;
         return Promise.resolve();
     }
 
     /**
      * Broadcasts an event to all other clients.
      *
-     * #### remarks
+     * @remarks
      * The event will be queued for delivery if the client isn't currently connected.
-     * @param evt Event to send. If omitted, an event will still be sent but it won't
-     * include any custom event data.
-     * @returns A promise with the full event object that was sent, including the timestamp of when the event
-     * was sent and the clientId if known. The clientId will be `undefined` if the client is
-     * disconnected at time of delivery.
+     * 
+     * @param evt Event to send. If omitted, an event will still be sent but it won't include any custom event data.
+     * 
+     * @returns A promise with the full event object that was sent, including the timestamp of when the event was sent and the clientId if known.
+     * The clientId will be `undefined` if the client is disconnected at time of delivery.
+     * 
+     * @throws error if initialization has not yet succeeded.
+     * @throws error if the local user does not have the required roles defined through the `allowedRoles` prop in `.initialize()`.
      */
     public async send(evt: TEvent): Promise<ILiveEvent<TEvent>> {
+        if (this.initializeState !== LiveDataObjectInitializeState.succeeded) {
+            throw new Error(`LiveEvent: not initialized prior to calling \`.send()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`);
+        }
         if (!this._eventTarget) {
-            throw new Error(`LiveEvent not started.`);
+            throw new Error(`LiveEvent: this._eventTarget is undefined, implying there was an error during initialization that should not occur. Please report this issue at https://aka.ms/teamsliveshare/issue.`)
         }
 
         return await this._eventTarget.sendEvent(evt);
@@ -140,7 +150,7 @@ export class LiveEvent<TEvent = any> extends LiveDataObject<{
     /**
      * Returns true if a received event is newer then the current event.
      *
-     * #### remarks
+     * @remarks
      * Used when building new Live objects to process state change events. The `isNewer()`
      * method implements an algorithm that deals with conflicting events that have the same timestamp
      * and older events that should have debounced the current event.

--- a/packages/live-share/src/LivePresence.ts
+++ b/packages/live-share/src/LivePresence.ts
@@ -16,7 +16,7 @@ import { LiveTelemetryLogger } from "./LiveTelemetryLogger";
 import { cloneValue, TelemetryEvents } from "./internals";
 import { TimeInterval } from "./TimeInterval";
 import { DynamicObjectRegistry } from "./DynamicObjectRegistry";
-import { IClientInfo, ILiveEvent, UserMeetingRole } from "./interfaces";
+import { IClientInfo, ILiveEvent, LiveDataObjectInitializeState, UserMeetingRole } from "./interfaces";
 import { LiveDataObject } from "./LiveDataObject";
 
 /**
@@ -86,13 +86,6 @@ export class LivePresence<
     );
 
     /**
-     * Returns true if the object has been initialized.
-     */
-    public get isInitialized(): boolean {
-        return !!this._synchronizer;
-    }
-
-    /**
      * Number of seconds without a presence update before a remote user is considered offline.
      *
      * @remarks
@@ -120,19 +113,32 @@ export class LivePresence<
     }
 
     /**
-     * Starts sharing presence information.
-     * @param data Optional. Custom data object to sshare. A deep copy of the data object is saved to avoid any accidental modifications.
+     * Initialize the object to begin sending/receiving presence updates through this DDS.
+     * 
+     * @param data Optional. Custom data object to share. A deep copy of the data object is saved to avoid any accidental modifications.
      * @param state Optional. Initial presence state. Defaults to `PresenceState.online`.
      * @param allowedRoles Optional. List of roles allowed to emit presence changes.
+     * 
+     * @returns a void promise that resolves once complete.
+     * 
+     * @throws error when `.initialize()` has already been called for this class instance.
+     * @throws fatal error when `.initialize()` has already been called for an object of same id but with a different class instance.
+     * This is most common when using dynamic objects through Fluid.
      */
     public async initialize(
         data?: TData,
         state = PresenceState.online,
         allowedRoles?: UserMeetingRole[]
     ): Promise<void> {
-        if (this._synchronizer) {
-            throw new Error(`LivePresence: already started.`);
+        if (this.initializeState !== LiveDataObjectInitializeState.needed) {
+            throw new Error(`LivePresence already started.`);
         }
+        // This error should not happen due to `initializeState` enum, but if it is somehow defined at this point, errors will occur.
+        if (this._synchronizer) {
+            throw new Error(`LivePresence: _synchronizer already set, which is an unexpected error. Please report this issue at https://aka.ms/teamsliveshare/issue.`);
+        }
+        // Update initialize state as pending
+        this.initializeState = LiveDataObjectInitializeState.pending;
         this._logger = new LiveTelemetryLogger(this.runtime, this.liveRuntime);
 
         // Save off allowed roles
@@ -153,24 +159,34 @@ export class LivePresence<
         this._synchronizer = new LiveObjectSynchronizer<
             ILivePresenceEvent<TData>
         >(this.id, this.runtime, this.liveRuntime);
-        await this._synchronizer!.start(
-            this._currentPresence!.data,
-            async (state, sender, local) => {
-                // Add user to list
-                await this.updateMembersList(state, local);
-                return false;
-            },
-            async (connecting) => {
-                if (connecting) return true;
-                // If user has eligible roles, allow the update to be sent
-                try {
-                    return await this.verifyLocalUserRoles();
-                } catch {
+        try {
+            await this._synchronizer!.start(
+                this._currentPresence!.data,
+                async (state, sender, local) => {
+                    // Add user to list
+                    await this.updateMembersList(state, local);
                     return false;
-                }
-            },
-            true // We want to update the timestamp periodically so that we know if a user is active
-        );
+                },
+                async (connecting) => {
+                    if (connecting) return true;
+                    // If user has eligible roles, allow the update to be sent
+                    try {
+                        return await this.verifyLocalUserRoles();
+                    } catch {
+                        return false;
+                    }
+                },
+                true // We want to update the timestamp periodically so that we know if a user is active
+            );
+        } catch (error: unknown) {
+            // Update initialize state as fatal error
+            this.initializeState = LiveDataObjectInitializeState.fatalError;
+            throw error;
+        }
+        // Update initialize state as succeeded.
+        // We do before sending initial update, since that requires this to happen first.
+        this.initializeState = LiveDataObjectInitializeState.succeeded;
+
         // Broadcast initial presence, or silently fail trying
         await this.update(
             this._currentPresence!.data.data,
@@ -209,13 +225,24 @@ export class LivePresence<
      *
      * @remarks
      * This will trigger the immediate broadcast of the users presence to all other clients.
+     * 
      * @param data Optional. Data object to change. A deep copy of the data object is saved to avoid any future changes.
      * @param state Optional. Presence state to change.
-     * @returns a void promise, and will throw if the user does not have the required roles
+     * 
+     * @returns a void promise that resolves once the update event has been sent to the server.
+     * 
+     * @throws error if initialization has not yet succeeded.
+     * @throws error if the local user does not have the required roles defined through the `allowedRoles` prop in `.initialize()`.
      */
     public async update(data?: TData, state?: PresenceState): Promise<void> {
-        if (!this._synchronizer || !this._currentPresence) {
-            throw new Error(`LivePresence: not started.`);
+        if (this.initializeState !== LiveDataObjectInitializeState.succeeded) {
+            throw new Error(`LivePresence: not initialized prior to calling \`.update()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`);
+        }
+        if (!this._synchronizer) {
+            throw new Error(`LivePresence: this._synchronizer is undefined, implying there was an error during initialization that should not occur. Please report this issue at https://aka.ms/teamsliveshare/issue.`);
+        }
+        if (!this._currentPresence) {
+            throw new Error(`LivePresence: this._currentPresence is undefined, implying there was an error during initialization that should not occur. Please report this issue at https://aka.ms/teamsliveshare/issue.`);
         }
 
         // Broadcast state change

--- a/packages/live-share/src/LiveShareClient.ts
+++ b/packages/live-share/src/LiveShareClient.ts
@@ -86,8 +86,11 @@ export class LiveShareClient {
      */
     constructor(host: ILiveShareHost, options?: ILiveShareClientOptions) {
         // Validate host passed in
-        if (!host || typeof host.getFluidTenantInfo != "function") {
-            throw new Error(`LiveShareClient: host not passed in`);
+        if (!host) {
+            throw new Error(`LiveShareClient: prop \`host\` is \`${host}\` when it is expected to be a non-optional value of type \`ILiveShareHost\`. Please ensure \`host\` is defined before initializing \`LiveShareClient\`.`);
+        }
+        if (typeof host.getFluidTenantInfo != "function") {
+            throw new Error(`LiveShareClient: \`host.getFluidTenantInfo\` is of type \`${typeof host.getFluidTenantInfo}\` when it is expected to be a type of \`function\`. For more information, review the \`ILiveShareHost\` interface.`);
         }
         this._host = host;
         // Save options

--- a/packages/live-share/src/LiveTimer.ts
+++ b/packages/live-share/src/LiveTimer.ts
@@ -5,7 +5,7 @@
 
 import { DataObjectFactory } from "@fluidframework/aqueduct";
 import { LiveObjectSynchronizer } from "./LiveObjectSynchronizer";
-import { IClientTimestamp, ILiveEvent, UserMeetingRole } from "./interfaces";
+import { IClientTimestamp, ILiveEvent, LiveDataObjectInitializeState, UserMeetingRole } from "./interfaces";
 import { IEvent } from "@fluidframework/common-definitions";
 import { LiveEvent } from "./LiveEvent";
 import { DynamicObjectRegistry } from "./DynamicObjectRegistry";
@@ -122,13 +122,6 @@ export class LiveTimer extends LiveDataObject<{
     );
 
     /**
-     * Returns true if the object has been initialized.
-     */
-    public get isInitialized(): boolean {
-        return !!this._synchronizer;
-    }
-
-    /**
      * Tick rate for timer in milliseconds. The default tick rate is 20 milliseconds
      *
      * @remarks
@@ -148,14 +141,26 @@ export class LiveTimer extends LiveDataObject<{
     }
 
     /**
-     * Initializes the object and starts listening for remote changes
+     * Initialize the object to begin sending/receiving timer updates through this DDS.
+     * 
      * @param allowedRoles Optional. List of roles allowed to make state changes.
-     * @returns a void promise
+     * 
+     * @returns a void promise that resolves once complete.
+     * 
+     * @throws error when `.initialize()` has already been called for this class instance.
+     * @throws fatal error when `.initialize()` has already been called for an object of same id but with a different class instance.
+     * This is most common when using dynamic objects through Fluid.
      */
     public async initialize(allowedRoles?: UserMeetingRole[]): Promise<void> {
-        if (this.isInitialized) {
+        if (this.initializeState !== LiveDataObjectInitializeState.needed) {
             throw new Error(`LiveTimer already started.`);
         }
+        // This error should not happen due to `initializeState` enum, but if it is somehow defined at this point, errors will occur.
+        if (this._synchronizer) {
+            throw new Error(`LiveTimer: _synchronizer already set, which is an unexpected error. Please report this issue at https://aka.ms/teamsliveshare/issue.`);
+        }
+        // Update initialize state as pending
+        this.initializeState = LiveDataObjectInitializeState.pending;
 
         // Save off allowed roles
         this._allowedRoles = allowedRoles || [];
@@ -166,23 +171,29 @@ export class LiveTimer extends LiveDataObject<{
             this.runtime,
             this.liveRuntime
         );
-        await this._synchronizer.start(
-            this._currentConfig.data,
-            async (state, sender) => {
-                // Check for state change.
-                // If it was valid, this will override the local user's previous value.
-                return await this.remoteConfigReceived(state, sender);
-            },
-            async (connecting) => {
-                if (connecting) return true;
-                // If user has eligible roles, allow the update to be sent
-                try {
-                    return await this.verifyLocalUserRoles();
-                } catch {
-                    return false;
+        try {
+            await this._synchronizer.start(
+                this._currentConfig.data,
+                async (state, sender) => {
+                    // Check for state change.
+                    // If it was valid, this will override the local user's previous value.
+                    return await this.remoteConfigReceived(state, sender);
+                },
+                async (connecting) => {
+                    if (connecting) return true;
+                    // If user has eligible roles, allow the update to be sent
+                    try {
+                        return await this.verifyLocalUserRoles();
+                    } catch {
+                        return false;
+                    }
                 }
-            }
-        );
+            );
+        } catch (error: unknown) {
+            // Update initialize state as fatal error
+            this.initializeState = LiveDataObjectInitializeState.fatalError;
+            throw error;
+        }
         // Get the initial remote state, if there is any
         const events = this._synchronizer.getEvents();
         if (!events) return;
@@ -197,6 +208,9 @@ export class LiveTimer extends LiveDataObject<{
             );
             if (didApply) break;
         }
+
+        // Update initialize state as succeeded
+        this.initializeState = LiveDataObjectInitializeState.succeeded;
     }
 
     /**
@@ -214,12 +228,17 @@ export class LiveTimer extends LiveDataObject<{
      *
      * @remarks
      * Starting an already started timer will restart the timer with a new duration.
+     * 
      * @param duration in Milliseconds
-     * @returns a void promise, and will throw if the user does not have the required roles
+     * 
+     * @returns a void promise that resolves once the start event has been sent to the server
+     * 
+     * @throws error if initialization has not yet succeeded.
+     * @throws error if the local user does not have the required roles defined through the `allowedRoles` prop in `.initialize()`.
      */
     public async start(duration: number): Promise<void> {
-        if (!this.isInitialized) {
-            throw new Error(`LiveTimer not started.`);
+        if (this.initializeState !== LiveDataObjectInitializeState.succeeded) {
+            throw new Error(`LiveTimer: not initialized prior to calling \`.start()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`);
         }
 
         await this.playInternal(duration, 0);
@@ -227,14 +246,18 @@ export class LiveTimer extends LiveDataObject<{
 
     /**
      * Resumes the timer.
+     * 
      * @remarks
      * Playing an already playing timer does nothing.
      *
-     * @returns a void promise, and will throw if the user does not have the required roles
+     * @returns a void promise that resolves once the play event has been sent to the server
+     * 
+     * @throws error if initialization has not yet succeeded.
+     * @throws error if the local user does not have the required roles defined through the `allowedRoles` prop in `.initialize()`.
      */
     public async play(): Promise<void> {
-        if (!this.isInitialized) {
-            throw new Error(`LiveTimer not started.`);
+        if (this.initializeState !== LiveDataObjectInitializeState.succeeded) {
+            throw new Error(`LiveTimer: not initialized prior to calling \`.play()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`);
         }
 
         if (
@@ -274,11 +297,14 @@ export class LiveTimer extends LiveDataObject<{
      * @remarks
      * Pausing an already paused timer does nothing.
      *
-     * @returns a void promise, and will throw if the user does not have the required roles
+     * @returns a void promise that resolves once the pause event has been sent to the server
+     * 
+     * @throws error if initialization has not yet succeeded.
+     * @throws error if the local user does not have the required roles defined through the `allowedRoles` prop in `.initialize()`.
      */
     public async pause(): Promise<void> {
-        if (!this.isInitialized) {
-            throw new Error(`LiveTimer not started.`);
+        if (this.initializeState !== LiveDataObjectInitializeState.succeeded) {
+            throw new Error(`LiveTimer: not initialized prior to calling \`.pause()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`);
         }
 
         if (this._currentConfig.data.running) {

--- a/packages/live-share/src/interfaces.ts
+++ b/packages/live-share/src/interfaces.ts
@@ -344,3 +344,25 @@ export type UpdateSynchronizationState<TState> = (
  * @returns return true if the local user can send this update, or false if not.
  */
 export type GetLocalUserCanSend = (connecting: boolean) => Promise<boolean>;
+
+/**
+ * The initialization state for the `LiveDataObject` class.
+ */
+export enum LiveDataObjectInitializeState {
+    /**
+     * The default state when `.initialize()` has not been called and/or a previous call to `.initialize()` failed
+     */
+    needed = "needed",
+    /**
+     * The state when `.initialize()` has been called but has not yet succeeded
+     */
+    pending = "pending",
+    /**
+     * The state when `.initialize()` has succeeded
+     */
+    succeeded = "succeeded",
+    /**
+     * The state when `.initialize()` has a fatal error and `.initialize()` is never expected to succeed
+     */
+    fatalError = "fatalError",
+}

--- a/samples/typescript/04.live-share-react/src/components/ExampleLivePresence.tsx
+++ b/samples/typescript/04.live-share-react/src/components/ExampleLivePresence.tsx
@@ -3,7 +3,15 @@ import { useLivePresence } from "@microsoft/live-share-react";
 import { FC } from "react";
 
 export const ExampleLivePresence: FC = () => {
-    const { localUser, allUsers, updatePresence } = useLivePresence();
+    const { localUser, allUsers, updatePresence, livePresence: v1 } = useLivePresence(
+        "CUSTOM-PRESENCE-KEY",
+        { toggleCount: 0 } // optional
+    );
+    const { livePresence: v2 } = useLivePresence(
+        "CUSTOM-PRESENCE-KEY",
+        { toggleCount: 0 } // optional
+    );
+    console.log(v1 === v2);
     return (
         <div style={{ padding: "24px 12px" }}>
             <h2>{"Users:"}</h2>
@@ -14,13 +22,16 @@ export const ExampleLivePresence: FC = () => {
                         style={{
                             color: user?.state === "offline" ? "red" : "green",
                         }}
-                    >{`${user.displayName}, isLocalUser: ${user.isLocalUser}`}</div>
+                    >{`${user.displayName}, isLocalUser: ${user.isLocalUser}, toggleCount: ${user.data?.toggleCount}`}</div>
                 ))}
             </div>
             <button
                 onClick={() => {
                     updatePresence(
-                        undefined,
+                        {
+                            toggleCount:
+                                (localUser?.data?.toggleCount ?? 0) + 1,
+                        },
                         localUser?.state === PresenceState.offline
                             ? PresenceState.online
                             : PresenceState.offline


### PR DESCRIPTION
- Dynamic DDS's created/fetched through `DynamicObjectManager` are now cached in memory, which helps prevent errors from calling `.initialize()` on two different class instances for the same Fluid object ID on `LiveDataObject` instances that use`ContainerSynchronizer`.
- Implemented new `initializeState` variable in `LiveDataObject`, and changed `isInitialized` to compare against for consistency among `LiveDataObject` instances. Updated `initialize()` functions to update that property accordingly for each `LiveDataObject`.
- Updated Live Share React hooks to check
- Improved error messages for change ops in `LivePresence`, `LiveState`, `LiveEvent`, and `LiveTimer`.
- Improved reference docs in some places.

Sample 04:
![image](https://github.com/microsoft/live-share-sdk/assets/11748606/13b4b791-6f20-429e-a7d1-b8b02261992e)

Sample 21:
![image](https://github.com/microsoft/live-share-sdk/assets/11748606/352fd036-8d6e-4651-9933-007d25f6f2ba)