### PR TITLE
Exposed getClientInfo in LiveDataObject

### DIFF
--- a/packages/live-share/src/LiveDataObject.ts
+++ b/packages/live-share/src/LiveDataObject.ts
@@ -5,7 +5,11 @@ import {
 } from "@fluidframework/aqueduct";
 import { LiveShareRuntime } from "./LiveShareRuntime";
 import { assert } from "@fluidframework/common-utils";
-import { LiveDataObjectInitializeState, UserMeetingRole } from "./interfaces";
+import {
+    IClientInfo,
+    LiveDataObjectInitializeState,
+    UserMeetingRole,
+} from "./interfaces";
 import { waitUntilConnected } from "./internals";
 
 /**
@@ -72,6 +76,15 @@ export abstract class LiveDataObject<
 
     public constructor(props: IDataObjectProps<I>) {
         super(props);
+    }
+
+    /**
+     * Get the client info for a given clientId
+     * @param clientId Fluid clientId we are requesting user info for
+     * @returns IClientInfo object if the user is known, otherwise it will return undefined
+     */
+    public getClientInfo(clientId: string): Promise<IClientInfo | undefined> {
+        return this.liveRuntime.getClientInfo(clientId);
     }
 
     /**

--- a/packages/live-share/src/test/LiveState.spec.ts
+++ b/packages/live-share/src/test/LiveState.spec.ts
@@ -109,7 +109,6 @@ describeNoCompat("LiveState", (getTestObjectProvider) => {
         });
 
         const object2done = new Deferred();
-        let object2ConnectReceived = false;
         object2.on("stateChanged", (state, local) => {
             try {
                 if (!local) {

--- a/samples/javascript/01.dice-roller/src/renderMeetingStage.js
+++ b/samples/javascript/01.dice-roller/src/renderMeetingStage.js
@@ -11,6 +11,7 @@ export async function renderMeetingStage(container, elem, theme) {
     stageTemplate["innerHTML"] = `
     <div class="wrapper ${theme} stage">
         <div class="dice"></div>
+        <p class="lastChangedBy"></p>
         <button class="roll">Roll</button>
         <div class="divider"></div>
         <h2>Users:</h2>
@@ -27,14 +28,21 @@ export async function renderMeetingStage(container, elem, theme) {
 async function renderSharedDice(diceState, wrapperElem) {
     const rollButton = wrapperElem.querySelector(".roll");
     const diceElem = wrapperElem.querySelector(".dice");
+    const lastChangedByText = wrapperElem.querySelector(".lastChangedBy");
 
     // Set the value at our dataKey with a random number between 1 and 6.
     rollButton.onclick = () => diceState.set(getRandomDiceValue());
 
     // Get the current value of the shared data to update the view whenever it changes.
-    const updateDice = () => {
-        const diceValue = diceState.state;
-        stylizeDiceElem(diceElem, diceValue);
+    const updateDice = (data, local, clientId) => {
+        stylizeDiceElem(diceElem, data);
+        if (local) {
+            lastChangedByText.textContent = `Last changed by: You`;
+        } else {
+            diceState.getClientInfo(clientId).then((clientInfo) => {
+                lastChangedByText.textContent = `Last changed by: ${clientInfo?.displayName}`;
+            });
+        }
     };
 
     // Use the changed event to trigger the rerender whenever the value changes.
@@ -45,7 +53,8 @@ async function renderSharedDice(diceState, wrapperElem) {
     await diceState.initialize(1, allowedRoles);
 
     // Render initial dice value
-    updateDice();
+    const diceValue = diceState.state;
+    stylizeDiceElem(diceElem, diceValue);
 }
 
 async function renderPresenceDiceList(presence, wrapperElem) {


### PR DESCRIPTION
Addresses #713

Exposed `getClientInfo` in `LiveDataObject`, which will allow the user to query information about other clients without the need for LivePresence.

Updated dice sample to show how it might be used to show the `displayName` of who most recently rolled the dice.
<img width="450" alt="image" src="https://github.com/microsoft/live-share-sdk/assets/10103298/014f9266-8163-4983-aa25-fb5a7c898cbe">

<img width="449" alt="image" src="https://github.com/microsoft/live-share-sdk/assets/10103298/c5d79e43-1cbe-47ac-a0e4-30883ee04621">
