### PR TITLE
Cleanup from adding enableBackgroundUpdates flag

### DIFF
--- a/packages/live-share/src/LiveObjectSynchronizer.ts
+++ b/packages/live-share/src/LiveObjectSynchronizer.ts
@@ -107,6 +107,7 @@ export class LiveObjectSynchronizer<TState> {
         if (!this._isDisposed) {
             this._isDisposed = true;
             this.liveRuntime.objectManager.unregisterObject(this.id);
+            this.liveRuntime.objectManager.off("joined", this._joinedListener);
         }
     }
 

--- a/packages/live-share/src/internals/LiveObjectManager.ts
+++ b/packages/live-share/src/internals/LiveObjectManager.ts
@@ -313,21 +313,23 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
             clientMap.set(event.clientId, event);
             if (!existingEvent) {
                 // first event from client for objectId, can now consider them joined on that object
-                // todo: some event name that fits the case of dds being ready to listen
-                this.emit("joined", { objectId, clientId: event.clientId });
+                this.emitJoined(objectId, event);
             }
         } else {
             clientMap = new Map();
             clientMap.set(event.clientId, event);
             this.objectStoreMap.set(objectId, clientMap);
-            // todo: some event name that fits the case of dds being ready to listen
-            this.emit("joined", {
-                objectId,
-                clientId: event.clientId,
-                timestamp: event.timestamp,
-            });
+            this.emitJoined(objectId, event);
         }
         return true;
+    }
+
+    private emitJoined(objectId: string, event: ILiveEvent<any>) {
+        this.emit("joined", {
+            objectId,
+            clientId: event.clientId,
+            timestamp: event.timestamp,
+        });
     }
 
     private startReceivingSignalUpdates() {


### PR DESCRIPTION
I forgot timestamp param in `joined` emit, which caused the correlation id on the telemetry event to have undefined for the timestamp.

<img width="316" alt="image" src="https://github.com/microsoft/live-share-sdk/assets/10103298/5ec19231-5e36-414b-9ff3-31c94546a51b">
<img width="510" alt="image" src="https://github.com/microsoft/live-share-sdk/assets/10103298/97c9fe68-a510-41de-a40c-5d2c5d771644">
