### PR TITLE
canSendBackgroundUpdates setting for LiveShareRuntime / ContainerSynchronizer

### DIFF
--- a/packages/live-share-turbo/src/FluidTurboClient.ts
+++ b/packages/live-share-turbo/src/FluidTurboClient.ts
@@ -53,6 +53,7 @@ export abstract class FluidTurboClient implements IFluidTurboClient {
      * @remarks
      * This is useful for scenarios where there are a large number of participants in a session, since service performance degrades as more socket connections are opened.
      * Intended for use when a small number of users are intended to be "in control", such as the `LiveFollowMode` class's `startPresenting()` feature.
+     * There should always be at least one user in the session that has `canSendBackgroundUpdates` set to true.
      * Set to true when the user is eligible to send background updates (e.g., "in control"), or false when that user is not in control.
      * This setting will not prevent the local user from explicitly changing the state of objects using `LiveObjectSynchronizer`, such as `.set()` in `LiveState`.
      * Impacts background updates of `LiveState`, `LivePresence`, `LiveTimer`, and `LiveFollowMode`.

--- a/packages/live-share-turbo/src/FluidTurboClient.ts
+++ b/packages/live-share-turbo/src/FluidTurboClient.ts
@@ -46,6 +46,21 @@ export abstract class FluidTurboClient implements IFluidTurboClient {
         return undefined;
     }
 
+    /**
+     * Setting for whether `LiveDataObject` instances using `LiveObjectSynchronizer` can send background updates.
+     * Default value is `true`.
+     *
+     * @remarks
+     * This is useful for scenarios where there are a large number of participants in a session, since service performance degrades as more socket connections are opened.
+     * Intended for use when a small number of users are intended to be "in control", such as the `LiveFollowMode` class's `startPresenting()` feature.
+     * Set to true when the user is eligible to send background updates (e.g., "in control"), or false when that user is not in control.
+     * This setting will not prevent the local user from explicitly changing the state of objects using `LiveObjectSynchronizer`, such as `.set()` in `LiveState`.
+     * Impacts background updates of `LiveState`, `LivePresence`, `LiveTimer`, and `LiveFollowMode`.
+     */
+    public abstract get canSendBackgroundUpdates(): boolean;
+
+    public abstract set canSendBackgroundUpdates(value: boolean);
+
     private get dynamicObjects(): DynamicObjectManager | undefined {
         if (this.results) {
             return this.results.container.initialObjects

--- a/packages/live-share-turbo/src/LiveShareTurboClient.ts
+++ b/packages/live-share-turbo/src/LiveShareTurboClient.ts
@@ -61,6 +61,25 @@ export class LiveShareTurboClient extends FluidTurboClient {
     }
 
     /**
+     * Setting for whether `LiveDataObject` instances using `LiveObjectSynchronizer` can send background updates.
+     * Default value is `true`.
+     *
+     * @remarks
+     * This is useful for scenarios where there are a large number of participants in a session, since service performance degrades as more socket connections are opened.
+     * Intended for use when a small number of users are intended to be "in control", such as the `LiveFollowMode` class's `startPresenting()` feature.
+     * Set to true when the user is eligible to send background updates (e.g., "in control"), or false when that user is not in control.
+     * This setting will not prevent the local user from explicitly changing the state of objects using `LiveObjectSynchronizer`, such as `.set()` in `LiveState`.
+     * Impacts background updates of `LiveState`, `LivePresence`, `LiveTimer`, and `LiveFollowMode`.
+     */
+    public get canSendBackgroundUpdates(): boolean {
+        return this._client.canSendBackgroundUpdates;
+    }
+
+    public set canSendBackgroundUpdates(value: boolean) {
+        this._client.canSendBackgroundUpdates = value;
+    }
+
+    /**
      * Connects to the fluid container for the current teams context.
      *
      * @remarks

--- a/packages/live-share-turbo/src/interfaces/IFluidTurboClient.ts
+++ b/packages/live-share-turbo/src/interfaces/IFluidTurboClient.ts
@@ -12,6 +12,19 @@ export interface IFluidTurboClient {
      */
     get stateMap(): SharedMap | undefined;
     /**
+     * Setting for whether `LiveDataObject` instances using `LiveObjectSynchronizer` can send background updates.
+     * Default value is `true`.
+     *
+     * @remarks
+     * This is useful for scenarios where there are a large number of participants in a session, since service performance degrades as more socket connections are opened.
+     * Intended for use when a small number of users are intended to be "in control", such as the `LiveFollowMode` class's `startPresenting()` feature.
+     * Set to true when the user is eligible to send background updates (e.g., "in control"), or false when that user is not in control.
+     * This setting will not prevent the local user from explicitly changing the state of objects using `LiveObjectSynchronizer`, such as `.set()` in `LiveState`.
+     * Impacts background updates of `LiveState`, `LivePresence`, `LiveTimer`, and `LiveFollowMode`.
+     */
+    get canSendBackgroundUpdates(): boolean;
+    set canSendBackgroundUpdates(value: boolean);
+    /**
      * Callback to load a Fluid DDS for a given key. If the object does not already exist, a new one will be created.
      *
      * @template T Type of Fluid object to load.

--- a/packages/live-share-turbo/src/interfaces/IFluidTurboClient.ts
+++ b/packages/live-share-turbo/src/interfaces/IFluidTurboClient.ts
@@ -18,6 +18,7 @@ export interface IFluidTurboClient {
      * @remarks
      * This is useful for scenarios where there are a large number of participants in a session, since service performance degrades as more socket connections are opened.
      * Intended for use when a small number of users are intended to be "in control", such as the `LiveFollowMode` class's `startPresenting()` feature.
+     * There should always be at least one user in the session that has `canSendBackgroundUpdates` set to true.
      * Set to true when the user is eligible to send background updates (e.g., "in control"), or false when that user is not in control.
      * This setting will not prevent the local user from explicitly changing the state of objects using `LiveObjectSynchronizer`, such as `.set()` in `LiveState`.
      * Impacts background updates of `LiveState`, `LivePresence`, `LiveTimer`, and `LiveFollowMode`.

--- a/packages/live-share-turbo/src/test/AzureTurboClient.spec.ts
+++ b/packages/live-share-turbo/src/test/AzureTurboClient.spec.ts
@@ -18,7 +18,7 @@ import { InsecureTokenProvider } from "@fluidframework/test-client-utils";
 import { generateUser } from "@fluidframework/server-services-client";
 import { LiveEvent } from "@microsoft/live-share";
 
-describe("LiveShareTurboClient", () => {
+describe("AzureTurboClient", () => {
     (window.performance as any).mark = () => {
         return {};
     };
@@ -31,12 +31,8 @@ describe("LiveShareTurboClient", () => {
         endpoint: "http://localhost:7070",
         type: "local",
     };
-    const client1 = new AzureTurboClient({
-        connection: connectionProps,
-    });
-    const client2 = new AzureTurboClient({
-        connection: connectionProps,
-    });
+    let client1: AzureTurboClient;
+    let client2: AzureTurboClient;
 
     const testMapKey = "TEST-MAP-KEY";
     const testLiveEventKey = "TEST-LIVE-EVENT-KEY";
@@ -50,6 +46,12 @@ describe("LiveShareTurboClient", () => {
     };
 
     beforeEach(async () => {
+        client1 = new AzureTurboClient({
+            connection: connectionProps,
+        });
+        client2 = new AzureTurboClient({
+            connection: connectionProps,
+        });
         const initialObjects: LoadableObjectClassRecord = {
             [testLiveEventKey]: LiveEvent,
         };

--- a/packages/live-share-turbo/src/test/LiveShareTurboClient.spec.ts
+++ b/packages/live-share-turbo/src/test/LiveShareTurboClient.spec.ts
@@ -29,8 +29,8 @@ describe("LiveShareTurboClient", () => {
         containerId = newContainerId;
     };
     const host = TestLiveShareHost.create(getContainerId, setContainerId);
-    const client1 = new LiveShareTurboClient(host);
-    const client2 = new LiveShareTurboClient(host);
+    let client1: LiveShareTurboClient;
+    let client2: LiveShareTurboClient;
 
     const testMapKey = "TEST-MAP-KEY";
     const testLiveEventKey = "TEST-LIVE-EVENT-KEY";
@@ -46,6 +46,8 @@ describe("LiveShareTurboClient", () => {
     };
 
     beforeEach(async () => {
+        client1 = new LiveShareTurboClient(host);
+        client2 = new LiveShareTurboClient(host);
         const initialObjects: LoadableObjectClassRecord = {
             [testLiveEventKey]: LiveEvent,
         };

--- a/packages/live-share/src/LiveShareClient.ts
+++ b/packages/live-share/src/LiveShareClient.ts
@@ -75,6 +75,7 @@ export interface ILiveShareClientOptions {
      * @remarks
      * This is useful for scenarios where there are a large number of participants in a session, since service performance degrades as more socket connections are opened.
      * Intended for use when a small number of users are intended to be "in control", such as the `LiveFollowMode` class's `startPresenting()` feature.
+     * There should always be at least one user in the session that has `canSendBackgroundUpdates` set to true.
      * Set to true when the user is eligible to send background updates (e.g., "in control"), or false when that user is not in control.
      * This setting will not prevent the local user from explicitly changing the state of objects using `LiveObjectSynchronizer`, such as `.set()` in `LiveState`.
      * Impacts background updates of `LiveState`, `LivePresence`, `LiveTimer`, and `LiveFollowMode`.
@@ -142,6 +143,7 @@ export class LiveShareClient {
      * @remarks
      * This is useful for scenarios where there are a large number of participants in a session, since service performance degrades as more socket connections are opened.
      * Intended for use when a small number of users are intended to be "in control", such as the `LiveFollowMode` class's `startPresenting()` feature.
+     * There should always be at least one user in the session that has `canSendBackgroundUpdates` set to true.
      * Set to true when the user is eligible to send background updates (e.g., "in control"), or false when that user is not in control.
      * This setting will not prevent the local user from explicitly changing the state of objects using `LiveObjectSynchronizer`, such as `.set()` in `LiveState`.
      * Impacts background updates of `LiveState`, `LivePresence`, `LiveTimer`, and `LiveFollowMode`.

--- a/packages/live-share/src/LiveShareRuntime.ts
+++ b/packages/live-share/src/LiveShareRuntime.ts
@@ -91,6 +91,7 @@ export class LiveShareRuntime {
      * @remarks
      * This is useful for scenarios where there are a large number of participants in a session, since service performance degrades as more socket connections are opened.
      * Intended for use when a small number of users are intended to be "in control", such as the `LiveFollowMode` class's `startPresenting()` feature.
+     * There should always be at least one user in the session that has `canSendBackgroundUpdates` set to true.
      * Set to true when the user is eligible to send background updates (e.g., "in control"), or false when that user is not in control.
      * This setting will not prevent the local user from explicitly changing the state of objects using `LiveObjectSynchronizer`, such as `.set()` in `LiveState`.
      * Impacts background updates of `LiveState`, `LivePresence`, `LiveTimer`, and `LiveFollowMode`.

--- a/packages/live-share/src/internals/ContainerSynchronizer.ts
+++ b/packages/live-share/src/internals/ContainerSynchronizer.ts
@@ -97,7 +97,13 @@ export class ContainerSynchronizer {
         return false;
     }
 
-    public async onSendUpdates(): Promise<void> {
+    /**
+     * On send background updates handler
+     *
+     * @returns void promise once the events were sent (unless skipped)
+     */
+    public async onSendBackgroundUpdates(): Promise<void> {
+        if (!this._liveRuntime.canSendBackgroundUpdates) return;
         await this.sendGroupEvent(
             this._connectedKeys,
             ObjectSynchronizerEvents.update
@@ -161,7 +167,7 @@ export class ContainerSynchronizer {
         const handlers = this._objects.get(objectId);
         if (!handlers) {
             throw new Error(
-                "ContainerSynchronizer.sendEventForObject(): cannot send an event for an object that is not registered"
+                "ContainerSynchronizer.sendThrottledEventForObject(): cannot send an event for an object that is not registered"
             );
         }
         const canSend = await handlers.getLocalUserCanSend(false);
@@ -349,11 +355,6 @@ export class ContainerSynchronizer {
         this._runtime.off("connected", this._onBoundConnectedListener);
     }
 
-    private async sendBackgroundUpdates(): Promise<void> {
-        if (!this._liveRuntime.canSendBackgroundUpdates) return;
-        return await this.onSendUpdates();
-    }
-
     private startBackgroundObjectUpdates() {
         // Stop existing background updates
         this.stopBackgroundObjectUpdates();
@@ -365,7 +366,7 @@ export class ContainerSynchronizer {
         );
         // Set background updates
         this._onSendUpdatesIntervalCallback =
-            this.sendBackgroundUpdates.bind(this);
+            this.onSendBackgroundUpdates.bind(this);
         this._hTimer = setInterval(
             this._onSendUpdatesIntervalCallback,
             this._liveRuntime.objectManager.updateInterval

--- a/packages/live-share/src/internals/ContainerSynchronizer.ts
+++ b/packages/live-share/src/internals/ContainerSynchronizer.ts
@@ -32,27 +32,11 @@ export class ContainerSynchronizer {
     ) => Promise<void>;
     private _onSendUpdatesIntervalCallback?: () => Promise<void>;
 
-    /**
-     * Setting for whether `LiveDataObject` instances using `LiveObjectSynchronizer` can send background updates.
-     * Default value is `true`.
-     *
-     * @remarks
-     * This should only be set from `LiveObjectManager`, which should only be set through `LiveShareRuntime`.
-     */
-    public get canSendBackgroundUpdates(): boolean {
-        return this._canSendBackgroundUpdates;
-    }
-
-    public set canSendBackgroundUpdates(value: boolean) {
-        this._canSendBackgroundUpdates = value;
-    }
-
     constructor(
         private readonly _runtime: IRuntimeSignaler,
         private _containerRuntime: IContainerRuntimeSignaler,
         private readonly _liveRuntime: LiveShareRuntime,
-        private readonly _objectStore: LiveObjectManager,
-        private _canSendBackgroundUpdates: boolean
+        private readonly _objectStore: LiveObjectManager
     ) {
         this.startListeningForConnected();
     }
@@ -366,7 +350,7 @@ export class ContainerSynchronizer {
     }
 
     private async sendBackgroundUpdates(): Promise<void> {
-        if (!this.canSendBackgroundUpdates) return;
+        if (!this._liveRuntime.canSendBackgroundUpdates) return;
         return await this.onSendUpdates();
     }
 

--- a/packages/live-share/src/internals/LiveObjectManager.ts
+++ b/packages/live-share/src/internals/LiveObjectManager.ts
@@ -34,6 +34,9 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
     private objectStoreMap: ILiveObjectStore = new Map();
 
     private _audience?: IAzureAudience;
+    private _synchronizer?: ContainerSynchronizer;
+    private _canSendBackgroundUpdates = true;
+
     private _onBoundReceivedSignalListener?: (
         message: IInboundSignalMessage,
         local: boolean
@@ -53,7 +56,20 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
      */
     public updateInterval = 10000;
 
-    private _synchronizer?: ContainerSynchronizer;
+    /**
+     * Setting for whether `LiveDataObject` instances using `LiveObjectSynchronizer` can send background updates.
+     * Default value is `true`.
+     *
+     * @remarks
+     * This should only be set from `LiveShareClient`.
+     */
+    public get canSendBackgroundUpdates(): boolean {
+        return this._canSendBackgroundUpdates;
+    }
+
+    public set canSendBackgroundUpdates(value: boolean) {
+        this._canSendBackgroundUpdates = value;
+    }
 
     /**
      * Start listening for changes

--- a/packages/live-share/src/internals/LiveObjectManager.ts
+++ b/packages/live-share/src/internals/LiveObjectManager.ts
@@ -257,7 +257,7 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
         );
         // If the non-local user is connecting for the first time
         if (message.type === ObjectSynchronizerEvents.connect) {
-            this._synchronizer?.onSendUpdates();
+            this._synchronizer?.onSendBackgroundUpdates();
         }
     }
 

--- a/packages/live-share/src/internals/LiveObjectManager.ts
+++ b/packages/live-share/src/internals/LiveObjectManager.ts
@@ -43,11 +43,11 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
     /**
      * Create a new registry for all of the `LiveObjectSynchronizer` objects for a Live Share session.
      * @param _liveRuntime runtime for the Live Share session.
+     * @param _containerRuntime signal runtime.
      */
     public constructor(
         private readonly _liveRuntime: LiveShareRuntime,
-        private _containerRuntime: IContainerRuntimeSignaler,
-        private _canSendBackgroundUpdates: boolean
+        private _containerRuntime: IContainerRuntimeSignaler
     ) {
         super();
     }
@@ -55,26 +55,6 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
      * The update interval in milliseconds
      */
     public updateInterval = 10000;
-
-    /**
-     * Setting for whether `LiveDataObject` instances using `LiveObjectSynchronizer` can send background updates.
-     * Default value is `true`.
-     *
-     * @remarks
-     * This should only be set from `LiveShareRuntime`.
-     */
-    public get canSendBackgroundUpdates(): boolean {
-        if (this._synchronizer) {
-            return this._synchronizer.canSendBackgroundUpdates;
-        }
-        return this._canSendBackgroundUpdates;
-    }
-
-    public set canSendBackgroundUpdates(value: boolean) {
-        this._canSendBackgroundUpdates = value;
-        if (!this._synchronizer) return;
-        this._synchronizer.canSendBackgroundUpdates = value;
-    }
 
     /**
      * Start listening for changes
@@ -111,8 +91,7 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
                 runtime,
                 this._containerRuntime,
                 this._liveRuntime,
-                this,
-                this.canSendBackgroundUpdates
+                this
             );
         }
 

--- a/packages/live-share/src/test/LiveEvent.spec.ts
+++ b/packages/live-share/src/test/LiveEvent.spec.ts
@@ -24,7 +24,9 @@ describeNoCompat("LiveEvent", (getTestObjectProvider) => {
     let object2: LiveEvent;
     let liveRuntime1: LiveShareRuntime = new LiveShareRuntime(
         TestLiveShareHost.create(),
-        new LocalTimestampProvider()
+        {
+            timestampProvider: new LocalTimestampProvider(),
+        }
     );
     let LiveEventProxy1 = getLiveDataObjectClassProxy<LiveEvent>(
         LiveEvent,
@@ -32,7 +34,9 @@ describeNoCompat("LiveEvent", (getTestObjectProvider) => {
     ) as DataObjectClass<LiveEvent>;
     let liveRuntime2: LiveShareRuntime = new LiveShareRuntime(
         TestLiveShareHost.create(),
-        new LocalTimestampProvider()
+        {
+            timestampProvider: new LocalTimestampProvider(),
+        }
     );
     let LiveEventProxy2 = getLiveDataObjectClassProxy<LiveEvent>(
         LiveEvent,
@@ -139,10 +143,9 @@ describeNoCompat("LiveEvent", (getTestObjectProvider) => {
 
     it("Should getTimestamp() using custom timestamp providers", async () => {
         const mock = new MockTimestampProvider();
-        const customRuntime = new LiveShareRuntime(
-            TestLiveShareHost.create(),
-            mock
-        );
+        const customRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+            timestampProvider: mock,
+        });
 
         const now = new Date().getTime();
         const timestamp = customRuntime.getTimestamp();
@@ -159,11 +162,9 @@ describeNoCompat("LiveEvent", (getTestObjectProvider) => {
 
     it("Should verifyRolesAllowed() using custom role verifier", async () => {
         const mock = new MockRoleVerifier([UserMeetingRole.presenter]);
-        const customRuntime = new LiveShareRuntime(
-            TestLiveShareHost.create(),
-            undefined,
-            mock
-        );
+        const customRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+            roleVerifier: mock,
+        });
 
         const allowed = await customRuntime.verifyRolesAllowed("test", [
             UserMeetingRole.presenter,

--- a/packages/live-share/src/test/LiveEventScope.spec.ts
+++ b/packages/live-share/src/test/LiveEventScope.spec.ts
@@ -21,25 +21,21 @@ function createConnectedSignalers() {
 }
 
 describe("LiveEventScope", () => {
-    let localLiveRuntime = new LiveShareRuntime(
-        TestLiveShareHost.create(),
-        new LocalTimestampProvider()
-    );
-    let remoteLiveRuntime = new LiveShareRuntime(
-        TestLiveShareHost.create(),
-        new LocalTimestampProvider()
-    );
+    let localLiveRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+        timestampProvider: new LocalTimestampProvider(),
+    });
+    let remoteLiveRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+        timestampProvider: new LocalTimestampProvider(),
+    });
 
     afterEach(async () => {
         // restore defaults
-        localLiveRuntime = new LiveShareRuntime(
-            TestLiveShareHost.create(),
-            new LocalTimestampProvider()
-        );
-        remoteLiveRuntime = new LiveShareRuntime(
-            TestLiveShareHost.create(),
-            new LocalTimestampProvider()
-        );
+        localLiveRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+            timestampProvider: new LocalTimestampProvider(),
+        });
+        remoteLiveRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+            timestampProvider: new LocalTimestampProvider(),
+        });
     });
 
     it("Should raise local and remote events", async () => {

--- a/packages/live-share/src/test/LiveEventSource.spec.ts
+++ b/packages/live-share/src/test/LiveEventSource.spec.ts
@@ -19,25 +19,21 @@ function createConnectedSignalers() {
 }
 
 describe("LiveEventSource", () => {
-    let localLiveRuntime = new LiveShareRuntime(
-        TestLiveShareHost.create(),
-        new LocalTimestampProvider()
-    );
-    let remoteLiveRuntime = new LiveShareRuntime(
-        TestLiveShareHost.create(),
-        new LocalTimestampProvider()
-    );
+    let localLiveRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+        timestampProvider: new LocalTimestampProvider(),
+    });
+    let remoteLiveRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+        timestampProvider: new LocalTimestampProvider(),
+    });
 
     afterEach(async () => {
         // restore defaults
-        localLiveRuntime = new LiveShareRuntime(
-            TestLiveShareHost.create(),
-            new LocalTimestampProvider()
-        );
-        remoteLiveRuntime = new LiveShareRuntime(
-            TestLiveShareHost.create(),
-            new LocalTimestampProvider()
-        );
+        localLiveRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+            timestampProvider: new LocalTimestampProvider(),
+        });
+        remoteLiveRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+            timestampProvider: new LocalTimestampProvider(),
+        });
     });
 
     it("Should send events", (done) => {

--- a/packages/live-share/src/test/LiveEventTarget.spec.ts
+++ b/packages/live-share/src/test/LiveEventTarget.spec.ts
@@ -19,25 +19,21 @@ function createConnectedSignalers() {
 }
 
 describe("LiveEventTarget", () => {
-    let localLiveRuntime = new LiveShareRuntime(
-        TestLiveShareHost.create(),
-        new LocalTimestampProvider()
-    );
-    let remoteLiveRuntime = new LiveShareRuntime(
-        TestLiveShareHost.create(),
-        new LocalTimestampProvider()
-    );
+    let localLiveRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+        timestampProvider: new LocalTimestampProvider(),
+    });
+    let remoteLiveRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+        timestampProvider: new LocalTimestampProvider(),
+    });
 
     afterEach(async () => {
         // restore defaults
-        localLiveRuntime = new LiveShareRuntime(
-            TestLiveShareHost.create(),
-            new LocalTimestampProvider()
-        );
-        remoteLiveRuntime = new LiveShareRuntime(
-            TestLiveShareHost.create(),
-            new LocalTimestampProvider()
-        );
+        localLiveRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+            timestampProvider: new LocalTimestampProvider(),
+        });
+        remoteLiveRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+            timestampProvider: new LocalTimestampProvider(),
+        });
     });
 
     it("Should receive events", (done) => {

--- a/packages/live-share/src/test/LiveEventTimer.spec.ts
+++ b/packages/live-share/src/test/LiveEventTimer.spec.ts
@@ -20,25 +20,21 @@ function createConnectedSignalers() {
 }
 
 describe("LiveEventTimer", () => {
-    let localLiveRuntime = new LiveShareRuntime(
-        TestLiveShareHost.create(),
-        new LocalTimestampProvider()
-    );
-    let remoteLiveRuntime = new LiveShareRuntime(
-        TestLiveShareHost.create(),
-        new LocalTimestampProvider()
-    );
+    let localLiveRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+        timestampProvider: new LocalTimestampProvider(),
+    });
+    let remoteLiveRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+        timestampProvider: new LocalTimestampProvider(),
+    });
 
     afterEach(async () => {
         // restore defaults
-        localLiveRuntime = new LiveShareRuntime(
-            TestLiveShareHost.create(),
-            new LocalTimestampProvider()
-        );
-        remoteLiveRuntime = new LiveShareRuntime(
-            TestLiveShareHost.create(),
-            new LocalTimestampProvider()
-        );
+        localLiveRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+            timestampProvider: new LocalTimestampProvider(),
+        });
+        remoteLiveRuntime = new LiveShareRuntime(TestLiveShareHost.create(), {
+            timestampProvider: new LocalTimestampProvider(),
+        });
     });
 
     it("Should send a single event after a delay", (done) => {
@@ -49,7 +45,7 @@ describe("LiveEventTimer", () => {
             signalers.localRuntime,
             localLiveRuntime
         );
-        const localTarget = new LiveEventTarget(
+        const localTarget = new LiveEventTarget<{}>(
             localScope,
             "test",
             (evt, local) => triggered++
@@ -94,7 +90,7 @@ describe("LiveEventTimer", () => {
             signalers.localRuntime,
             localLiveRuntime
         );
-        const localTarget = new LiveEventTarget(
+        const localTarget = new LiveEventTarget<{}>(
             localScope,
             "test",
             (evt, local) => triggered++

--- a/packages/live-share/src/test/MockLiveShareRuntime.ts
+++ b/packages/live-share/src/test/MockLiveShareRuntime.ts
@@ -11,7 +11,9 @@ export class MockLiveShareRuntime extends LiveShareRuntime {
         host = TestLiveShareHost.create(),
         timestampProvider: ITimestampProvider = new LocalTimestampProvider()
     ) {
-        super(host, timestampProvider);
+        super(host, {
+            timestampProvider,
+        });
         if (shouldCreateMockContainer) {
             const localContainer = new MockContainerRuntimeSignaler();
             this.__dangerouslySetContainerRuntime(localContainer);

--- a/samples/typescript/04.live-share-react/src/components/ExampleLivePresence.tsx
+++ b/samples/typescript/04.live-share-react/src/components/ExampleLivePresence.tsx
@@ -12,11 +12,6 @@ export const ExampleLivePresence: FC = () => {
         "CUSTOM-PRESENCE-KEY",
         { toggleCount: 0 } // optional
     );
-    const { livePresence: v2 } = useLivePresence(
-        "CUSTOM-PRESENCE-KEY",
-        { toggleCount: 0 } // optional
-    );
-    console.log(v1 === v2);
     return (
         <div style={{ padding: "24px 12px" }}>
             <h2>{"Users:"}</h2>

--- a/samples/typescript/04.live-share-react/src/components/ExampleLiveState.tsx
+++ b/samples/typescript/04.live-share-react/src/components/ExampleLiveState.tsx
@@ -1,6 +1,10 @@
-import { useLiveShareContext, useLiveState } from "@microsoft/live-share-react";
-import { UserMeetingRole } from "@microsoft/live-share";
-import { FC, ReactNode } from "react";
+import {
+    useFluidObjectsContext,
+    useLiveShareContext,
+    useLiveState,
+} from "@microsoft/live-share-react";
+import { UserMeetingRole, LiveShareClient } from "@microsoft/live-share";
+import { FC, ReactNode, useState } from "react";
 
 enum ExampleAppStatus {
     WAITING = "WAITING",
@@ -45,6 +49,7 @@ export const ExampleLiveState: FC<IExampleStateProps> = (props) => {
                     >
                         {"Start"}
                     </button>
+                    <BackgroundUpdates />
                 </div>
                 <h1>{"Welcome to Fluid React!"}</h1>
                 {props.waitingContent}
@@ -64,8 +69,40 @@ export const ExampleLiveState: FC<IExampleStateProps> = (props) => {
                 >
                     {"End"}
                 </button>
+                <BackgroundUpdates />
             </div>
             {props.startContent}
+        </div>
+    );
+};
+
+/**
+ * Background updates are sent periodically for all `LiveDataObject` instances that use `LiveObjectSynchronizer`.
+ * `LiveState` is one such data object. Setting `canSendBackgroundUpdates` will impact all other data objects as well.
+ * Read the reference docs for `LiveShareClient.canSendBackgroundUpdates` for more information.
+ */
+const BackgroundUpdates: FC = () => {
+    const { clientRef } = useFluidObjectsContext();
+    const [checked, setChecked] = useState<boolean>(
+        clientRef.current.canSendBackgroundUpdates
+    );
+    return (
+        <div
+            className="flex row vAlign"
+            style={{
+                paddingLeft: "20px",
+            }}
+        >
+            <input
+                type="checkbox"
+                checked={checked}
+                onChange={(ev) => {
+                    clientRef.current.canSendBackgroundUpdates =
+                        ev.target.checked;
+                    setChecked(ev.target.checked);
+                }}
+            />
+            <div>{"Can send background updates"}</div>
         </div>
     );
 };


### PR DESCRIPTION
Resolves #711.

- Introduced new `canSendBackgroundUpdates` setting that when false, prevents periodic background updates _and_ responding to `connect` messages from other clients.
- Added optional `canSendBackgroundUpdates` option to `ILiveShareClientProps`
- Changed props of `LiveShareRuntime` constructor to accept `ILiveShareClientProps` rather than separate props for each variable. This is technically a breaking change, though it isn't really intended for used outside of the Live Share packages, so this should be fine.
- Fixed unit tests and live-share-turbo files that initialized `LiveShareRuntime` with old props
- Added new unit test to validate `canSendBackgroundUpdates` setting.
- Added "Can send background updates" to sample 04 (typescript only).