### PR TITLE
Add local and source to ExtendedMediaSessionActionDetails

### DIFF
--- a/packages/live-share-media/src/LiveMediaSession.ts
+++ b/packages/live-share-media/src/LiveMediaSession.ts
@@ -295,6 +295,7 @@ export class LiveMediaSession extends LiveDataObject {
                         this.coordinator.beginSuspension(waitPoint);
                     this.dispatchAction({
                         action: "wait",
+                        source: "system",
                         clientId,
                         local: true,
                         suspension,

--- a/packages/live-share-media/src/LiveMediaSession.ts
+++ b/packages/live-share-media/src/LiveMediaSession.ts
@@ -296,6 +296,7 @@ export class LiveMediaSession extends LiveDataObject {
                     this.dispatchAction({
                         action: "wait",
                         clientId,
+                        local: true,
                         suspension,
                     });
                 });

--- a/packages/live-share-media/src/MediaPlayerSynchronizer.ts
+++ b/packages/live-share-media/src/MediaPlayerSynchronizer.ts
@@ -524,6 +524,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
         waitUntilConnected(this._runtime).then((clientId: string) => {
             this.dispatchUserAction({
                 action: "seekto",
+                source: "user",
                 clientId,
                 local: true,
                 seekTime: seekTo,
@@ -549,6 +550,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
 
         this.dispatchUserAction({
             action: "play",
+            source: "user",
             clientId: await waitUntilConnected(this._runtime),
             local: true,
         });
@@ -572,6 +574,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
 
         this.dispatchUserAction({
             action: "pause",
+            source: "user",
             clientId: await waitUntilConnected(this._runtime),
             local: true,
         });
@@ -601,6 +604,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
 
         this.dispatchUserAction({
             action: "seekto",
+            source: "user",
             clientId: await waitUntilConnected(this._runtime),
             seekTime: time,
             local: true,
@@ -627,6 +631,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
 
         this.dispatchUserAction({
             action: "settrack",
+            source: "user",
             clientId: await waitUntilConnected(this._runtime),
             metadata: track,
             local: true,
@@ -651,6 +656,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
 
         this.dispatchUserAction({
             action: "datachange",
+            source: "user",
             clientId: await waitUntilConnected(this._runtime),
             local: true,
             data: data,

--- a/packages/live-share-media/src/MediaPlayerSynchronizer.ts
+++ b/packages/live-share-media/src/MediaPlayerSynchronizer.ts
@@ -525,6 +525,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
             this.dispatchUserAction({
                 action: "seekto",
                 clientId,
+                local: true,
                 seekTime: seekTo,
             });
         });
@@ -549,6 +550,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
         this.dispatchUserAction({
             action: "play",
             clientId: await waitUntilConnected(this._runtime),
+            local: true,
         });
     }
 
@@ -571,6 +573,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
         this.dispatchUserAction({
             action: "pause",
             clientId: await waitUntilConnected(this._runtime),
+            local: true,
         });
     }
 
@@ -600,6 +603,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
             action: "seekto",
             clientId: await waitUntilConnected(this._runtime),
             seekTime: time,
+            local: true,
         });
     }
 
@@ -625,6 +629,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
             action: "settrack",
             clientId: await waitUntilConnected(this._runtime),
             metadata: track,
+            local: true,
         });
     }
 
@@ -647,6 +652,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
         this.dispatchUserAction({
             action: "datachange",
             clientId: await waitUntilConnected(this._runtime),
+            local: true,
             data: data,
         });
     }

--- a/packages/live-share-media/src/MediaSessionExtensions.ts
+++ b/packages/live-share-media/src/MediaSessionExtensions.ts
@@ -95,6 +95,15 @@ export type ExtendedMediaSessionPlaybackState =
     | "ended";
 
 /**
+ * The source of the action for `LiveMediaSession`.
+ *
+ * @remarks
+ * Is `user` when the action was explicitly invoked via the `LiveMediaSessionCoordinator`.
+ * Is `system` when the action was invoked via `GroupCoordinatorState` when the local client is out of sync.
+ */
+export type ExtendedMediaSessionActionSource = "user" | "system";
+
+/**
  * Metadata for `LiveMediaSession`.
  *
  * @remarks
@@ -124,6 +133,14 @@ export interface ExtendedMediaSessionActionDetails {
      * The action type of this event.
      */
     action: ExtendedMediaSessionAction;
+    /**
+     * The source of the action.
+     *
+     * @remarks
+     * Is `user` when the action was explicitly invoked via the `LiveMediaSessionCoordinator`.
+     * Is `system` when the action was invoked via `GroupCoordinatorState` when the local client is out of sync.
+     */
+    source: ExtendedMediaSessionActionSource;
     /**
      * Unique identifier of the client that triggered this action.
      */

--- a/packages/live-share-media/src/MediaSessionExtensions.ts
+++ b/packages/live-share-media/src/MediaSessionExtensions.ts
@@ -3,18 +3,76 @@
  * Licensed under the Microsoft Live Share SDK License.
  */
 
+/**
+ * Suspension object for when group synchronization is suspended for the local user.
+ */
 export interface MediaSessionCoordinatorSuspension {
+    /**
+     * The wait point that the suspension was created with.
+     *
+     * @remarks
+     * If undefined, the suspension was not created with a wait point.
+     */
     waitPoint?: CoordinationWaitPoint;
+    /**
+     * Ends the suspension.
+     *
+     * @param seekTo the timestamp to seek to after the suspension ends.
+     * If no value is provided, the local user will return to the group playback position.
+     *
+     * @remarks
+     * If there are other suspensions active, all other suspensions must be ended before group synchronization can resume.
+     */
     end(seekTo?: number): void;
 }
 
+/**
+ * Wait point interface for a suspension.
+ *
+ * @remarks
+ * Used by {@link MediaSessionCoordinatorSuspension} to schedule a suspension at a specific media position.
+ */
+export interface CoordinationWaitPoint {
+    /**
+     * The position in milliseconds that the suspension should begin.
+     */
+    position: number;
+    /**
+     * Optional. The reason for the suspension.
+     */
+    reason?: string;
+    /**
+     * Optional. The max clients to wait for before a suspension ends.
+     */
+    maxClients?: number;
+}
+
+/**
+ * The state of the `LiveMediaSessionCoordinator`.
+ */
 export type MediaSessionCoordinatorState = "closed" | "waiting" | "joined";
 
+/**
+ * Event types of `LiveMediaSessionCoordinator`.
+ */
 export enum MediaSessionCoordinatorEvents {
+    /**
+     * Event emitted after the coordinator's state changed
+     */
     coordinatorstatechange = "coordinatorstatechange",
+    /**
+     * Event emitted when an action was triggered.
+     */
     triggeraction = "triggeraction",
 }
 
+/**
+ * Action types supported for `LiveMediaSession`.
+ *
+ * @remarks
+ * These types extend the default actions supported by the `MediaSession` specification in browsers.
+ * These additional actions help with group synchronization.
+ */
 export type ExtendedMediaSessionAction =
     | MediaSessionAction
     | "settrack"
@@ -23,35 +81,90 @@ export type ExtendedMediaSessionAction =
     | "datachange"
     | "blocked";
 
+/**
+ * Extended playback state for `LiveMediaSession`.
+ *
+ * @remarks
+ * These types extend the default state types supported by the `MediaSession` specification in browsers.
+ * These additional types help with group synchronization.
+ */
 export type ExtendedMediaSessionPlaybackState =
     | MediaSessionPlaybackState
     | "suspended"
     | "waiting"
     | "ended";
 
+/**
+ * Metadata for `LiveMediaSession`.
+ *
+ * @remarks
+ * These types extend the default session metadata supported by the `MediaSession` specification in browsers.
+ * These additional types help with group synchronization.
+ */
 export interface ExtendedMediaMetadata extends MediaMetadata {
+    /**
+     * A unique identifier for the track (e.g., UUID, URL, etc.)
+     */
     trackIdentifier: string;
-    liveStream: boolean;
+    /**
+     * Flag indicating whether or not the stream is a live broadcast.
+     */
+    liveStream?: boolean;
 }
 
-export interface CoordinationWaitPoint {
-    position: number;
-    reason?: string;
-    maxClients?: number;
-}
-
+/**
+ * Details for emitted actions from `LiveMediaSession`.
+ *
+ * @remarks
+ * These types extend the default event details supported by the `MediaSession` specification in browsers.
+ * These additional types help with group synchronization.
+ */
 export interface ExtendedMediaSessionActionDetails {
+    /**
+     * The action type of this event.
+     */
     action: ExtendedMediaSessionAction;
+    /**
+     * Unique identifier of the client that triggered this action.
+     */
     clientId: string;
+    /**
+     * Flag indicating whether or not the action was triggered by the local client.
+     */
+    local: boolean;
+    /**
+     * Flag indicating whether or not this was a fast seek action.
+     */
     fastSeek?: boolean | null;
+    /**
+     * The offset of the seek.
+     */
     seekOffset?: number | null;
+    /**
+     * Timestamp of the seek event.
+     */
     seekTime?: number | null;
+    /**
+     * Updated session metadata that was changed via this action.
+     */
     metadata?: ExtendedMediaMetadata | null;
+    /**
+     * Suspension associated with this action.
+     */
     suspension?: MediaSessionCoordinatorSuspension | null;
+    /**
+     * Custom data associated with this action.
+     */
     data?: object | null;
+    /**
+     * Action type that was blocked.
+     */
     blocked?: ExtendedMediaSessionAction | null;
 }
 
+/**
+ * Handler for `LiveMediaSession` actions.
+ */
 export interface ExtendedMediaSessionActionHandler {
     (details: ExtendedMediaSessionActionDetails): void;
 }

--- a/packages/live-share-media/src/internals/GroupPlaybackTrack.ts
+++ b/packages/live-share-media/src/internals/GroupPlaybackTrack.ts
@@ -9,6 +9,7 @@ import { IMediaPlayerState } from "../LiveMediaSessionCoordinator";
 import {
     CoordinationWaitPoint,
     ExtendedMediaMetadata,
+    ExtendedMediaSessionActionSource,
 } from "../MediaSessionExtensions";
 
 /**
@@ -99,7 +100,10 @@ export class GroupPlaybackTrack extends EventEmitter {
         return undefined;
     }
 
-    public updateTrack(track: IPlaybackTrack): boolean {
+    public updateTrack(
+        track: IPlaybackTrack,
+        source: ExtendedMediaSessionActionSource
+    ): boolean {
         // Guard against missing waitPoints collection
         if (!Array.isArray(track.waitPoints)) {
             track.waitPoints = [];
@@ -149,6 +153,7 @@ export class GroupPlaybackTrack extends EventEmitter {
             name: GroupPlaybackTrackEvents.trackChange,
             clientId: track.clientId,
             metadata: track.metadata,
+            source,
         });
 
         return true;

--- a/packages/live-share-media/src/internals/GroupPlaybackTrackData.ts
+++ b/packages/live-share-media/src/internals/GroupPlaybackTrackData.ts
@@ -9,6 +9,7 @@ import {
     GroupPlaybackTrack,
     GroupPlaybackTrackEvents,
 } from "./GroupPlaybackTrack";
+import { ExtendedMediaSessionActionSource } from "../MediaSessionExtensions";
 
 /**
  * @hidden
@@ -64,7 +65,10 @@ export class GroupPlaybackTrackData extends EventEmitter {
         return this.current.data;
     }
 
-    public updateData(event: IPlaybackTrackData): boolean {
+    public updateData(
+        event: IPlaybackTrackData,
+        source: ExtendedMediaSessionActionSource
+    ): boolean {
         // Ignore state changes that are older
         const current = this.current;
         if (event.timestamp < current.timestamp) {
@@ -92,6 +96,7 @@ export class GroupPlaybackTrackData extends EventEmitter {
             type: PlaybackTrackDataEvents.dataChange,
             clientId: event.clientId,
             data: event.data,
+            source,
         });
 
         return true;

--- a/packages/live-share-media/src/internals/GroupTransportState.ts
+++ b/packages/live-share-media/src/internals/GroupTransportState.ts
@@ -9,6 +9,7 @@ import { IMediaPlayerState } from "../LiveMediaSessionCoordinator";
 import {
     ExtendedMediaSessionPlaybackState,
     ExtendedMediaSessionAction,
+    ExtendedMediaSessionActionSource,
 } from "../MediaSessionExtensions";
 import {
     GroupPlaybackTrack,
@@ -104,7 +105,10 @@ export class GroupTransportState extends EventEmitter {
         );
     }
 
-    public updateState(state: ITransportState): boolean {
+    public updateState(
+        state: ITransportState,
+        source: ExtendedMediaSessionActionSource
+    ): boolean {
         // Ignore if same playback state and start position
         if (this.compare(state)) {
             return false;
@@ -138,6 +142,7 @@ export class GroupTransportState extends EventEmitter {
                 action: "seekto",
                 clientId: state.clientId,
                 seekTime: state.startPosition,
+                source,
             });
         } else if (state.playbackState == "playing") {
             const now = this._liveRuntime.getTimestamp();
@@ -148,6 +153,7 @@ export class GroupTransportState extends EventEmitter {
                 action: "play",
                 clientId: state.clientId,
                 seekTime: projectedPosition,
+                source,
             });
         } else {
             this.emit(GroupTransportStateEvents.transportStateChange, {
@@ -155,6 +161,7 @@ export class GroupTransportState extends EventEmitter {
                 action: "pause",
                 clientId: state.clientId,
                 seekTime: state.startPosition,
+                source,
             });
         }
 

--- a/packages/live-share-media/src/test/LiveMediaSession_Synchronizer.spec.ts
+++ b/packages/live-share-media/src/test/LiveMediaSession_Synchronizer.spec.ts
@@ -123,10 +123,12 @@ describeNoCompat(
                 {
                     action: "play",
                     clientId: await object1.clientId(),
+                    local: false,
                 },
                 {
                     action: "pause",
                     clientId: await object2.clientId(),
+                    local: true,
                 },
             ];
             const sync1 = object1.synchronize(testMediaPlayer1);
@@ -167,14 +169,17 @@ describeNoCompat(
                 {
                     action: "seekto",
                     clientId: await object1.clientId(),
+                    local: false,
                 },
                 {
                     action: "play",
                     clientId: await object1.clientId(),
+                    local: false,
                 },
                 {
                     action: "pause",
                     clientId: await object2.clientId(),
+                    local: true,
                 },
             ];
             const sync1 = object1.synchronize(testMediaPlayer1);
@@ -216,14 +221,17 @@ describeNoCompat(
                 {
                     action: "play",
                     clientId: await object1.clientId(),
+                    local: false,
                 },
                 {
                     action: "seekto",
                     clientId: await object1.clientId(),
+                    local: false,
                 },
                 {
                     action: "pause",
                     clientId: await object2.clientId(),
+                    local: true,
                 },
             ];
             const sync1 = object1.synchronize(testMediaPlayer1);
@@ -334,10 +342,12 @@ describeNoCompat(
                 {
                     action: "play",
                     clientId: await object1.clientId(),
+                    local: false,
                 },
                 {
                     action: "settrack",
                     clientId: await object1.clientId(),
+                    local: false,
                 },
             ];
             const sync1 = object1.synchronize(testMediaPlayer1);
@@ -386,16 +396,19 @@ describeNoCompat(
                 {
                     action: "seekto",
                     clientId: await object1.clientId(),
+                    local: true,
                 },
             ];
             const object2ExpectedEventOrder = [
                 {
                     action: "play",
                     clientId: await object2.clientId(),
+                    local: true,
                 },
                 {
                     action: "seekto",
                     clientId: await object1.clientId(),
+                    local: false,
                 },
             ];
             const sync1 = object1.synchronize(testMediaPlayer1);
@@ -440,10 +453,12 @@ describeNoCompat(
                 {
                     action: "settrack",
                     clientId: await object1.clientId(),
+                    local: true,
                 },
                 {
                     action: "play",
                     clientId: await object1.clientId(),
+                    local: true,
                 },
             ];
             const sync1 = object1.synchronize(testMediaPlayer1);
@@ -730,28 +745,34 @@ describeNoCompat(
                 {
                     action: "settrack",
                     clientId: await object1.clientId(),
+                    local: true,
                 },
                 {
                     action: "play",
                     clientId: await object1.clientId(),
+                    local: true,
                 },
             ];
             const object2ExpectedEventOrder = [
                 {
                     action: "settrack",
                     clientId: await object1.clientId(),
+                    local: false,
                 },
                 {
                     action: "play",
                     clientId: await object1.clientId(),
+                    local: false,
                 },
                 {
                     action: "catchup",
                     clientId: await object2.clientId(),
+                    local: true,
                 },
                 {
                     action: "play",
                     clientId: await object1.clientId(),
+                    local: false,
                 },
             ];
             const sync1 = object1.synchronize(testMediaPlayer1);
@@ -839,7 +860,7 @@ async function assertActionOccurred(
 
 async function assertExpectedEvents(
     synchronizer: MediaPlayerSynchronizer,
-    expectedEventOrder: { action: string; clientId: string }[]
+    expectedEventOrder: { action: string; clientId: string; local: boolean }[]
 ): Promise<void> {
     let deferred = new Deferred();
     let eventCount = 0;
@@ -858,6 +879,10 @@ async function assertExpectedEvents(
                     details.clientId ===
                         expectedEventOrder[eventCount].clientId,
                     "unexpected sender clientId"
+                );
+                assert(
+                    details.local === expectedEventOrder[eventCount].local,
+                    "unexpected locality"
                 );
                 eventCount += 1;
             } catch (error: any) {

--- a/packages/live-share-media/src/test/LiveMediaSession_Synchronizer.spec.ts
+++ b/packages/live-share-media/src/test/LiveMediaSession_Synchronizer.spec.ts
@@ -26,6 +26,7 @@ import { isErrorLike } from "@microsoft/live-share/bin/internals";
 import {
     ExtendedMediaMetadata,
     ExtendedMediaSessionActionDetails,
+    ExtendedMediaSessionActionSource,
 } from "../MediaSessionExtensions";
 import {
     IMediaPlayerSynchronizerEvent,
@@ -119,16 +120,18 @@ describeNoCompat(
             const testMediaPlayer2 = new TestMediaPlayer();
             await object1.initialize();
             await object2.initialize();
-            const expectedEventOrder = [
+            const expectedEventOrder: IExpectedEvent[] = [
                 {
                     action: "play",
                     clientId: await object1.clientId(),
                     local: false,
+                    source: "user",
                 },
                 {
                     action: "pause",
                     clientId: await object2.clientId(),
                     local: true,
+                    source: "user",
                 },
             ];
             const sync1 = object1.synchronize(testMediaPlayer1);
@@ -165,21 +168,24 @@ describeNoCompat(
             const testMediaPlayer2 = new TestMediaPlayer();
             await object1.initialize();
             await object2.initialize();
-            const expectedEventOrder = [
+            const expectedEventOrder: IExpectedEvent[] = [
                 {
                     action: "seekto",
                     clientId: await object1.clientId(),
                     local: false,
+                    source: "user",
                 },
                 {
                     action: "play",
                     clientId: await object1.clientId(),
                     local: false,
+                    source: "user",
                 },
                 {
                     action: "pause",
                     clientId: await object2.clientId(),
                     local: true,
+                    source: "user",
                 },
             ];
             const sync1 = object1.synchronize(testMediaPlayer1);
@@ -217,21 +223,24 @@ describeNoCompat(
             const testMediaPlayer2 = new TestMediaPlayer();
             await object1.initialize();
             await object2.initialize();
-            const expectedEventOrder = [
+            const expectedEventOrder: IExpectedEvent[] = [
                 {
                     action: "play",
                     clientId: await object1.clientId(),
                     local: false,
+                    source: "user",
                 },
                 {
                     action: "seekto",
                     clientId: await object1.clientId(),
                     local: false,
+                    source: "user",
                 },
                 {
                     action: "pause",
                     clientId: await object2.clientId(),
                     local: true,
+                    source: "user",
                 },
             ];
             const sync1 = object1.synchronize(testMediaPlayer1);
@@ -338,16 +347,18 @@ describeNoCompat(
             const testMediaPlayer2 = new TestMediaPlayer();
             await object1.initialize([UserMeetingRole.organizer]);
             await object2.initialize([UserMeetingRole.organizer]);
-            const expectedEventOrder = [
+            const expectedEventOrder: IExpectedEvent[] = [
                 {
                     action: "play",
                     clientId: await object1.clientId(),
                     local: false,
+                    source: "user",
                 },
                 {
                     action: "settrack",
                     clientId: await object1.clientId(),
                     local: false,
+                    source: "user",
                 },
             ];
             const sync1 = object1.synchronize(testMediaPlayer1);
@@ -392,23 +403,26 @@ describeNoCompat(
             const testMediaPlayer2 = new TestMediaPlayer();
             await object1.initialize([UserMeetingRole.organizer]);
             await object2.initialize([UserMeetingRole.organizer]);
-            const object1ExpectedEventOrder = [
+            const object1ExpectedEventOrder: IExpectedEvent[] = [
                 {
                     action: "seekto",
                     clientId: await object1.clientId(),
                     local: true,
+                    source: "user",
                 },
             ];
-            const object2ExpectedEventOrder = [
+            const object2ExpectedEventOrder: IExpectedEvent[] = [
                 {
                     action: "play",
                     clientId: await object2.clientId(),
                     local: true,
+                    source: "user",
                 },
                 {
                     action: "seekto",
                     clientId: await object1.clientId(),
                     local: false,
+                    source: "user",
                 },
             ];
             const sync1 = object1.synchronize(testMediaPlayer1);
@@ -449,16 +463,18 @@ describeNoCompat(
             );
             const testMediaPlayer1 = new TestMediaPlayer();
             await object1.initialize([UserMeetingRole.organizer]);
-            const expectedEventOrder = [
+            const expectedEventOrder: IExpectedEvent[] = [
                 {
                     action: "settrack",
                     clientId: await object1.clientId(),
                     local: true,
+                    source: "user",
                 },
                 {
                     action: "play",
                     clientId: await object1.clientId(),
                     local: true,
+                    source: "user",
                 },
             ];
             const sync1 = object1.synchronize(testMediaPlayer1);
@@ -741,38 +757,44 @@ describeNoCompat(
 
             await object1.initialize();
             await object2.initialize();
-            const object1ExpectedEventOrder = [
+            const object1ExpectedEventOrder: IExpectedEvent[] = [
                 {
                     action: "settrack",
                     clientId: await object1.clientId(),
                     local: true,
+                    source: "user",
                 },
                 {
                     action: "play",
                     clientId: await object1.clientId(),
                     local: true,
+                    source: "user",
                 },
             ];
-            const object2ExpectedEventOrder = [
+            const object2ExpectedEventOrder: IExpectedEvent[] = [
                 {
                     action: "settrack",
                     clientId: await object1.clientId(),
                     local: false,
+                    source: "user",
                 },
                 {
                     action: "play",
                     clientId: await object1.clientId(),
                     local: false,
+                    source: "user",
                 },
                 {
                     action: "catchup",
                     clientId: await object2.clientId(),
                     local: true,
+                    source: "system",
                 },
                 {
                     action: "play",
                     clientId: await object1.clientId(),
                     local: false,
+                    source: "system",
                 },
             ];
             const sync1 = object1.synchronize(testMediaPlayer1);
@@ -858,9 +880,16 @@ async function assertActionOccurred(
     });
 }
 
+interface IExpectedEvent {
+    action: string;
+    clientId: string;
+    local: boolean;
+    source: ExtendedMediaSessionActionSource;
+}
+
 async function assertExpectedEvents(
     synchronizer: MediaPlayerSynchronizer,
-    expectedEventOrder: { action: string; clientId: string; local: boolean }[]
+    expectedEventOrder: IExpectedEvent[]
 ): Promise<void> {
     let deferred = new Deferred();
     let eventCount = 0;
@@ -871,18 +900,23 @@ async function assertExpectedEvents(
             try {
                 const details = evt.details;
                 assert(evt.error === undefined, evt.error);
+                const expectedEvent = expectedEventOrder[eventCount];
                 assert(
-                    details.action === expectedEventOrder[eventCount].action,
-                    "unexpected action"
+                    details.action === expectedEvent.action,
+                    `unexpected action: should be ${expectedEvent.action}, instead is ${details.action}`
                 );
                 assert(
                     details.clientId ===
                         expectedEventOrder[eventCount].clientId,
-                    "unexpected sender clientId"
+                    `unexpected sender clientId: should be ${expectedEvent.clientId}, instead is ${details.clientId}`
                 );
                 assert(
                     details.local === expectedEventOrder[eventCount].local,
-                    "unexpected locality"
+                    `unexpected locality: should be ${expectedEvent.local}, instead is ${details.local}`
+                );
+                assert(
+                    details.source === expectedEventOrder[eventCount].source,
+                    `unexpected source: should be ${expectedEvent.source}, instead is ${details.source}`
                 );
                 eventCount += 1;
             } catch (error: any) {


### PR DESCRIPTION
Fixes #727.

Changes:
- Added `local` flag to `ExtendedMediaSessionActionDetails` interface
- Added `source` type to `ExtendedMediaSessionActionDetails` interface
- Added some missing typedocs
- Updated UTs to test expected `local` response