### PR TITLE
Fixed `LiveState` and `LivePresence` logger bug where success was being marked as error

### DIFF
--- a/packages/live-share/src/LivePresence.ts
+++ b/packages/live-share/src/LivePresence.ts
@@ -393,12 +393,14 @@ export class LivePresence<
             if (localEvent) {
                 this._logger?.sendTelemetryEvent(
                     TelemetryEvents.LivePresence.LocalPresenceChanged,
-                    { user: evt }
+                    null,
+                    { user: JSON.stringify(evt) }
                 );
             } else {
                 this._logger?.sendTelemetryEvent(
                     TelemetryEvents.LivePresence.RemotePresenceChanged,
-                    { user: evt }
+                    null,
+                    { user: JSON.stringify(evt) }
                 );
             }
         };

--- a/packages/live-share/src/LiveState.ts
+++ b/packages/live-share/src/LiveState.ts
@@ -261,7 +261,11 @@ export class LiveState<TState = any> extends LiveDataObject<{
         );
         this._logger?.sendTelemetryEvent(
             TelemetryEvents.LiveState.StateChanged,
-            { oldState, newState }
+            null,
+            {
+                oldState: JSON.stringify(oldState),
+                newState: JSON.stringify(newState),
+            }
         );
     }
 }


### PR DESCRIPTION
- Fixed bug in `LivePresence` where success cases were unintentionally logged as an error param of `sendTelemetryEvent`
- Fixed bug in `LiveState` where success cases were unintentionally logged as an error param of `sendTelemetryEvent`