### PR TITLE
Replay events from other clients that existed before registering DDS

### DIFF
--- a/packages/live-share-canvas/src/core/LiveCanvas.ts
+++ b/packages/live-share-canvas/src/core/LiveCanvas.ts
@@ -881,9 +881,9 @@ export class LiveCanvas extends LiveDataObject {
 
     /**
      * Initializes the live inking session.
-     * 
+     *
      * @param inkingManager The InkingManager instance providing the drawing and events that will be synchronized across clients.
-     * 
+     *
      * @returns a void promise that resolves once complete.
      */
     async initialize(

--- a/packages/live-share-media/src/LiveMediaSession.ts
+++ b/packages/live-share-media/src/LiveMediaSession.ts
@@ -101,11 +101,11 @@ export class LiveMediaSession extends LiveDataObject {
 
     /**
      * Initialize the object to begin sending/receiving group playback updates through this DDS.
-     * 
+     *
      * @param allowedRoles Optional. List of roles allowed to group transport operations like play/pause/seek/setTrack.
-     * 
+     *
      * @returns a void promise that resolves once complete.
-     * 
+     *
      * @throws error when `.initialize()` has already been called for this class instance.
      */
     public async initialize(allowedRoles?: UserMeetingRole[]): Promise<void> {

--- a/packages/live-share-react/src/live-hooks/useLiveEvent.ts
+++ b/packages/live-share-react/src/live-hooks/useLiveEvent.ts
@@ -117,7 +117,9 @@ export function useLiveEvent<TEvent = any>(
             setLatestReceived(received);
         };
         liveEvent.on(LiveEventEvents.received, onEventReceived);
-        if (liveEvent.initializeState === LiveDataObjectInitializeState.needed) {
+        if (
+            liveEvent.initializeState === LiveDataObjectInitializeState.needed
+        ) {
             // Start live event
             liveEvent.initialize(allowedRoles);
         }

--- a/packages/live-share-react/src/live-hooks/useLivePresence.ts
+++ b/packages/live-share-react/src/live-hooks/useLivePresence.ts
@@ -113,7 +113,10 @@ export function useLivePresence<TData extends object = object>(
         };
         livePresence.on("presenceChanged", onPresenceChanged);
 
-        if (livePresence.initializeState === LiveDataObjectInitializeState.needed) {
+        if (
+            livePresence.initializeState ===
+            LiveDataObjectInitializeState.needed
+        ) {
             livePresence.initialize(
                 isInitialDataCallback<TData>(initialData)
                     ? initialData()

--- a/packages/live-share-react/src/live-hooks/useLiveState.ts
+++ b/packages/live-share-react/src/live-hooks/useLiveState.ts
@@ -3,7 +3,11 @@
  * Licensed under the Microsoft Live Share SDK License.
  */
 
-import { LiveDataObjectInitializeState, LiveState, UserMeetingRole } from "@microsoft/live-share";
+import {
+    LiveDataObjectInitializeState,
+    LiveState,
+    UserMeetingRole,
+} from "@microsoft/live-share";
 import React from "react";
 import { SetLiveStateAction } from "../types";
 import { useDynamicDDS } from "../shared-hooks";
@@ -88,7 +92,9 @@ export function useLiveState<TState = any>(
             setCurrentState(state);
         };
         liveState.on("stateChanged", onStateChanged);
-        if (liveState.initializeState === LiveDataObjectInitializeState.needed) {
+        if (
+            liveState.initializeState === LiveDataObjectInitializeState.needed
+        ) {
             liveState.initialize(initialState, allowedRoles);
         }
         if (JSON.stringify(liveState.state) !== JSON.stringify(initialState)) {

--- a/packages/live-share-react/src/live-hooks/useLiveState.ts
+++ b/packages/live-share-react/src/live-hooks/useLiveState.ts
@@ -88,7 +88,6 @@ export function useLiveState<TState = any>(
         if (liveState === undefined) return;
 
         const onStateChanged = (state: TState) => {
-            console.log(state);
             setCurrentState(state);
         };
         liveState.on("stateChanged", onStateChanged);

--- a/packages/live-share-react/src/live-hooks/useLiveTimer.ts
+++ b/packages/live-share-react/src/live-hooks/useLiveTimer.ts
@@ -155,7 +155,9 @@ export function useLiveTimer(
         liveTimer.on(LiveTimerEvents.played, onDidPlay);
         liveTimer.on(LiveTimerEvents.paused, onDidPause);
         liveTimer.on(LiveTimerEvents.onTick, onDidTick);
-        if (liveTimer.initializeState === LiveDataObjectInitializeState.needed) {
+        if (
+            liveTimer.initializeState === LiveDataObjectInitializeState.needed
+        ) {
             // Start live event
             liveTimer.initialize(allowedRoles);
         }

--- a/packages/live-share-react/src/live-hooks/useMediaSynchronizer.ts
+++ b/packages/live-share-react/src/live-hooks/useMediaSynchronizer.ts
@@ -3,7 +3,10 @@
  * Licensed under the Microsoft Live Share SDK License.
  */
 
-import { LiveDataObjectInitializeState, UserMeetingRole } from "@microsoft/live-share";
+import {
+    LiveDataObjectInitializeState,
+    UserMeetingRole,
+} from "@microsoft/live-share";
 import React from "react";
 import {
     CoordinationWaitPoint,
@@ -211,7 +214,10 @@ export function useMediaSynchronizer(
             synchronizer.viewOnly = viewOnly;
         }
 
-        if (mediaSession.initializeState === LiveDataObjectInitializeState.needed) {
+        if (
+            mediaSession.initializeState ===
+            LiveDataObjectInitializeState.needed
+        ) {
             // Start synchronizing the media session
             mediaSession.initialize(allowedRoles ?? []);
         } else if (initialTrack) {

--- a/packages/live-share-turbo/src/dds-objects/DynamicObjectManager.ts
+++ b/packages/live-share-turbo/src/dds-objects/DynamicObjectManager.ts
@@ -36,7 +36,8 @@ export class DynamicObjectManager extends LiveDataObject {
     /**
      * Local memory store for DDS's loaded dynamically.
      */
-    private _dynamicObjectsMap: Map<string, Promise<FluidObject<any>>> = new Map();
+    private _dynamicObjectsMap: Map<string, Promise<FluidObject<any>>> =
+        new Map();
 
     /**
      * The objects fluid type/name.

--- a/packages/live-share/src/LiveDataObject.ts
+++ b/packages/live-share/src/LiveDataObject.ts
@@ -19,8 +19,8 @@ export abstract class LiveDataObject<
      */
     public static LiveEnabled = true;
 
-    
-    private _initializeState: LiveDataObjectInitializeState = LiveDataObjectInitializeState.needed;
+    private _initializeState: LiveDataObjectInitializeState =
+        LiveDataObjectInitializeState.needed;
 
     /**
      * @hidden
@@ -48,7 +48,7 @@ export abstract class LiveDataObject<
 
     /**
      * Flag that indicates whether initialization has succeeded or not.
-     * 
+     *
      * @remarks
      * This field is true when {@link initializeState} is `succeeded`, or false when {@link initializeState} is any other value.
      */
@@ -58,7 +58,7 @@ export abstract class LiveDataObject<
 
     /**
      * The initialization status of the data object.
-     * 
+     *
      * @remarks
      * Used to know whether it is safe to call `.initialize()`
      */

--- a/packages/live-share/src/LiveEvent.ts
+++ b/packages/live-share/src/LiveEvent.ts
@@ -5,7 +5,12 @@
 
 import { DataObjectFactory } from "@fluidframework/aqueduct";
 import { IEvent } from "@fluidframework/common-definitions";
-import { UserMeetingRole, IClientTimestamp, ILiveEvent, LiveDataObjectInitializeState } from "./interfaces";
+import {
+    UserMeetingRole,
+    IClientTimestamp,
+    ILiveEvent,
+    LiveDataObjectInitializeState,
+} from "./interfaces";
 import { LiveEventScope } from "./LiveEventScope";
 import { LiveEventTarget } from "./LiveEventTarget";
 import { DynamicObjectRegistry } from "./DynamicObjectRegistry";
@@ -80,15 +85,15 @@ export class LiveEvent<TEvent = any> extends LiveDataObject<{
 
     /**
      * Initialize the object to begin sending/receiving events through this DDS.
-     * 
+     *
      * @remarks
      * You should register `received` event listeners before calling this function to ensure no incoming events are missed.
      * `received` events will not be emitted until after this function is called.
-     * 
+     *
      * @param allowedRoles Optional. List of roles allowed to send events.
-     * 
+     *
      * @returns a void promise that resolves once complete.
-     * 
+     *
      * @throws error when `.initialize()` has already been called for this class instance.
      */
     public initialize(allowedRoles?: UserMeetingRole[]): Promise<void> {
@@ -127,21 +132,25 @@ export class LiveEvent<TEvent = any> extends LiveDataObject<{
      *
      * @remarks
      * The event will be queued for delivery if the client isn't currently connected.
-     * 
+     *
      * @param evt Event to send. If omitted, an event will still be sent but it won't include any custom event data.
-     * 
+     *
      * @returns A promise with the full event object that was sent, including the timestamp of when the event was sent and the clientId if known.
      * The clientId will be `undefined` if the client is disconnected at time of delivery.
-     * 
+     *
      * @throws error if initialization has not yet succeeded.
      * @throws error if the local user does not have the required roles defined through the `allowedRoles` prop in `.initialize()`.
      */
     public async send(evt: TEvent): Promise<ILiveEvent<TEvent>> {
         if (this.initializeState !== LiveDataObjectInitializeState.succeeded) {
-            throw new Error(`LiveEvent: not initialized prior to calling \`.send()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`);
+            throw new Error(
+                `LiveEvent: not initialized prior to calling \`.send()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`
+            );
         }
         if (!this._eventTarget) {
-            throw new Error(`LiveEvent: this._eventTarget is undefined, implying there was an error during initialization that should not occur. Please report this issue at https://aka.ms/teamsliveshare/issue.`)
+            throw new Error(
+                `LiveEvent: this._eventTarget is undefined, implying there was an error during initialization that should not occur. Please report this issue at https://aka.ms/teamsliveshare/issue.`
+            );
         }
 
         return await this._eventTarget.sendEvent(evt);

--- a/packages/live-share/src/LivePresence.ts
+++ b/packages/live-share/src/LivePresence.ts
@@ -176,12 +176,6 @@ export class LivePresence<
             this._currentPresence!.data.data,
             this._currentPresence!.data.state
         ).catch(() => {});
-        // Update remote user initial presence for existing values
-        this._synchronizer!.getEvents()?.forEach((evt) => {
-            if (evt.clientId === this._currentPresence!.clientId) return;
-            // Add user to list or silently fail trying
-            this.updateMembersList(evt, false).catch(() => {});
-        });
     }
 
     /**

--- a/packages/live-share/src/LivePresence.ts
+++ b/packages/live-share/src/LivePresence.ts
@@ -16,7 +16,11 @@ import { LiveTelemetryLogger } from "./LiveTelemetryLogger";
 import { cloneValue, TelemetryEvents } from "./internals";
 import { TimeInterval } from "./TimeInterval";
 import { DynamicObjectRegistry } from "./DynamicObjectRegistry";
-import { IClientInfo, ILiveEvent, LiveDataObjectInitializeState, UserMeetingRole } from "./interfaces";
+import {
+    IClientInfo,
+    LiveDataObjectInitializeState,
+    UserMeetingRole,
+} from "./interfaces";
 import { LiveDataObject } from "./LiveDataObject";
 
 /**
@@ -114,13 +118,13 @@ export class LivePresence<
 
     /**
      * Initialize the object to begin sending/receiving presence updates through this DDS.
-     * 
+     *
      * @param data Optional. Custom data object to share. A deep copy of the data object is saved to avoid any accidental modifications.
      * @param state Optional. Initial presence state. Defaults to `PresenceState.online`.
      * @param allowedRoles Optional. List of roles allowed to emit presence changes.
-     * 
+     *
      * @returns a void promise that resolves once complete.
-     * 
+     *
      * @throws error when `.initialize()` has already been called for this class instance.
      * @throws fatal error when `.initialize()` has already been called for an object of same id but with a different class instance.
      * This is most common when using dynamic objects through Fluid.
@@ -135,7 +139,9 @@ export class LivePresence<
         }
         // This error should not happen due to `initializeState` enum, but if it is somehow defined at this point, errors will occur.
         if (this._synchronizer) {
-            throw new Error(`LivePresence: _synchronizer already set, which is an unexpected error. Please report this issue at https://aka.ms/teamsliveshare/issue.`);
+            throw new Error(
+                `LivePresence: _synchronizer already set, which is an unexpected error. Please report this issue at https://aka.ms/teamsliveshare/issue.`
+            );
         }
         // Update initialize state as pending
         this.initializeState = LiveDataObjectInitializeState.pending;
@@ -219,24 +225,30 @@ export class LivePresence<
      *
      * @remarks
      * This will trigger the immediate broadcast of the users presence to all other clients.
-     * 
+     *
      * @param data Optional. Data object to change. A deep copy of the data object is saved to avoid any future changes.
      * @param state Optional. Presence state to change.
-     * 
+     *
      * @returns a void promise that resolves once the update event has been sent to the server.
-     * 
+     *
      * @throws error if initialization has not yet succeeded.
      * @throws error if the local user does not have the required roles defined through the `allowedRoles` prop in `.initialize()`.
      */
     public async update(data?: TData, state?: PresenceState): Promise<void> {
         if (this.initializeState !== LiveDataObjectInitializeState.succeeded) {
-            throw new Error(`LivePresence: not initialized prior to calling \`.update()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`);
+            throw new Error(
+                `LivePresence: not initialized prior to calling \`.update()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`
+            );
         }
         if (!this._synchronizer) {
-            throw new Error(`LivePresence: this._synchronizer is undefined, implying there was an error during initialization that should not occur. Please report this issue at https://aka.ms/teamsliveshare/issue.`);
+            throw new Error(
+                `LivePresence: this._synchronizer is undefined, implying there was an error during initialization that should not occur. Please report this issue at https://aka.ms/teamsliveshare/issue.`
+            );
         }
         if (!this._currentPresence) {
-            throw new Error(`LivePresence: this._currentPresence is undefined, implying there was an error during initialization that should not occur. Please report this issue at https://aka.ms/teamsliveshare/issue.`);
+            throw new Error(
+                `LivePresence: this._currentPresence is undefined, implying there was an error during initialization that should not occur. Please report this issue at https://aka.ms/teamsliveshare/issue.`
+            );
         }
 
         // Broadcast state change

--- a/packages/live-share/src/LiveShareClient.ts
+++ b/packages/live-share/src/LiveShareClient.ts
@@ -87,10 +87,14 @@ export class LiveShareClient {
     constructor(host: ILiveShareHost, options?: ILiveShareClientOptions) {
         // Validate host passed in
         if (!host) {
-            throw new Error(`LiveShareClient: prop \`host\` is \`${host}\` when it is expected to be a non-optional value of type \`ILiveShareHost\`. Please ensure \`host\` is defined before initializing \`LiveShareClient\`.`);
+            throw new Error(
+                `LiveShareClient: prop \`host\` is \`${host}\` when it is expected to be a non-optional value of type \`ILiveShareHost\`. Please ensure \`host\` is defined before initializing \`LiveShareClient\`.`
+            );
         }
         if (typeof host.getFluidTenantInfo != "function") {
-            throw new Error(`LiveShareClient: \`host.getFluidTenantInfo\` is of type \`${typeof host.getFluidTenantInfo}\` when it is expected to be a type of \`function\`. For more information, review the \`ILiveShareHost\` interface.`);
+            throw new Error(
+                `LiveShareClient: \`host.getFluidTenantInfo\` is of type \`${typeof host.getFluidTenantInfo}\` when it is expected to be a type of \`function\`. For more information, review the \`ILiveShareHost\` interface.`
+            );
         }
         this._host = host;
         // Save options

--- a/packages/live-share/src/LiveState.ts
+++ b/packages/live-share/src/LiveState.ts
@@ -144,18 +144,6 @@ export class LiveState<TState = any> extends LiveDataObject<{
                 }
             }
         );
-        // Get the initial remote state, if there is any
-        const events = this._synchronizer.getEvents();
-        if (!events) return;
-        for (let eIndex = 0; eIndex < events.length; eIndex++) {
-            const event = events[eIndex];
-            const didApply = await this.onReceivedStateEvent(
-                event,
-                event.clientId,
-                event.clientId === (await this.waitUntilConnected())
-            );
-            if (didApply) break;
-        }
     }
 
     /**

--- a/packages/live-share/src/LiveState.ts
+++ b/packages/live-share/src/LiveState.ts
@@ -6,7 +6,11 @@
 import { DataObjectFactory } from "@fluidframework/aqueduct";
 import { assert } from "@fluidframework/common-utils";
 import { IEvent } from "@fluidframework/common-definitions";
-import { ILiveEvent, LiveDataObjectInitializeState, UserMeetingRole } from "./interfaces";
+import {
+    ILiveEvent,
+    LiveDataObjectInitializeState,
+    UserMeetingRole,
+} from "./interfaces";
 import { cloneValue, TelemetryEvents } from "./internals";
 import { LiveTelemetryLogger } from "./LiveTelemetryLogger";
 import { LiveEvent } from "./LiveEvent";
@@ -90,12 +94,12 @@ export class LiveState<TState = any> extends LiveDataObject<{
 
     /**
      * Initialize the object to begin sending/receiving state updates through this DDS.
-     * 
+     *
      * @param initialState Initial state value
      * @param allowedRoles Optional. List of roles allowed to make state changes.
-     * 
+     *
      * @returns a void promise that resolves once complete
-     * 
+     *
      * @throws error when `.initialize()` has already been called for this class instance.
      * @throws fatal error when `.initialize()` has already been called for an object of same id but with a different class instance.
      * This is most common when using dynamic objects through Fluid.
@@ -109,7 +113,9 @@ export class LiveState<TState = any> extends LiveDataObject<{
         }
         // This error should not happen due to `initializeState` enum, but if it is somehow defined at this point, errors will occur.
         if (this._synchronizer) {
-            throw new Error(`LiveState: _synchronizer already set, which is an unexpected error. Please report this issue at https://aka.ms/teamsliveshare/issue.`);
+            throw new Error(
+                `LiveState: _synchronizer already set, which is an unexpected error. Please report this issue at https://aka.ms/teamsliveshare/issue.`
+            );
         }
         // Update initialize state as pending
         this.initializeState = LiveDataObjectInitializeState.pending;
@@ -172,17 +178,19 @@ export class LiveState<TState = any> extends LiveDataObject<{
 
     /**
      * Set a new state value
-     * 
+     *
      * @param state New state value.
-     * 
+     *
      * @returns a void promise that resolves once the set event has been sent to the server.
-     * 
+     *
      * @throws error if initialization has not yet succeeded.
      * @throws error if the local user does not have the required roles defined through the `allowedRoles` prop in `.initialize()`.
      */
     public async set(state: TState): Promise<void> {
         if (this.initializeState !== LiveDataObjectInitializeState.succeeded) {
-            throw new Error(`LiveState: not initialized prior to calling \`.set()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`);
+            throw new Error(
+                `LiveState: not initialized prior to calling \`.set()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`
+            );
         }
 
         // Broadcast state change

--- a/packages/live-share/src/LiveTimer.ts
+++ b/packages/live-share/src/LiveTimer.ts
@@ -5,7 +5,12 @@
 
 import { DataObjectFactory } from "@fluidframework/aqueduct";
 import { LiveObjectSynchronizer } from "./LiveObjectSynchronizer";
-import { IClientTimestamp, ILiveEvent, LiveDataObjectInitializeState, UserMeetingRole } from "./interfaces";
+import {
+    IClientTimestamp,
+    ILiveEvent,
+    LiveDataObjectInitializeState,
+    UserMeetingRole,
+} from "./interfaces";
 import { IEvent } from "@fluidframework/common-definitions";
 import { LiveEvent } from "./LiveEvent";
 import { DynamicObjectRegistry } from "./DynamicObjectRegistry";
@@ -142,11 +147,11 @@ export class LiveTimer extends LiveDataObject<{
 
     /**
      * Initialize the object to begin sending/receiving timer updates through this DDS.
-     * 
+     *
      * @param allowedRoles Optional. List of roles allowed to make state changes.
-     * 
+     *
      * @returns a void promise that resolves once complete.
-     * 
+     *
      * @throws error when `.initialize()` has already been called for this class instance.
      * @throws fatal error when `.initialize()` has already been called for an object of same id but with a different class instance.
      * This is most common when using dynamic objects through Fluid.
@@ -216,17 +221,19 @@ export class LiveTimer extends LiveDataObject<{
      *
      * @remarks
      * Starting an already started timer will restart the timer with a new duration.
-     * 
+     *
      * @param duration in Milliseconds
-     * 
+     *
      * @returns a void promise that resolves once the start event has been sent to the server
-     * 
+     *
      * @throws error if initialization has not yet succeeded.
      * @throws error if the local user does not have the required roles defined through the `allowedRoles` prop in `.initialize()`.
      */
     public async start(duration: number): Promise<void> {
         if (this.initializeState !== LiveDataObjectInitializeState.succeeded) {
-            throw new Error(`LiveTimer: not initialized prior to calling \`.start()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`);
+            throw new Error(
+                `LiveTimer: not initialized prior to calling \`.start()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`
+            );
         }
 
         await this.playInternal(duration, 0);
@@ -234,18 +241,20 @@ export class LiveTimer extends LiveDataObject<{
 
     /**
      * Resumes the timer.
-     * 
+     *
      * @remarks
      * Playing an already playing timer does nothing.
      *
      * @returns a void promise that resolves once the play event has been sent to the server
-     * 
+     *
      * @throws error if initialization has not yet succeeded.
      * @throws error if the local user does not have the required roles defined through the `allowedRoles` prop in `.initialize()`.
      */
     public async play(): Promise<void> {
         if (this.initializeState !== LiveDataObjectInitializeState.succeeded) {
-            throw new Error(`LiveTimer: not initialized prior to calling \`.play()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`);
+            throw new Error(
+                `LiveTimer: not initialized prior to calling \`.play()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`
+            );
         }
 
         if (
@@ -286,13 +295,15 @@ export class LiveTimer extends LiveDataObject<{
      * Pausing an already paused timer does nothing.
      *
      * @returns a void promise that resolves once the pause event has been sent to the server
-     * 
+     *
      * @throws error if initialization has not yet succeeded.
      * @throws error if the local user does not have the required roles defined through the `allowedRoles` prop in `.initialize()`.
      */
     public async pause(): Promise<void> {
         if (this.initializeState !== LiveDataObjectInitializeState.succeeded) {
-            throw new Error(`LiveTimer: not initialized prior to calling \`.pause()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`);
+            throw new Error(
+                `LiveTimer: not initialized prior to calling \`.pause()\`. \`initializeState\` is \`${this.initializeState}\` but should be \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`
+            );
         }
 
         if (this._currentConfig.data.running) {

--- a/packages/live-share/src/LiveTimer.ts
+++ b/packages/live-share/src/LiveTimer.ts
@@ -183,20 +183,6 @@ export class LiveTimer extends LiveDataObject<{
                 }
             }
         );
-        // Get the initial remote state, if there is any
-        const events = this._synchronizer.getEvents();
-        if (!events) return;
-        for (let eIndex = 0; eIndex < events.length; eIndex++) {
-            const event = events[eIndex];
-            const didApply = await this.remoteConfigReceived(
-                {
-                    ...event,
-                    clientId: event.clientId,
-                },
-                event.clientId
-            );
-            if (didApply) break;
-        }
     }
 
     /**

--- a/packages/live-share/src/internals/ContainerSynchronizer.ts
+++ b/packages/live-share/src/internals/ContainerSynchronizer.ts
@@ -25,7 +25,7 @@ export class ContainerSynchronizer {
     private _onReceiveObjectUpdateListener?: (
         objectId: string,
         event: ILiveEvent<any>,
-        local: boolean,
+        local: boolean
     ) => Promise<void>;
     private _onSendUpdatesIntervalCallback?: () => Promise<void>;
 
@@ -64,7 +64,7 @@ export class ContainerSynchronizer {
             this.onReceiveUpdate(
                 id,
                 event,
-                event.clientId === this._runtime.clientId,
+                event.clientId === this._runtime.clientId
             );
         });
 
@@ -271,7 +271,7 @@ export class ContainerSynchronizer {
     private async onReceiveUpdate(
         objectId: string,
         event: ILiveEvent<any>,
-        local: boolean,
+        local: boolean
     ): Promise<void> {
         const handler = this._objects.get(objectId);
         if (!handler) return;
@@ -281,10 +281,13 @@ export class ContainerSynchronizer {
             local
         );
         if (!overwriteForLocal) return;
-        this._objectStore.updateEventLocallyInStore.bind(this._objectStore)(objectId, {
-            ...event,
-            clientId: await this.waitUntilConnected(),
-        });
+        this._objectStore.updateEventLocallyInStore.bind(this._objectStore)(
+            objectId,
+            {
+                ...event,
+                clientId: await this.waitUntilConnected(),
+            }
+        );
     }
 
     /**

--- a/packages/live-share/src/internals/ContainerSynchronizer.ts
+++ b/packages/live-share/src/internals/ContainerSynchronizer.ts
@@ -274,18 +274,17 @@ export class ContainerSynchronizer {
         local: boolean,
     ): Promise<void> {
         const handler = this._objects.get(objectId);
-        if (handler) {
-            const overwriteForLocal = await handler.updateState(
-                event,
-                event.clientId,
-                local
-            );
-            if (!overwriteForLocal) return;
-            this._objectStore.updateEventLocallyInStore.bind(this._objectStore)(objectId, {
-                ...event,
-                clientId: await this.waitUntilConnected(),
-            });
-        }
+        if (!handler) return;
+        const overwriteForLocal = await handler.updateState(
+            event,
+            event.clientId,
+            local
+        );
+        if (!overwriteForLocal) return;
+        this._objectStore.updateEventLocallyInStore.bind(this._objectStore)(objectId, {
+            ...event,
+            clientId: await this.waitUntilConnected(),
+        });
     }
 
     /**

--- a/packages/live-share/src/internals/LiveObjectManager.ts
+++ b/packages/live-share/src/internals/LiveObjectManager.ts
@@ -264,7 +264,7 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
                 ObjectSynchronizerEvents.update,
                 id,
                 cloneValue(receivedEvent),
-                local,
+                local
             );
         }
     }
@@ -272,7 +272,7 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
     /**
      * @hidden
      * Updates the local event in memory for a given clientId
-     * 
+     *
      * @returns true if it was inserted, or false if it was skipped because the event is older
      */
     public updateEventLocallyInStore(

--- a/packages/live-share/src/internals/LiveObjectManager.ts
+++ b/packages/live-share/src/internals/LiveObjectManager.ts
@@ -106,6 +106,10 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
             data: initialState,
             name: ObjectSynchronizerEvents.update,
         };
+
+        // const event = this.getLatestEventForObject(id) ?? initialEvent;
+        // event.clientId = await waitUntilConnected(runtime);
+
         this.updateEventLocallyInStore(id, initialEvent);
     }
 
@@ -272,7 +276,7 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
     /**
      * @returns true if it was inserted, or false if it was skipped because the event is older
      */
-    private updateEventLocallyInStore(
+    public updateEventLocallyInStore(
         objectId: string,
         event: ILiveEvent<any>
     ): boolean {

--- a/packages/live-share/src/internals/LiveObjectManager.ts
+++ b/packages/live-share/src/internals/LiveObjectManager.ts
@@ -107,10 +107,7 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
             name: ObjectSynchronizerEvents.update,
         };
 
-        // const event = this.getLatestEventForObject(id) ?? initialEvent;
-        // event.clientId = await waitUntilConnected(runtime);
-
-        const didUpdate = this.updateEventLocallyInStore(id, initialEvent);
+        this.updateEventLocallyInStore(id, initialEvent);
     }
 
     /**

--- a/packages/live-share/src/internals/LiveObjectManager.ts
+++ b/packages/live-share/src/internals/LiveObjectManager.ts
@@ -110,7 +110,7 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
         // const event = this.getLatestEventForObject(id) ?? initialEvent;
         // event.clientId = await waitUntilConnected(runtime);
 
-        this.updateEventLocallyInStore(id, initialEvent);
+        const didUpdate = this.updateEventLocallyInStore(id, initialEvent);
     }
 
     /**
@@ -268,12 +268,14 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
                 id,
                 cloneValue(receivedEvent),
                 local,
-                this.updateEventLocallyInStore.bind(this)
             );
         }
     }
 
     /**
+     * @hidden
+     * Updates the local event in memory for a given clientId
+     * 
      * @returns true if it was inserted, or false if it was skipped because the event is older
      */
     public updateEventLocallyInStore(

--- a/samples/typescript/04.live-share-react/src/components/ExampleLivePresence.tsx
+++ b/samples/typescript/04.live-share-react/src/components/ExampleLivePresence.tsx
@@ -3,7 +3,12 @@ import { useLivePresence } from "@microsoft/live-share-react";
 import { FC } from "react";
 
 export const ExampleLivePresence: FC = () => {
-    const { localUser, allUsers, updatePresence, livePresence: v1 } = useLivePresence(
+    const {
+        localUser,
+        allUsers,
+        updatePresence,
+        livePresence: v1,
+    } = useLivePresence(
         "CUSTOM-PRESENCE-KEY",
         { toggleCount: 0 } // optional
     );


### PR DESCRIPTION
* Play back the most recent cached event for each clientId to get the initial remote state. This fixes initial state issues on the local client.
* ran `npm run doctor`