### PR TITLE
Added enableBackgroundUpdates option for each LiveObjectSynchronizer

### DIFF
--- a/packages/live-share-media/src/LiveMediaSession.ts
+++ b/packages/live-share-media/src/LiveMediaSession.ts
@@ -205,6 +205,7 @@ export class LiveMediaSession extends LiveDataObject {
 
         // Create coordinator and listen for triggered actions
         this._coordinator = new LiveMediaSessionCoordinator(
+            this.id,
             this.runtime,
             this.liveRuntime,
             () => this.getCurrentPlayerState()

--- a/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
+++ b/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
@@ -535,13 +535,7 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
             // start needs to happen after setting initializedState to "succeeded"
             await this._synchronizer?.start(
                 undefined,
-                async (evt, sender, local) => {
-                    return await this.onReceivedConnectEvent(
-                        evt,
-                        sender,
-                        local
-                    );
-                },
+                async (evt, sender, local) => false,
                 async (connecting) => true
             );
         } catch (error: unknown) {
@@ -657,6 +651,11 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
             this._runtime,
             this._liveRuntime
         );
+
+        // todo: move this into constructor?
+        this._synchronizer.onJoinedListener = (clientId: string) => {
+            this.onReceivedConnectEvent(clientId);
+        };
     }
 
     private getPlayerPosition(): number {
@@ -672,21 +671,18 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
         }
     }
 
-    private async onReceivedConnectEvent(
-        evt: ILiveEvent<undefined>,
-        sender: string,
-        local: boolean
-    ): Promise<boolean> {
-        this._logger.sendTelemetryEvent(
-            TelemetryEvents.SessionCoordinator.RemoteConnectReceived,
-            null,
-            {
-                correlationId: LiveTelemetryLogger.formatCorrelationId(
-                    evt.clientId,
-                    evt.timestamp
-                ),
-            }
-        );
+    // private onReceivedConnectEvent(evt: ILiveEvent<undefined>) {
+    private onReceivedConnectEvent(clientId: string) {
+        // this._logger.sendTelemetryEvent(
+        //     TelemetryEvents.SessionCoordinator.RemoteConnectReceived,
+        //     null,
+        //     {
+        //         correlationId: LiveTelemetryLogger.formatCorrelationId(
+        //             evt.clientId,
+        //             evt.timestamp
+        //         ),
+        //     }
+        // );
 
         // Immediately send a position update
         try {
@@ -701,6 +697,5 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
                 throw err;
             }
         }
-        return false;
     }
 }

--- a/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
+++ b/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
@@ -677,6 +677,17 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
         sender: string,
         local: boolean
     ): Promise<boolean> {
+        this._logger.sendTelemetryEvent(
+            TelemetryEvents.SessionCoordinator.RemoteConnectReceived,
+            null,
+            {
+                correlationId: LiveTelemetryLogger.formatCorrelationId(
+                    evt.clientId,
+                    evt.timestamp
+                ),
+            }
+        );
+
         // Immediately send a position update
         try {
             const state = this._getPlayerState();

--- a/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
+++ b/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
@@ -14,6 +14,8 @@ import {
     LiveDataObjectInitializeState,
     LiveDataObjectInitializeNotNeededError,
     LiveDataObjectNotInitializedError,
+    LiveObjectSynchronizer,
+    ILiveEvent,
 } from "@microsoft/live-share";
 import {
     CoordinationWaitPoint,
@@ -70,6 +72,7 @@ export interface IMediaPlayerState {
  * in sync with the group.
  */
 export class LiveMediaSessionCoordinator extends EventEmitter {
+    private readonly _id: string;
     private readonly _runtime: IRuntimeSignaler;
     private readonly _liveRuntime: LiveShareRuntime;
     private readonly _logger: LiveTelemetryLogger;
@@ -87,7 +90,10 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
     private _setTrackEvent?: LiveEventTarget<ISetTrackEvent>;
     private _setTrackDataEvent?: LiveEventTarget<ISetTrackDataEvent>;
     private _positionUpdateEvent?: LiveEventTarget<IPositionUpdateEvent>;
-    private _joinedEvent?: LiveEventTarget<undefined>;
+
+    // Synchronizer does not play a significant role in LiveMediaSession beyond being able to
+    // use "connect" events to replace old "joined" events when sending position data to new clients.
+    private _synchronizer?: LiveObjectSynchronizer<undefined>;
 
     // Distributed state
     private _groupState?: GroupCoordinatorState;
@@ -97,11 +103,13 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
      * Applications shouldn't directly create new coordinator instances.
      */
     constructor(
+        id: string,
         runtime: IRuntimeSignaler,
         liveRuntime: LiveShareRuntime,
         getPlayerState: () => IMediaPlayerState
     ) {
         super();
+        this._id = id;
         this._runtime = runtime;
         this._liveRuntime = liveRuntime;
         this._logger = new LiveTelemetryLogger(runtime, liveRuntime);
@@ -522,6 +530,28 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
             throw error;
         }
         this.initializeState = LiveDataObjectInitializeState.succeeded;
+
+        try {
+            // start needs to happen after setting initializedState to "succeeded"
+            await this._synchronizer?.start(
+                undefined,
+                async (evt, sender, local) => {
+                    return await this.onReceivedConnectEvent(
+                        evt,
+                        sender,
+                        local
+                    );
+                },
+                async (connecting) => true
+            );
+        } catch (error: unknown) {
+            // not a fatal error for LiveMediaSession, only used for "connect" event to send new clients position updates.
+            this._logger.sendErrorEvent(
+                TelemetryEvents.SessionCoordinator
+                    .LiveObjectSynchronizerStartError,
+                error
+            );
+        }
     }
 
     /**
@@ -622,45 +652,11 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
                 this._groupState!.handlePositionUpdate(event, local)
         );
 
-        // Listen for joined event
-        this._joinedEvent = new LiveEventTarget(
-            unrestrictedScope,
-            "joined",
-            (evt, local) => {
-                // Immediately send a position update
-                this._logger.sendTelemetryEvent(
-                    TelemetryEvents.SessionCoordinator.RemoteJoinReceived,
-                    null,
-                    {
-                        correlationId: LiveTelemetryLogger.formatCorrelationId(
-                            evt.clientId,
-                            evt.timestamp
-                        ),
-                    }
-                );
-                try {
-                    const state = this._getPlayerState();
-                    this.sendPositionUpdate(state);
-                } catch (err: any) {
-                    // if player is not setup yet, local client might have also just joined and can't send its position.
-                    const playerNotSetup =
-                        isErrorLike(err) &&
-                        err.message.includes(
-                            "LiveMediaSession:getCurrentPlayerState"
-                        );
-                    if (!playerNotSetup) {
-                        throw err;
-                    }
-                }
-            }
+        this._synchronizer = new LiveObjectSynchronizer<undefined>(
+            this._id,
+            this._runtime,
+            this._liveRuntime
         );
-        // Send initial joined event
-        this._joinedEvent?.sendEvent(undefined).catch((err) => {
-            this._logger.sendErrorEvent(
-                TelemetryEvents.SessionCoordinator.SendJoinedEventError,
-                err
-            );
-        });
     }
 
     private getPlayerPosition(): number {
@@ -674,5 +670,26 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
                     ? positionState.position
                     : 0.0;
         }
+    }
+
+    private async onReceivedConnectEvent(
+        evt: ILiveEvent<undefined>,
+        sender: string,
+        local: boolean
+    ): Promise<boolean> {
+        // Immediately send a position update
+        try {
+            const state = this._getPlayerState();
+            this.sendPositionUpdate(state);
+        } catch (err: any) {
+            // if player is not setup yet, local client might have also just joined and can't send its position.
+            const playerNotSetup =
+                isErrorLike(err) &&
+                err.message.includes("LiveMediaSession:getCurrentPlayerState");
+            if (!playerNotSetup) {
+                throw err;
+            }
+        }
+        return false;
     }
 }

--- a/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
+++ b/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
@@ -536,7 +536,9 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
             await this._synchronizer?.start(
                 undefined,
                 async (evt, sender, local) => false,
-                async (connecting) => true
+                async (connecting) => true,
+                false,
+                false
             );
         } catch (error: unknown) {
             // not a fatal error for LiveMediaSession, only used for "connect" event to send new clients position updates.

--- a/packages/live-share-media/src/internals/consts.ts
+++ b/packages/live-share-media/src/internals/consts.ts
@@ -62,7 +62,6 @@ export const TelemetryEvents = {
         EndSuspensionAndWait: transmit(
             "SessionCoordinator:EndSuspensionAndWait"
         ),
-        RemoteJoinReceived: "SessionCoordinator:RemoteJoinReceived",
         RemoteSetTrackReceived: transmit(
             "SessionCoordinator:RemoteSetTrackReceived"
         ),
@@ -75,7 +74,8 @@ export const TelemetryEvents = {
             "SessionCoordinator:RemoteSeekToReceived"
         ),
         PositionUpdateEventError: "SessionCoordinator:PositionUpdateEventError",
-        SendJoinedEventError: "SessionCoordinator:SendJoinedEventError",
+        LiveObjectSynchronizerStartError:
+            "SessionCoordinator:LiveObjectSynchronizerStartError",
     },
     GroupCoordinator: {
         TrackChanged: "GroupCoordinator:TrackChanged",

--- a/packages/live-share-media/src/internals/consts.ts
+++ b/packages/live-share-media/src/internals/consts.ts
@@ -62,6 +62,7 @@ export const TelemetryEvents = {
         EndSuspensionAndWait: transmit(
             "SessionCoordinator:EndSuspensionAndWait"
         ),
+        RemoteConnectReceived: "SessionCoordinator:RemoteConnectReceived",
         RemoteSetTrackReceived: transmit(
             "SessionCoordinator:RemoteSetTrackReceived"
         ),

--- a/packages/live-share-media/src/test/LiveMediaSession_ManualActionHandler.spec.ts
+++ b/packages/live-share-media/src/test/LiveMediaSession_ManualActionHandler.spec.ts
@@ -122,43 +122,6 @@ async function getObjects(
 describeNoCompat(
     "LiveMediaSession Manual Action Handlers (mostly testing coordinator)",
     (getTestObjectProvider) => {
-        it("should send 'joined' event when joined.", async () => {
-            const { object1, object2, dispose } = await getObjects(
-                getTestObjectProvider
-            );
-
-            await object1.initialize();
-            assert(
-                object1.isInitialized,
-                "LiveMediaSession objects not initialized"
-            );
-            assert(
-                object1.coordinator.isInitialized,
-                "LiveMediaSessionCoordinator objects not initialized"
-            );
-            // wait for next event loop, simulate existing user waiting for other people to join.
-            // otherwise joined event will fire for both users
-            await waitForDelay(1);
-
-            // create a duplicate scope/target with same event name as one declared in coordinator
-            const scope1 = new LiveEventScope(
-                object1.runtimeForTesting(),
-                object1.liveRuntimeForTesting()
-            );
-
-            let joinCount = 0;
-            new LiveEventTarget(scope1, "joined", (event, local) => {
-                joinCount += 1;
-            });
-
-            await object2.initialize();
-            // wait for next event loop
-            await waitForDelay(1);
-
-            assert(joinCount == 1, `joined event not sent`);
-            dispose();
-        });
-
         it("should send 'positionUpdate' event when someone joins.", async () => {
             const { object1, object2, dispose } = await getObjects(
                 getTestObjectProvider

--- a/packages/live-share/src/LiveObjectSynchronizer.ts
+++ b/packages/live-share/src/LiveObjectSynchronizer.ts
@@ -81,6 +81,7 @@ export class LiveObjectSynchronizer<TState> {
         initialState: TState,
         updateState: UpdateSynchronizationState<TState>,
         getLocalUserCanSend: GetLocalUserCanSend,
+        // onJoined: (clientId: string) => void,
         shouldUpdateTimestampPeriodically = false
     ): Promise<void> {
         return this.liveRuntime.objectManager.registerObject<TState>(
@@ -166,6 +167,22 @@ export class LiveObjectSynchronizer<TState> {
         return this.liveRuntime.objectManager.sendThrottledEventForObject(
             this.id,
             data
+        );
+    }
+
+    // TODO: make this pretty, move into constructor, maybe add optional object for config on start?
+    private _joinedListener: (clientId: string) => void = () => {};
+    public set onJoinedListener(callback: (clientId: string) => void) {
+        this.liveRuntime.objectManager.off("joined", this._joinedListener);
+        this._joinedListener = callback;
+
+        this.liveRuntime.objectManager.on(
+            "joined",
+            ({ objectId, clientId }) => {
+                if (objectId === this.id) {
+                    this._joinedListener(clientId);
+                }
+            }
         );
     }
 }

--- a/packages/live-share/src/LiveObjectSynchronizer.ts
+++ b/packages/live-share/src/LiveObjectSynchronizer.ts
@@ -77,7 +77,8 @@ export class LiveObjectSynchronizer<TState> {
      * @param initialState The initial state for the local user. Does not impact remote state that has been set since connecting to the session.
      * @param updateState A function called to process a state update received from a remote instance. This will be called anytime a "connect" or "update" message is received.
      * @param getLocalUserCanSend A async function called to determine whether the local user can send a connect/update message. Return true if the user can send the update.
-     * @param shouldUpdateTimestampPeriodically flag for updating the timestamp whenever sending out a periodic update
+     * @param shouldUpdateTimestampPeriodically flag for updating the timestamp whenever sending out a periodic update.
+     * @param enableBackgroundUpdates flag for enabling/disabling background updates. True by default.
      */
     public start(
         initialState: TState,
@@ -173,6 +174,10 @@ export class LiveObjectSynchronizer<TState> {
         );
     }
 
+    /**
+     * Set a callback for when a new client joins the session.
+     * @param callback called when a new client joins with the clientId, and timestamp.
+     */
     public set onJoinedListener(
         callback: (clientId: string, timestamp: number) => void
     ) {

--- a/packages/live-share/src/LiveObjectSynchronizer.ts
+++ b/packages/live-share/src/LiveObjectSynchronizer.ts
@@ -55,6 +55,8 @@ import {
  */
 export class LiveObjectSynchronizer<TState> {
     private _isDisposed = false;
+    private _joinedListener: (clientId: string, timestamp: number) => void =
+        () => {};
 
     /**
      * Creates a new `LiveObjectSynchronizer` instance.
@@ -171,17 +173,17 @@ export class LiveObjectSynchronizer<TState> {
         );
     }
 
-    // TODO: make this pretty, move into constructor, maybe add optional object for config on start?
-    private _joinedListener: (clientId: string) => void = () => {};
-    public set onJoinedListener(callback: (clientId: string) => void) {
+    public set onJoinedListener(
+        callback: (clientId: string, timestamp: number) => void
+    ) {
         this.liveRuntime.objectManager.off("joined", this._joinedListener);
         this._joinedListener = callback;
 
         this.liveRuntime.objectManager.on(
             "joined",
-            ({ objectId, clientId }) => {
+            ({ objectId, clientId, timestamp }) => {
                 if (objectId === this.id) {
-                    this._joinedListener(clientId);
+                    this._joinedListener(clientId, timestamp);
                 }
             }
         );

--- a/packages/live-share/src/LiveObjectSynchronizer.ts
+++ b/packages/live-share/src/LiveObjectSynchronizer.ts
@@ -81,8 +81,8 @@ export class LiveObjectSynchronizer<TState> {
         initialState: TState,
         updateState: UpdateSynchronizationState<TState>,
         getLocalUserCanSend: GetLocalUserCanSend,
-        // onJoined: (clientId: string) => void,
-        shouldUpdateTimestampPeriodically = false
+        shouldUpdateTimestampPeriodically = false, // TODO: options object with named params for live share v2?
+        enableBackgroundUpdates = true
     ): Promise<void> {
         return this.liveRuntime.objectManager.registerObject<TState>(
             this.id,
@@ -92,7 +92,8 @@ export class LiveObjectSynchronizer<TState> {
                 updateState,
                 getLocalUserCanSend,
                 shouldUpdateTimestampPeriodically,
-            }
+            },
+            enableBackgroundUpdates
         );
     }
 

--- a/packages/live-share/src/LiveObjectSynchronizer.ts
+++ b/packages/live-share/src/LiveObjectSynchronizer.ts
@@ -84,7 +84,7 @@ export class LiveObjectSynchronizer<TState> {
         initialState: TState,
         updateState: UpdateSynchronizationState<TState>,
         getLocalUserCanSend: GetLocalUserCanSend,
-        shouldUpdateTimestampPeriodically = false, // TODO: options object with named params for live share v2?
+        shouldUpdateTimestampPeriodically = false,
         enableBackgroundUpdates = true
     ): Promise<void> {
         return this.liveRuntime.objectManager.registerObject<TState>(

--- a/packages/live-share/src/internals/ContainerSynchronizer.ts
+++ b/packages/live-share/src/internals/ContainerSynchronizer.ts
@@ -115,7 +115,9 @@ export class ContainerSynchronizer {
     public async onSendBackgroundUpdates(): Promise<void> {
         if (!this._liveRuntime.canSendBackgroundUpdates) return;
         await this.sendGroupEvent(
-            this._connectedKeys,
+            this._connectedKeys.filter((key) =>
+                this._ddsBackgroundUpdateEnabled.has(key)
+            ),
             ObjectSynchronizerEvents.update
         ).catch((err) => console.error(err));
     }

--- a/packages/live-share/src/internals/ContainerSynchronizer.ts
+++ b/packages/live-share/src/internals/ContainerSynchronizer.ts
@@ -21,7 +21,6 @@ export class ContainerSynchronizer {
     private _throttledEventsQueue: ThrottledEventQueue =
         new ThrottledEventQueue(this);
     private _connectedKeys: string[] = [];
-    private _refCount = 0;
     private _hTimer: NodeJS.Timeout | undefined;
     private _connectSentForClientId?: string;
     private _onBoundConnectedListener?: (clientId: string) => Promise<void>;
@@ -31,6 +30,7 @@ export class ContainerSynchronizer {
         local: boolean
     ) => Promise<void>;
     private _onSendUpdatesIntervalCallback?: () => Promise<void>;
+    private _ddsBackgroundUpdateEnabled: Set<string> = new Set<string>();
 
     constructor(
         private readonly _runtime: IRuntimeSignaler,
@@ -43,7 +43,8 @@ export class ContainerSynchronizer {
 
     public registerObject(
         id: string,
-        handlers: GetAndUpdateStateHandlers<any>
+        handlers: GetAndUpdateStateHandlers<any>,
+        enableBackgroundUpdates: boolean
     ): void {
         if (this._objects.has(id)) {
             throw new Error(
@@ -72,8 +73,11 @@ export class ContainerSynchronizer {
         });
 
         // Start update timer on first ref
-        if (this._refCount++ == 0) {
-            this.startBackgroundObjectUpdates();
+        if (enableBackgroundUpdates) {
+            this._ddsBackgroundUpdateEnabled.add(id);
+            if (this._ddsBackgroundUpdateEnabled.size == 1) {
+                this.startBackgroundObjectUpdates();
+            }
         }
     }
 
@@ -82,16 +86,22 @@ export class ContainerSynchronizer {
             // Remove object ref
             this._objects.delete(id);
 
-            // Stop update timer on last de-ref
-            if (--this._refCount == 0) {
-                this.stopBackgroundObjectUpdates();
-                return true;
-            }
-
             // Remove id from key lists
             this._connectedKeys = this._connectedKeys.filter(
                 (key) => key != id
             );
+
+            const ddsBackgroundUpdateEnabled =
+                this._ddsBackgroundUpdateEnabled.has(id);
+
+            // Stop update timer on last de-ref
+            if (ddsBackgroundUpdateEnabled) {
+                this._ddsBackgroundUpdateEnabled.delete(id);
+                if (this._ddsBackgroundUpdateEnabled.size == 0) {
+                    this.stopBackgroundObjectUpdates();
+                    return true;
+                }
+            }
         }
 
         return false;

--- a/packages/live-share/src/internals/LiveObjectManager.ts
+++ b/packages/live-share/src/internals/LiveObjectManager.ts
@@ -321,7 +321,11 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
             clientMap.set(event.clientId, event);
             this.objectStoreMap.set(objectId, clientMap);
             // todo: some event name that fits the case of dds being ready to listen
-            this.emit("joined", { objectId, clientId: event.clientId });
+            this.emit("joined", {
+                objectId,
+                clientId: event.clientId,
+                timestamp: event.timestamp,
+            });
         }
         return true;
     }

--- a/packages/live-share/src/internals/LiveObjectManager.ts
+++ b/packages/live-share/src/internals/LiveObjectManager.ts
@@ -83,7 +83,8 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
         id: string,
         runtime: IRuntimeSignaler,
         initialState: TState,
-        handlers: GetAndUpdateStateHandlers<TState>
+        handlers: GetAndUpdateStateHandlers<TState>,
+        enableBackgroundUpdates: boolean
     ): Promise<void> {
         // Get/create containers synchronizer
         if (!this._synchronizer) {
@@ -96,7 +97,11 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
         }
 
         // Register object
-        this._synchronizer.registerObject(id, handlers);
+        this._synchronizer.registerObject(
+            id,
+            handlers,
+            enableBackgroundUpdates
+        );
 
         const initialEvent: ILiveEvent<TState> = {
             clientId: await waitUntilConnected(runtime),

--- a/packages/live-share/src/internals/LiveObjectManager.ts
+++ b/packages/live-share/src/internals/LiveObjectManager.ts
@@ -306,10 +306,17 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
                 if (!LiveEvent.isNewer(existingEvent, event)) return false;
             }
             clientMap.set(event.clientId, event);
+            if (!existingEvent) {
+                // first event from client for objectId, can now consider them joined on that object
+                // todo: some event name that fits the case of dds being ready to listen
+                this.emit("joined", { objectId, clientId: event.clientId });
+            }
         } else {
             clientMap = new Map();
             clientMap.set(event.clientId, event);
             this.objectStoreMap.set(objectId, clientMap);
+            // todo: some event name that fits the case of dds being ready to listen
+            this.emit("joined", { objectId, clientId: event.clientId });
         }
         return true;
     }

--- a/packages/live-share/src/test/LiveObjectSynchronizer.spec.ts
+++ b/packages/live-share/src/test/LiveObjectSynchronizer.spec.ts
@@ -6,7 +6,7 @@
 import { strict as assert } from "assert";
 import { LiveObjectSynchronizer } from "../LiveObjectSynchronizer";
 import { MockRuntimeSignaler } from "./MockRuntimeSignaler";
-import { Deferred } from "../internals";
+import { Deferred, waitForDelay } from "../internals";
 import { MockLiveShareRuntime } from "./MockLiveShareRuntime";
 
 interface ITestState {
@@ -170,15 +170,19 @@ describe("LiveObjectSynchronizer", () => {
                     assert(sender, `local: sender  ID not received`);
                     // The event is only emitted when the timestamp of a value has changed
                     changesEmitted++;
-                    assert(changesEmitted < 2, "received is >= 2");
+                    assert(changesEmitted < 6, "received is >= 6");
                 } catch (err) {
                     done.reject(err);
                 }
                 return Promise.resolve(true);
             },
-            () => {
+            (connecting) => {
+                if (connecting) {
+                    // counting updates not connects
+                    return Promise.resolve(true);
+                }
                 sent++;
-                if (sent == 2) {
+                if (sent == 6) {
                     done.resolve();
                 }
                 // If this is called, it will send out an update
@@ -201,6 +205,68 @@ describe("LiveObjectSynchronizer", () => {
         );
 
         await done.promise;
+        localObject.dispose();
+        remoteObject.dispose();
+        localLiveRuntime.stop();
+        remoteLiveRuntime.stop();
+    });
+
+    it("Should not send periodic updates if dds specific enableBackgroundUpdates is false", async () => {
+        const localLiveRuntime = new MockLiveShareRuntime(true, 20);
+        const remoteLiveRuntime = new MockLiveShareRuntime(true, 20);
+        localLiveRuntime.connectToOtherRuntime(remoteLiveRuntime);
+        await localLiveRuntime.start();
+        await remoteLiveRuntime.start();
+
+        let sent = 0;
+        const done = new Deferred();
+        const localRuntime = new MockRuntimeSignaler();
+        const localObject = new LiveObjectSynchronizer<ITestState>(
+            "test",
+            localRuntime,
+            localLiveRuntime
+        );
+        await localObject.start(
+            { client: "local" },
+            (state, sender) => {
+                done.reject();
+                return Promise.resolve(true);
+            },
+            (connecting) => {
+                if (connecting) {
+                    // counting updates not connects
+                    return Promise.resolve(true);
+                }
+                sent++;
+                if (sent == 6) {
+                    // should never resolve, see race with timeout at end
+                    done.resolve();
+                }
+                // If this is called, it will send out an update
+                return Promise.resolve(true);
+            },
+            false,
+            false
+        );
+
+        const remoteRuntime = new MockRuntimeSignaler();
+        const remoteObject = new LiveObjectSynchronizer<ITestState>(
+            "test",
+            remoteRuntime,
+            remoteLiveRuntime
+        );
+        await remoteObject.start(
+            { client: "remote" },
+            (state, sender) => {
+                return Promise.resolve(true);
+            },
+            () => Promise.resolve(true),
+            false,
+            false
+        );
+
+        await Promise.race([done.promise, waitForDelay(300)]);
+        assert(sent == 0, `sent ${sent} updates when no updates was expected`);
         localObject.dispose();
         remoteObject.dispose();
         localLiveRuntime.stop();

--- a/packages/live-share/src/test/LiveObjectSynchronizer.spec.ts
+++ b/packages/live-share/src/test/LiveObjectSynchronizer.spec.ts
@@ -183,6 +183,7 @@ describe("LiveObjectSynchronizer", () => {
                 }
                 sent++;
                 if (sent == 6) {
+                    // 6 background updates
                     done.resolve();
                 }
                 // If this is called, it will send out an update


### PR DESCRIPTION
Added `enableBackgroundUpdates` option for each `LiveObjectSynchronizer` instance. This flag is set to false on `LiveMediaSession`.

Replaced `joined` event in `LiveMediaSession` with LiveObjectSynchronizer `connect` event. This cuts down on an additional signal sent by every client when first joining the session.

<img width="1646" alt="image" src="https://github.com/microsoft/live-share-sdk/assets/10103298/242f7a70-626b-43a0-825f-0025fcf89bd5">


validation: 
LiveMediaSession object Id: `515a1cdd-afdc-4bd3-8c4f-1f01641c7754`

LiveMediaSession initial data is part of connect signal.
```json
[
  "submitSignal",
  "74c72476-bd2d-4b9a-888d-4cb8494bc424",
  [
    [
      "{\"clientSignalSequenceNumber\":2,\"contents\":{\"type\":\"connect\",\"content\":{\"clientId\":\"74c72476-bd2d-4b9a-888d-4cb8494bc424\",\"data\":{\"63f73608-6889-4896-ba85-310662f8b210\":{\"data\":{\"status\":\"WAITING\"},\"timestamp\":0},\"515a1cdd-afdc-4bd3-8c4f-1f01641c7754\":{\"timestamp\":0}},\"timestamp\":0,\"name\":\"connect\"}}}"
    ]
  ]
]
```

LiveMediaSession is not part of update signals.
```json
[
  "submitSignal",
  "74c72476-bd2d-4b9a-888d-4cb8494bc424",
  [
    [
      "{\"clientSignalSequenceNumber\":8,\"contents\":{\"type\":\"update\",\"content\":{\"clientId\":\"74c72476-bd2d-4b9a-888d-4cb8494bc424\",\"data\":{\"63f73608-6889-4896-ba85-310662f8b210\":{\"data\":{\"status\":\"WAITING\"},\"timestamp\":0}},\"timestamp\":1707260718431,\"name\":\"update\"}}}"
    ]
  ]
]
```