### PR TITLE
Updates on exports and improved error messages

### DIFF
--- a/packages/live-share-media/src/LiveMediaSession.ts
+++ b/packages/live-share-media/src/LiveMediaSession.ts
@@ -7,6 +7,7 @@ import { DataObjectFactory } from "@fluidframework/aqueduct";
 import {
     DynamicObjectRegistry,
     LiveDataObject,
+    LiveDataObjectInitializeNotNeededError,
     LiveDataObjectInitializeState,
     LiveTelemetryLogger,
     UserMeetingRole,
@@ -109,9 +110,10 @@ export class LiveMediaSession extends LiveDataObject {
      * @throws error when `.initialize()` has already been called for this class instance.
      */
     public async initialize(allowedRoles?: UserMeetingRole[]): Promise<void> {
-        if (this.initializeState !== LiveDataObjectInitializeState.needed) {
-            throw new Error(`LiveMediaSession already started.`);
-        }
+        LiveDataObjectInitializeNotNeededError.assert(
+            "LiveMediaSession:initialize",
+            this.initializeState
+        );
         // Update initialize state as pending
         this.initializeState = LiveDataObjectInitializeState.pending;
         if (allowedRoles) {
@@ -285,7 +287,7 @@ export class LiveMediaSession extends LiveDataObject {
                 // Ensure handler registered
                 if (!this._actionHandlers.has("wait")) {
                     throw new Error(
-                        `SharedMediaSession: wait point hit but no 'wait' action registered.`
+                        `LiveMediaSession:checkWaitPointHit - wait point hit but no 'wait' action registered.\nTo fix this error, set a \`wait\` action using the \`setActionHandler()\` function.`
                     );
                 }
 
@@ -308,7 +310,7 @@ export class LiveMediaSession extends LiveDataObject {
     private getCurrentPlayerState(): IMediaPlayerState {
         if (!this._requestPlayerStateHandler) {
             throw new Error(
-                `LiveMediaSession: no getPlayerState callback configured.`
+                "LiveMediaSession:getCurrentPlayerState - no getPlayerState callback configured.\nTo fix this error, ensure `setRequestPlayerStateHandler()` has been set with a delegate to retrieve your player's state, or use the `synchronize()` function to create a new `MediaPlayerSynchronizer` instance tied to your `IMediaPlayer` instance."
             );
         }
 

--- a/packages/live-share-media/src/LiveMediaSession.ts
+++ b/packages/live-share-media/src/LiveMediaSession.ts
@@ -310,7 +310,7 @@ export class LiveMediaSession extends LiveDataObject {
     private getCurrentPlayerState(): IMediaPlayerState {
         if (!this._requestPlayerStateHandler) {
             throw new Error(
-                "LiveMediaSession:getCurrentPlayerState - no getPlayerState callback configured.\nTo fix this error, ensure `setRequestPlayerStateHandler()` has been set with a delegate to retrieve your player's state, or use the `synchronize()` function to create a new `MediaPlayerSynchronizer` instance tied to your `IMediaPlayer` instance."
+                "LiveMediaSession:getCurrentPlayerState - no `requestPlayerStateHandler` callback configured.\nTo fix this error, ensure `setRequestPlayerStateHandler()` has been set with a delegate to retrieve your player's state, or use the `synchronize()` function to create a new `MediaPlayerSynchronizer` instance tied to your `IMediaPlayer` instance."
             );
         }
 

--- a/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
+++ b/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
@@ -646,7 +646,7 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
                     const playerNotSetup =
                         isErrorLike(err) &&
                         err.message.includes(
-                            "LiveMediaSession: no getPlayerState callback configured."
+                            "LiveMediaSession:getCurrentPlayerState"
                         );
                     if (!playerNotSetup) {
                         throw err;

--- a/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
+++ b/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
@@ -11,6 +11,9 @@ import {
     TimeInterval,
     UserMeetingRole,
     LiveShareRuntime,
+    LiveDataObjectInitializeState,
+    LiveDataObjectInitializeNotNeededError,
+    LiveDataObjectNotInitializedError,
 } from "@microsoft/live-share";
 import {
     CoordinationWaitPoint,
@@ -26,6 +29,8 @@ import {
     GroupCoordinatorState,
     GroupCoordinatorStateEvents,
     ISetTrackDataEvent,
+    TrackMetadataNotSetError,
+    ActionBlockedError,
 } from "./internals";
 import { LiveMediaSessionCoordinatorSuspension } from "./LiveMediaSessionCoordinatorSuspension";
 import EventEmitter from "events";
@@ -72,7 +77,8 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
     private _positionUpdateInterval = new TimeInterval(2000);
     private _maxPlaybackDrift = new TimeInterval(1000);
     private _lastWaitPoint?: CoordinationWaitPoint;
-    private _hasInitialized = false;
+    private initializeState: LiveDataObjectInitializeState =
+        LiveDataObjectInitializeState.needed;
 
     // Broadcast events
     private _playEvent?: LiveEventTarget<ITransportCommandEvent>;
@@ -214,23 +220,22 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
      * @returns a void promise that resolves once complete, throws if user does not have proper roles
      */
     public async play(): Promise<void> {
-        if (!this._hasInitialized) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.play() called before initialize() called.`
-            );
-        }
-
-        if (!this._groupState?.playbackTrack.current.metadata) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.play() called before MediaSession.metadata assigned.`
-            );
-        }
-
-        if (!this.canPlayPause) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.play() operation blocked.`
-            );
-        }
+        LiveDataObjectNotInitializedError.assert(
+            "LiveMediaSessionCoordinator:play",
+            "play",
+            this.initializeState
+        );
+        TrackMetadataNotSetError.assert(
+            !!this._groupState?.playbackTrack.current.metadata,
+            "LiveMediaSessionCoordinator:play",
+            "play"
+        );
+        ActionBlockedError.assert(
+            this.canPlayPause,
+            "LiveMediaSessionCoordinator:play",
+            "play",
+            "canPlayPause"
+        );
 
         // Get projected position
         const position = this.getPlayerPosition();
@@ -257,23 +262,22 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
      * @returns a void promise that resolves once complete, throws if user does not have proper roles
      */
     public async pause(): Promise<void> {
-        if (!this._hasInitialized) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.pause() called before initialize() called.`
-            );
-        }
-
-        if (!this._groupState?.playbackTrack.current.metadata) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.pause() called before MediaSession.metadata assigned.`
-            );
-        }
-
-        if (!this.canPlayPause) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.pause() operation blocked.`
-            );
-        }
+        LiveDataObjectNotInitializedError.assert(
+            "LiveMediaSessionCoordinator:pause",
+            "pause",
+            this.initializeState
+        );
+        TrackMetadataNotSetError.assert(
+            !!this._groupState?.playbackTrack.current.metadata,
+            "LiveMediaSessionCoordinator:pause",
+            "pause"
+        );
+        ActionBlockedError.assert(
+            this.canPlayPause,
+            "LiveMediaSessionCoordinator:pause",
+            "pause",
+            "canPlayPause"
+        );
 
         // Get projected position
         const position = this.getPlayerPosition();
@@ -300,23 +304,22 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
      * @returns a void promise that resolves once complete, throws if user does not have proper roles
      */
     public async seekTo(time: number): Promise<void> {
-        if (!this._hasInitialized) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.seekTo() called before initialize() called.`
-            );
-        }
-
-        if (!this._groupState?.playbackTrack.current.metadata) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.seekTo() called before MediaSession.metadata assigned.`
-            );
-        }
-
-        if (!this.canSeek) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.seekTo() operation blocked.`
-            );
-        }
+        LiveDataObjectNotInitializedError.assert(
+            "LiveMediaSessionCoordinator:seekTo",
+            "seekTo",
+            this.initializeState
+        );
+        TrackMetadataNotSetError.assert(
+            !!this._groupState?.playbackTrack.current.metadata,
+            "LiveMediaSessionCoordinator:seekTo",
+            "seekTo"
+        );
+        ActionBlockedError.assert(
+            this.canSeek,
+            "LiveMediaSessionCoordinator:seekTo",
+            "seekTo",
+            "canSeek"
+        );
 
         // Send transport command
         this._logger.sendTelemetryEvent(
@@ -349,17 +352,17 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
         metadata: ExtendedMediaMetadata | null,
         waitPoints?: CoordinationWaitPoint[]
     ): Promise<void> {
-        if (!this._hasInitialized) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.setTrack() called before initialize() called.`
-            );
-        }
-
-        if (!this.canSetTrack) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.setTrack() operation blocked.`
-            );
-        }
+        LiveDataObjectNotInitializedError.assert(
+            "LiveMediaSessionCoordinator:setTrack",
+            "setTrack",
+            this.initializeState
+        );
+        ActionBlockedError.assert(
+            this.canSetTrack,
+            "LiveMediaSessionCoordinator:setTrack",
+            "setTrack",
+            "canSetTrack"
+        );
 
         // Send transport command
         this._logger.sendTelemetryEvent(
@@ -384,17 +387,17 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
      * @returns a void promise that resolves once complete, throws if user does not have proper roles
      */
     public async setTrackData(data: object | null): Promise<void> {
-        if (!this._hasInitialized) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.setTrackData() called before initialize() called.`
-            );
-        }
-
-        if (!this.canSetTrackData) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.setTrackData() operation blocked.`
-            );
-        }
+        LiveDataObjectNotInitializedError.assert(
+            "LiveMediaSessionCoordinator:setTrackData",
+            "setTrackData",
+            this.initializeState
+        );
+        ActionBlockedError.assert(
+            this.canSetTrackData,
+            "LiveMediaSessionCoordinator:setTrackData",
+            "setTrackData",
+            "canSetTrackData"
+        );
 
         // Send transport command
         this._logger.sendTelemetryEvent(
@@ -432,17 +435,16 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
     public beginSuspension(
         waitPoint?: CoordinationWaitPoint
     ): MediaSessionCoordinatorSuspension {
-        if (!this._hasInitialized) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.beginSuspension() called before initialize() called.`
-            );
-        }
-
-        if (!this._groupState?.playbackTrack.current.metadata) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.beginSuspension() called before MediaSession.metadata assigned.`
-            );
-        }
+        LiveDataObjectNotInitializedError.assert(
+            "LiveMediaSessionCoordinator:beginSuspension",
+            "beginSuspension",
+            this.initializeState
+        );
+        TrackMetadataNotSetError.assert(
+            !!this._groupState?.playbackTrack.current.metadata,
+            "LiveMediaSessionCoordinator:beginSuspension",
+            "beginSuspension"
+        );
 
         // Tell group state that suspension is started
         if (waitPoint) {
@@ -496,7 +498,7 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
      * Called by MediaSession to verify the coordinator has been initialized.
      */
     public get isInitialized(): boolean {
-        return this._hasInitialized;
+        return this.initializeState === LiveDataObjectInitializeState.succeeded;
     }
 
     /**
@@ -506,15 +508,20 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
     public async initialize(
         acceptTransportChangesFrom?: UserMeetingRole[]
     ): Promise<void> {
-        if (this._hasInitialized) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.initialize() already initialized.`
-            );
-        }
+        LiveDataObjectInitializeNotNeededError.assert(
+            "LiveMediaSessionCoordinator:initialize",
+            this.initializeState
+        );
+        this.initializeState = LiveDataObjectInitializeState.pending;
 
-        // Create children
-        await this.createChildren(acceptTransportChangesFrom);
-        this._hasInitialized = true;
+        try {
+            // Create children
+            await this.createChildren(acceptTransportChangesFrom);
+        } catch (error: unknown) {
+            this.initializeState = LiveDataObjectInitializeState.needed;
+            throw error;
+        }
+        this.initializeState = LiveDataObjectInitializeState.succeeded;
     }
 
     /**
@@ -534,11 +541,11 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
      * Called by MediaSession to trigger the sending of a position update.
      */
     public sendPositionUpdate(state: IMediaPlayerState): void {
-        if (!this._hasInitialized) {
-            throw new Error(
-                `LiveMediaSessionCoordinator.sendPositionUpdate() called before initialize() called.`
-            );
-        }
+        LiveDataObjectNotInitializedError.assert(
+            "LiveMediaSessionCoordinator:sendPositionUpdate",
+            "sendPositionUpdate",
+            this.initializeState
+        );
 
         if (this.canSendPositionUpdates) {
             // Send position update event

--- a/packages/live-share-media/src/MediaPlayerSynchronizer.ts
+++ b/packages/live-share-media/src/MediaPlayerSynchronizer.ts
@@ -483,7 +483,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
     public beginSeek(): void {
         if (this._seekSuspension) {
             throw new Error(
-                `MediaPlayerSynchronizer: cannot begin seek. A seek is already in progress.`
+                "MediaPlayerSynchronizer:beginSeek - cannot begin seek since a seek is already in progress.\nTo prevent this error, ensure you first call `endSeek()` before calling `beginSeek()` again."
             );
         }
 
@@ -500,7 +500,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
     public endSeek(seekTo: number): void {
         if (!this._seekSuspension) {
             throw new Error(
-                `MediaPlayerSynchronizer: cannot end seek. No seek is in progress.`
+                "MediaPlayerSynchronizer:endSeek - cannot end seek while no seek is in progress.\nTo prevent this error, ensure you first call `beginSeek()`."
             );
         }
 

--- a/packages/live-share-media/src/internals/GroupCoordinatorState.ts
+++ b/packages/live-share-media/src/internals/GroupCoordinatorState.ts
@@ -290,7 +290,9 @@ export class GroupCoordinatorState extends EventEmitter {
 
     public endSuspension(syncState: boolean): void {
         if (this._suspensionCnt == 0) {
-            throw new Error(`Too many suspensions.`);
+            throw new Error(
+                `GroupCoordinatorState:endSuspension - cannot end suspension when there are no active suspensions. The expected value is > 0 but the actual count is ${this._suspensionCnt}`
+            );
         }
 
         this._suspensionCnt--;

--- a/packages/live-share-media/src/internals/errors.ts
+++ b/packages/live-share-media/src/internals/errors.ts
@@ -1,0 +1,42 @@
+/**
+ * @hidden
+ * Use for operations that are blocked due to the metadata not being set.
+ */
+export class TrackMetadataNotSetError extends Error {
+    constructor(prefix: string, callingFunction: string) {
+        super(
+            `${prefix} -  called before playback track metadata has been assigned.\nTo fix this error, ensure \`setTrack()\` has been called with the track information before calling \`${callingFunction}()\``
+        );
+    }
+
+    static assert(
+        condition: boolean,
+        prefix: string,
+        callingFunction: string
+    ): asserts condition {
+        if (condition) return;
+        throw new TrackMetadataNotSetError(prefix, callingFunction);
+    }
+}
+
+/**
+ * @hidden
+ * Use for operations that are blocked due to the metadata not being set.
+ */
+export class ActionBlockedError extends Error {
+    constructor(prefix: string, callingFunction: string, settingName: string) {
+        super(
+            `${prefix} - operation blocked due to \`${settingName}\` being set to false.\nTo fix this error, ensure \`${settingName}\` is true before calling \`${callingFunction}()\`, or set \`${settingName}\` to true. If you are using \`MediaPlayerSynchronizer\`, you can instead use the \`viewOnly\`, which when set to false, it will set \`${settingName}\` value to true.`
+        );
+    }
+
+    static assert(
+        condition: boolean,
+        prefix: string,
+        callingFunction: string,
+        settingName: string
+    ): asserts condition {
+        if (condition) return;
+        throw new ActionBlockedError(prefix, callingFunction, settingName);
+    }
+}

--- a/packages/live-share-media/src/internals/index.ts
+++ b/packages/live-share-media/src/internals/index.ts
@@ -9,3 +9,4 @@ export * from "./GroupPlaybackPosition";
 export * from "./GroupPlaybackTrack";
 export * from "./GroupPlaybackTrackData";
 export * from "./GroupTransportState";
+export * from "./errors";

--- a/packages/live-share-media/src/test/LiveMediaSession_ManualActionHandler.spec.ts
+++ b/packages/live-share-media/src/test/LiveMediaSession_ManualActionHandler.spec.ts
@@ -17,7 +17,7 @@ import {
     UserMeetingRole,
 } from "@microsoft/live-share";
 import { TestLiveShareHost } from "@microsoft/live-share";
-import { getLiveDataObjectClassProxy } from "@microsoft/live-share";
+import { getLiveDataObjectClass } from "@microsoft/live-share";
 import { waitForDelay } from "@microsoft/live-share/src/internals";
 import { MockLiveShareRuntime } from "@microsoft/live-share/src/test/MockLiveShareRuntime";
 import {
@@ -45,11 +45,11 @@ async function getObjects(
         timestampProvider
     );
 
-    let ObjectProxy1: any = getLiveDataObjectClassProxy<TestLiveMediaSession>(
+    let ObjectProxy1: any = getLiveDataObjectClass<TestLiveMediaSession>(
         TestLiveMediaSession,
         liveRuntime1
     );
-    let ObjectProxy2: any = getLiveDataObjectClassProxy<TestLiveMediaSession>(
+    let ObjectProxy2: any = getLiveDataObjectClass<TestLiveMediaSession>(
         TestLiveMediaSession,
         liveRuntime2
     );

--- a/packages/live-share-media/src/test/LiveMediaSession_Synchronizer.spec.ts
+++ b/packages/live-share-media/src/test/LiveMediaSession_Synchronizer.spec.ts
@@ -19,7 +19,7 @@ import {
     UserMeetingRole,
 } from "@microsoft/live-share";
 import { TestLiveShareHost } from "@microsoft/live-share";
-import { getLiveDataObjectClassProxy } from "@microsoft/live-share";
+import { getLiveDataObjectClass } from "@microsoft/live-share";
 import { waitForDelay } from "@microsoft/live-share/src/internals";
 import { MockLiveShareRuntime } from "@microsoft/live-share/src/test/MockLiveShareRuntime";
 import { isErrorLike } from "@microsoft/live-share/bin/internals";
@@ -53,11 +53,11 @@ async function getObjects(
         timestampProvider
     );
 
-    let ObjectProxy1: any = getLiveDataObjectClassProxy<TestLiveMediaSession>(
+    let ObjectProxy1: any = getLiveDataObjectClass<TestLiveMediaSession>(
         TestLiveMediaSession,
         liveRuntime1
     );
-    let ObjectProxy2: any = getLiveDataObjectClassProxy<TestLiveMediaSession>(
+    let ObjectProxy2: any = getLiveDataObjectClass<TestLiveMediaSession>(
         TestLiveMediaSession,
         liveRuntime2
     );

--- a/packages/live-share-react/src/internal/index.ts
+++ b/packages/live-share-react/src/internal/index.ts
@@ -1,3 +1,2 @@
-export * from "./useSharedStateRegistry";
 export * from "./errors";
 export * from "./type-guards";

--- a/packages/live-share-react/src/providers/AzureProvider.tsx
+++ b/packages/live-share-react/src/providers/AzureProvider.tsx
@@ -13,7 +13,7 @@ import { IAzureContainerResults } from "../types";
 import {
     ISharedStateRegistryResponse,
     useSharedStateRegistry,
-} from "../internal";
+} from "../shared-hooks";
 import {
     AzureTurboClient,
     IFluidTurboClient,

--- a/packages/live-share-react/src/providers/LiveShareProvider.tsx
+++ b/packages/live-share-react/src/providers/LiveShareProvider.tsx
@@ -5,7 +5,7 @@
 
 import { IFluidContainer, LoadableObjectClassRecord } from "fluid-framework";
 import React from "react";
-import { useSharedStateRegistry } from "../internal";
+import { useSharedStateRegistry } from "../shared-hooks";
 import {
     ILiveShareClientOptions,
     ILiveShareHost,

--- a/packages/live-share-react/src/shared-hooks/index.ts
+++ b/packages/live-share-react/src/shared-hooks/index.ts
@@ -1,3 +1,4 @@
 export * from "./useSharedState";
 export * from "./useSharedMap";
 export * from "./useDynamicDDS";
+export * from "./useSharedStateRegistry";

--- a/packages/live-share-react/src/shared-hooks/useSharedStateRegistry.ts
+++ b/packages/live-share-react/src/shared-hooks/useSharedStateRegistry.ts
@@ -14,6 +14,9 @@ import {
     UpdateSharedStateAction,
 } from "../types";
 
+/**
+ * Response for the {@link useSharedStateRegistry} hook.
+ */
 export interface ISharedStateRegistryResponse {
     /**
      * Register a set state action callback
@@ -35,6 +38,9 @@ export interface ISharedStateRegistryResponse {
 
 /**
  * Hook used internally to keep track of the SharedSetStateActionMap for each unique key. It sets state values for provided keys and updates components listening to the values.
+ *
+ * @remarks
+ * Use this if you are building a custom `LiveShareProvider` or `AzureProvider` implementation in your app.
  *
  * @param results IAzureContainerResults response or undefined
  * @returns ISharedStateRegistryResponse object

--- a/packages/live-share-turbo/src/AzureTurboClient.ts
+++ b/packages/live-share-turbo/src/AzureTurboClient.ts
@@ -17,7 +17,7 @@ import {
     AzureLiveShareHost,
     ILiveShareHost,
     LiveShareRuntime,
-    getLiveShareContainerSchemaProxy,
+    getLiveContainerSchema,
 } from "@microsoft/live-share";
 import { FluidTurboClient } from "./FluidTurboClient";
 
@@ -128,7 +128,7 @@ export class AzureTurboClient extends FluidTurboClient {
     private getInjectedContainerSchema(
         initialObjects?: LoadableObjectClassRecord
     ): ContainerSchema {
-        return getLiveShareContainerSchemaProxy(
+        return getLiveContainerSchema(
             this.getContainerSchema(initialObjects),
             this._runtime
         );

--- a/packages/live-share/src/AzureLiveShareHost.ts
+++ b/packages/live-share/src/AzureLiveShareHost.ts
@@ -16,7 +16,7 @@ import { Deferred } from "./internals";
  * We provide no SLA guarantees on this implementation while it is in alpha.
  *
  * @remarks
- * To use this API, first pass your `ContainerSchema` through the `getLiveShareContainerSchemaProxy` function.
+ * To use this API, first pass your `ContainerSchema` through the `getLiveContainerSchema` function.
  * This should be done before calling `.getContainer()` or `createContainer()`.
  * Then, call `setAudience()` with the `IAzureAudience` object (in `AzureContainerServices`) returned by the `AzureClient`.
  */

--- a/packages/live-share/src/LiveDataObject.ts
+++ b/packages/live-share/src/LiveDataObject.ts
@@ -45,7 +45,7 @@ export abstract class LiveDataObject<
     protected get liveRuntime(): LiveShareRuntime {
         assert(
             this._liveRuntime !== null,
-            "LiveShareRuntime not initialized. Ensure your Fluid `ContainerSchema` was first wrapped inside of `getLiveShareSchema`, or use `.joinContainer()` in `LiveShareClient`."
+            "LiveShareRuntime not initialized. Ensure your Fluid `ContainerSchema` was first wrapped inside of `getLiveContainerSchema()` before calling `client.getContainer()` / `client.createContainer()` from your `AzureClient` (or equivalent) instance.\nAlternatively, you can use the `.joinContainer()` in `LiveShareClient`, which does this for you.\nIf you are using `LiveShareClient` and are still encountering this issue, please report this issue at https://aka.ms/teamsliveshare/issue."
         );
         return this._liveRuntime;
     }

--- a/packages/live-share/src/LiveDataObject.ts
+++ b/packages/live-share/src/LiveDataObject.ts
@@ -10,7 +10,7 @@ import {
     LiveDataObjectInitializeState,
     UserMeetingRole,
 } from "./interfaces";
-import { waitUntilConnected } from "./internals";
+import { LiveShareReportIssueLink, waitUntilConnected } from "./internals";
 
 /**
  * Extends Fluid's DataObject class. Intended for use with Live Share custom DDS's that rely on a `ILiveShareHost`.
@@ -45,7 +45,7 @@ export abstract class LiveDataObject<
     protected get liveRuntime(): LiveShareRuntime {
         assert(
             this._liveRuntime !== null,
-            "LiveShareRuntime not initialized. Ensure your Fluid `ContainerSchema` was first wrapped inside of `getLiveContainerSchema()` before calling `client.getContainer()` / `client.createContainer()` from your `AzureClient` (or equivalent) instance.\nAlternatively, you can use the `.joinContainer()` in `LiveShareClient`, which does this for you.\nIf you are using `LiveShareClient` and are still encountering this issue, please report this issue at https://aka.ms/teamsliveshare/issue."
+            `LiveShareRuntime not initialized. Ensure your Fluid \`ContainerSchema\` was first wrapped inside of \`getLiveContainerSchema()\` before calling \`client.getContainer()\` / \`client.createContainer()\` from your \`AzureClient\` (or equivalent) instance.\nAlternatively, you can use the \`.joinContainer()\` in \`LiveShareClient\`, which does this for you.\nIf you are using \`LiveShareClient\` and are still encountering this issue, please report this issue at ${LiveShareReportIssueLink}.`
         );
         return this._liveRuntime;
     }

--- a/packages/live-share/src/LivePresence.ts
+++ b/packages/live-share/src/LivePresence.ts
@@ -145,7 +145,7 @@ export class LivePresence<
         );
         // This error should not happen due to `initializeState` enum, but if it is somehow defined at this point, errors will occur.
         UnexpectedError.assert(
-            !!this._synchronizer,
+            !this._synchronizer,
             "LivePresence:initialize",
             "_synchronizer already set, which is an unexpected error."
         );

--- a/packages/live-share/src/LiveShareClient.ts
+++ b/packages/live-share/src/LiveShareClient.ts
@@ -22,7 +22,7 @@ import {
 import { LocalTimestampProvider } from "./LocalTimestampProvider";
 import { TestLiveShareHost } from "./TestLiveShareHost";
 import { LiveShareRuntime } from "./LiveShareRuntime";
-import { getLiveShareContainerSchemaProxy } from "./schema-injection-utils";
+import { getLiveContainerSchema } from "./schema-injection-utils";
 
 /**
  * @hidden
@@ -177,7 +177,7 @@ export class LiveShareClient {
             const pStartRuntime = this._runtime.start();
 
             // Apply runtime to ContainerSchema
-            const schema = getLiveShareContainerSchemaProxy(
+            const schema = getLiveContainerSchema(
                 fluidContainerSchema,
                 this._runtime
             );

--- a/packages/live-share/src/LiveShareClient.ts
+++ b/packages/live-share/src/LiveShareClient.ts
@@ -200,7 +200,7 @@ export class LiveShareClient {
                         );
                     } else {
                         throw new Error(
-                            `LiveShareClient: Unable to find fluid endpoint for: ${frsTenantInfo.serviceEndpoint}`
+                            `LiveShareClient:joinContainer - unable to find fluid endpoint for: ${frsTenantInfo.serviceEndpoint}`
                         );
                     }
                 }

--- a/packages/live-share/src/LiveState.ts
+++ b/packages/live-share/src/LiveState.ts
@@ -119,7 +119,7 @@ export class LiveState<TState = any> extends LiveDataObject<{
         );
         // This error should not happen due to prior assertion, but if it is somehow defined at this point, errors will occur.
         UnexpectedError.assert(
-            !!this._synchronizer,
+            !this._synchronizer,
             "LiveState:initialize",
             "_synchronizer already set, which implies there was an error during initialization that should not occur."
         );

--- a/packages/live-share/src/LiveTimer.ts
+++ b/packages/live-share/src/LiveTimer.ts
@@ -168,7 +168,7 @@ export class LiveTimer extends LiveDataObject<{
         );
         // This error should not happen due to prior assertion, but if it is somehow defined at this point, errors will occur.
         UnexpectedError.assert(
-            !!this._synchronizer,
+            !this._synchronizer,
             "LiveTimer:initialize",
             "_synchronizer already set, which implies there was an error during initialization that should not occur."
         );

--- a/packages/live-share/src/errors.ts
+++ b/packages/live-share/src/errors.ts
@@ -1,0 +1,78 @@
+import { LiveShareReportIssueLink } from "./internals";
+import { LiveDataObjectInitializeState } from "./interfaces";
+
+/**
+ * @hidden
+ * Use for errors that are unexpected.
+ */
+export class UnexpectedError extends Error {
+    constructor(prefix: string, message: string) {
+        super(
+            `${prefix} - ${message}\nPlease report this issue at ${LiveShareReportIssueLink}.`
+        );
+    }
+
+    static assert(
+        condition: boolean,
+        prefix: string,
+        message: string
+    ): asserts condition {
+        if (!condition) return;
+        throw new UnexpectedError(prefix, message);
+    }
+}
+
+/**
+ * @hidden
+ * Use for functions in `LiveDataObject` inherited classes that expect `initializeState` to be succeeded.
+ */
+export class LiveDataObjectNotInitializedError extends Error {
+    constructor(
+        prefix: string,
+        callerName: string,
+        initializeState: LiveDataObjectInitializeState
+    ) {
+        super(
+            `${prefix} - not initialized prior to calling \`${callerName}()\`. \`initializeState\` is \`${initializeState}\` but must equal \`succeeded\`.\nTo fix this error, ensure \`.initialize()\` has resolved before calling this function.`
+        );
+    }
+
+    static assert(
+        prefix: string,
+        callerName: string,
+        initializeState: LiveDataObjectInitializeState
+    ) {
+        if (initializeState === LiveDataObjectInitializeState.succeeded) return;
+        throw new LiveDataObjectNotInitializedError(
+            prefix,
+            callerName,
+            initializeState
+        );
+    }
+}
+
+/**
+ * @hidden
+ * Use for `.initialize()` functions in `LiveDataObject` inherited classes when initialize was already called.
+ */
+export class LiveDataObjectInitializeNotNeededError extends Error {
+    constructor(
+        prefix: string,
+        initializeState: LiveDataObjectInitializeState
+    ) {
+        super(
+            `${prefix} -  initialization is not needed. \`initializeState\` is \`${initializeState}\` but must equal \`needed\`.\nTo fix this error, ensure you only call \`.initialize()\` when \`initializeState\` equals \`needed\`.`
+        );
+    }
+
+    static assert(
+        prefix: string,
+        initializeState: LiveDataObjectInitializeState
+    ) {
+        if (initializeState === LiveDataObjectInitializeState.needed) return;
+        throw new LiveDataObjectInitializeNotNeededError(
+            prefix,
+            initializeState
+        );
+    }
+}

--- a/packages/live-share/src/errors.ts
+++ b/packages/live-share/src/errors.ts
@@ -17,7 +17,7 @@ export class UnexpectedError extends Error {
         prefix: string,
         message: string
     ): asserts condition {
-        if (!condition) return;
+        if (condition) return;
         throw new UnexpectedError(prefix, message);
     }
 }

--- a/packages/live-share/src/index.ts
+++ b/packages/live-share/src/index.ts
@@ -27,3 +27,4 @@ export * from "./LiveDataObject";
 export * from "./LiveShareRuntime";
 export * from "./AzureLiveShareHost";
 export * from "./LiveObjectSynchronizer";
+export * from "./errors";

--- a/packages/live-share/src/internals/ThrottledEventQueue.ts
+++ b/packages/live-share/src/internals/ThrottledEventQueue.ts
@@ -2,6 +2,7 @@ import { ILiveEvent } from "../interfaces";
 import { ContainerSynchronizer } from "./ContainerSynchronizer";
 import { Deferred } from "./Deferred";
 import { ObjectSynchronizerEvents } from "./consts";
+import { UnexpectedError } from "../errors";
 import { StateSyncEventContent } from "./internal-interfaces";
 
 /**
@@ -50,11 +51,11 @@ export class ThrottledEventQueue {
                             this._events,
                             ObjectSynchronizerEvents.update
                         );
-                    if (!response) {
-                        throw new Error(
-                            "ThrottledEventQueue: unable to send empty set of updates, which should not occur. Please report this issue at https://aka.ms/teamsliveshare/issue."
-                        );
-                    }
+                    UnexpectedError.assert(
+                        !!response,
+                        "ThrottledEventQueue",
+                        "unable to send empty set of updates, which should not occur."
+                    );
                     this._deferred?.resolve(response);
                 } catch (error: unknown) {
                     this._deferred?.reject(error);
@@ -64,11 +65,11 @@ export class ThrottledEventQueue {
                 }
             }, this._throttleIntervalMilli);
         }
-        if (!this._deferred) {
-            throw new Error(
-                "ThrottledEventQueue: no deferred set, which should not occur. Please report this issue at https://aka.ms/teamsliveshare/issue."
-            );
-        }
+        UnexpectedError.assert(
+            !!this._deferred,
+            "ThrottledEventQueue",
+            "no deferred set, which should not occur."
+        );
         const response = await this._deferred.promise;
         return {
             clientId: response.clientId,

--- a/packages/live-share/src/internals/consts.ts
+++ b/packages/live-share/src/internals/consts.ts
@@ -36,3 +36,8 @@ export const ObjectSynchronizerEvents = {
     update: "update",
     connect: "connect",
 };
+
+/**
+ * @hidden
+ */
+export const LiveShareReportIssueLink = "https://aka.ms/teamsliveshare/issue";

--- a/packages/live-share/src/test/LiveEvent.spec.ts
+++ b/packages/live-share/src/test/LiveEvent.spec.ts
@@ -14,7 +14,7 @@ import { MockRoleVerifier } from "./MockRoleVerifier";
 import { LocalTimestampProvider } from "../LocalTimestampProvider";
 import { UserMeetingRole, ILiveEvent } from "../interfaces";
 import { TestLiveShareHost } from "../TestLiveShareHost";
-import { getLiveDataObjectClassProxy } from "../schema-injection-utils";
+import { getLiveDataObjectClass } from "../schema-injection-utils";
 import { LiveShareRuntime } from "../LiveShareRuntime";
 import { DataObjectClass } from "fluid-framework";
 
@@ -28,7 +28,7 @@ describeNoCompat("LiveEvent", (getTestObjectProvider) => {
             timestampProvider: new LocalTimestampProvider(),
         }
     );
-    let LiveEventProxy1 = getLiveDataObjectClassProxy<LiveEvent>(
+    let LiveEventProxy1 = getLiveDataObjectClass<LiveEvent>(
         LiveEvent,
         liveRuntime1
     ) as DataObjectClass<LiveEvent>;
@@ -38,7 +38,7 @@ describeNoCompat("LiveEvent", (getTestObjectProvider) => {
             timestampProvider: new LocalTimestampProvider(),
         }
     );
-    let LiveEventProxy2 = getLiveDataObjectClassProxy<LiveEvent>(
+    let LiveEventProxy2 = getLiveDataObjectClass<LiveEvent>(
         LiveEvent,
         liveRuntime2
     ) as DataObjectClass<LiveEvent>;

--- a/packages/live-share/src/test/LiveFollowMode.spec.ts
+++ b/packages/live-share/src/test/LiveFollowMode.spec.ts
@@ -14,7 +14,7 @@ import {
     LiveFollowMode,
 } from "../LiveFollowMode";
 import { Deferred, waitForDelay } from "../internals";
-import { getLiveDataObjectClassProxy } from "../schema-injection-utils";
+import { getLiveDataObjectClass } from "../schema-injection-utils";
 import { MockLiveShareRuntime } from "./MockLiveShareRuntime";
 import { LivePresenceUser } from "../LivePresenceUser";
 
@@ -27,10 +27,10 @@ async function getObjects(getTestObjectProvider) {
     let liveRuntime1 = new MockLiveShareRuntime(false);
     let liveRuntime2 = new MockLiveShareRuntime(false);
 
-    let ObjectProxy1: any = getLiveDataObjectClassProxy<
+    let ObjectProxy1: any = getLiveDataObjectClass<
         LiveFollowMode<TestFollowData>
     >(LiveFollowMode, liveRuntime1);
-    let ObjectProxy2: any = getLiveDataObjectClassProxy<
+    let ObjectProxy2: any = getLiveDataObjectClass<
         LiveFollowMode<TestFollowData>
     >(LiveFollowMode, liveRuntime2);
 

--- a/packages/live-share/src/test/LivePresence.spec.ts
+++ b/packages/live-share/src/test/LivePresence.spec.ts
@@ -20,7 +20,7 @@ import {
     UserMeetingRole,
 } from "../interfaces";
 import { TestLiveShareHost } from "../TestLiveShareHost";
-import { getLiveDataObjectClassProxy } from "../schema-injection-utils";
+import { getLiveDataObjectClass } from "../schema-injection-utils";
 import { MockLiveShareRuntime } from "./MockLiveShareRuntime";
 
 class TestLivePresence<
@@ -44,10 +44,10 @@ async function getObjects(
         liveRuntime2.setHost(customHost);
     }
 
-    let ObjectProxy1: any = getLiveDataObjectClassProxy<
+    let ObjectProxy1: any = getLiveDataObjectClass<
         TestLivePresence<{ foo: string }>
     >(TestLivePresence, liveRuntime1);
-    let ObjectProxy2: any = getLiveDataObjectClassProxy<
+    let ObjectProxy2: any = getLiveDataObjectClass<
         TestLivePresence<{ foo: string }>
     >(TestLivePresence, liveRuntime2);
 

--- a/packages/live-share/src/test/LiveState.spec.ts
+++ b/packages/live-share/src/test/LiveState.spec.ts
@@ -9,7 +9,7 @@ import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
 import { LiveState } from "../LiveState";
 import { Deferred } from "../internals";
-import { getLiveDataObjectClassProxy } from "../schema-injection-utils";
+import { getLiveDataObjectClass } from "../schema-injection-utils";
 import { MockLiveShareRuntime } from "./MockLiveShareRuntime";
 
 interface TestStateData {
@@ -22,10 +22,10 @@ async function getObjects(getTestObjectProvider) {
     let liveRuntime1 = new MockLiveShareRuntime(false);
     let liveRuntime2 = new MockLiveShareRuntime(false);
 
-    let ObjectProxy1: any = getLiveDataObjectClassProxy<
+    let ObjectProxy1: any = getLiveDataObjectClass<
         LiveState<TestStateData>
     >(LiveState, liveRuntime1);
-    let ObjectProxy2: any = getLiveDataObjectClassProxy<
+    let ObjectProxy2: any = getLiveDataObjectClass<
         LiveState<TestStateData>
     >(LiveState, liveRuntime2);
 

--- a/packages/live-share/src/test/LiveTimer.spec.ts
+++ b/packages/live-share/src/test/LiveTimer.spec.ts
@@ -9,7 +9,7 @@ import { ITestObjectProvider } from "@fluidframework/test-utils";
 import { describeNoCompat } from "@fluidframework/test-version-utils";
 import { LiveTimer } from "../LiveTimer";
 import { Deferred, waitForDelay } from "../internals";
-import { getLiveDataObjectClassProxy } from "../schema-injection-utils";
+import { getLiveDataObjectClass } from "../schema-injection-utils";
 import { MockLiveShareRuntime } from "./MockLiveShareRuntime";
 
 async function getObjects(
@@ -20,11 +20,11 @@ async function getObjects(
     let liveRuntime1 = new MockLiveShareRuntime(false, updateInterval);
     let liveRuntime2 = new MockLiveShareRuntime(false, updateInterval);
 
-    let ObjectProxy1: any = getLiveDataObjectClassProxy<LiveTimer>(
+    let ObjectProxy1: any = getLiveDataObjectClass<LiveTimer>(
         LiveTimer,
         liveRuntime1
     );
-    let ObjectProxy2: any = getLiveDataObjectClassProxy<LiveTimer>(
+    let ObjectProxy2: any = getLiveDataObjectClass<LiveTimer>(
         LiveTimer,
         liveRuntime2
     );


### PR DESCRIPTION
- Fixed typos in error messages.
- Improved errors across the board and made dedicated error classes to make it easier to get more consistent messages and reduce likelihood of copy/paste typos (previously there were a lot for longer error messages).
- Deprecated `getLiveContainerSchemaProxy` and replaced with cleaner named `getLiveContainerSchema`
- Renamed previously hidden `getLiveDataObjectClassProxy` to `getLiveDataObjectClass`, and moved it to public so devs making custom `LiveDataObject` instances can write unit tests in our same style
- Export publicly `useSharedStateRegistry` hook in react package to enable custom context provider outside of React package (used for `LiveShareOdspProvider`.