### PR TITLE
MediaPlayerSynchronizer groupaction events now emit ignored actions during suspension, with ignored reason

### DIFF
--- a/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
+++ b/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
@@ -624,6 +624,11 @@ export class LiveMediaSessionCoordinator extends EventEmitter {
             this.emit(evt.name, evt)
         );
 
+        this._groupState.on(
+            GroupCoordinatorStateEvents.triggeractionignored,
+            (evt) => this.emit(evt.name, evt)
+        );
+
         // Listen for track changes
         this._setTrackEvent = new LiveEventTarget<ISetTrackEvent>(
             scope,

--- a/packages/live-share-media/src/MediaPlayerSynchronizer.ts
+++ b/packages/live-share-media/src/MediaPlayerSynchronizer.ts
@@ -20,7 +20,7 @@ import {
 import { VolumeManager } from "./VolumeManager";
 import { LiveMediaSession } from "./LiveMediaSession";
 import { IMediaPlayer } from "./IMediaPlayer";
-import { TelemetryEvents } from "./internals";
+import { ITriggerActionEvent, TelemetryEvents } from "./internals";
 import { waitUntilConnected } from "@microsoft/live-share/bin/internals";
 
 /**
@@ -242,7 +242,7 @@ export class MediaPlayerSynchronizer extends EventEmitter {
                 case "blocked":
                     this._logger.sendTelemetryEvent(
                         TelemetryEvents.MediaPlayerSynchronizer
-                            .PlaybackRateChangeBlocked
+                            .PlayerBlockedOperation
                     );
                     break;
             }
@@ -252,6 +252,13 @@ export class MediaPlayerSynchronizer extends EventEmitter {
         this._mediaSession.coordinator.on(
             MediaSessionCoordinatorEvents.coordinatorstatechange,
             (evt) => this.emit(evt.type, evt)
+        );
+
+        this._mediaSession.coordinator.on(
+            MediaSessionCoordinatorEvents.triggeractionignored,
+            (evt: ITriggerActionEvent) => {
+                this.dispatchGroupAction(evt.details, undefined);
+            }
         );
 
         // Register media session actions
@@ -687,7 +694,6 @@ export class MediaPlayerSynchronizer extends EventEmitter {
         });
     }
 
-    // TODO: what is delay useful for? we do not use, delete?
     private dispatchGroupAction(
         details: ExtendedMediaSessionActionDetails,
         error: Error | undefined

--- a/packages/live-share-media/src/MediaSessionExtensions.ts
+++ b/packages/live-share-media/src/MediaSessionExtensions.ts
@@ -59,6 +59,10 @@ export enum MediaSessionCoordinatorEvents {
      * Event emitted when an action was triggered.
      */
     triggeraction = "triggeraction",
+    /**
+     * Event emitted when an action would have been triggered, but a suspension is active for the local client.
+     */
+    triggeractionignored = "triggeractionignored",
 }
 
 /**
@@ -117,6 +121,15 @@ export interface ExtendedMediaMetadata extends MediaMetadata {
 }
 
 /**
+ * The reasons why an action is ignored.
+ *
+ * @remarks
+ * Is `localusersuspended` when the action updated the group state, but ignored locally due to the local client being suspended.
+
+ */
+export type ExtendedMediaSessionActionIgnore = "localusersuspended";
+
+/**
  * Details for emitted actions from `LiveMediaSession`.
  *
  * @remarks
@@ -170,8 +183,14 @@ export interface ExtendedMediaSessionActionDetails {
     data?: object | null;
     /**
      * Action type that was blocked.
+     * TODO: does this make sense to have? blocked is never used anywhere, and in my use case would always be equal to action property
      */
-    blocked?: ExtendedMediaSessionAction | null;
+    // blocked?: ExtendedMediaSessionAction | null;
+
+    /**
+     * Reason for Action type being blocked.
+     */
+    ignored?: ExtendedMediaSessionActionIgnore | null;
 }
 
 /**

--- a/packages/live-share-media/src/MediaSessionExtensions.ts
+++ b/packages/live-share-media/src/MediaSessionExtensions.ts
@@ -182,7 +182,7 @@ export interface ExtendedMediaSessionActionDetails {
      */
     data?: object | null;
     /**
-     * Reason for Action type being blocked.
+     * Reason an action is ignored by the local client, undefined if not ignored.
      */
     ignored?: ExtendedMediaSessionActionIgnore | null;
 }

--- a/packages/live-share-media/src/MediaSessionExtensions.ts
+++ b/packages/live-share-media/src/MediaSessionExtensions.ts
@@ -182,12 +182,6 @@ export interface ExtendedMediaSessionActionDetails {
      */
     data?: object | null;
     /**
-     * Action type that was blocked.
-     * TODO: does this make sense to have? blocked is never used anywhere, and in my use case would always be equal to action property
-     */
-    // blocked?: ExtendedMediaSessionAction | null;
-
-    /**
      * Reason for Action type being blocked.
      */
     ignored?: ExtendedMediaSessionActionIgnore | null;

--- a/packages/live-share-media/src/MediaSessionExtensions.ts
+++ b/packages/live-share-media/src/MediaSessionExtensions.ts
@@ -184,7 +184,7 @@ export interface ExtendedMediaSessionActionDetails {
     /**
      * Reason an action is ignored by the local client, undefined if not ignored.
      */
-    ignored?: ExtendedMediaSessionActionIgnore | null;
+    ignoreReason?: ExtendedMediaSessionActionIgnore | null;
 }
 
 /**

--- a/packages/live-share-media/src/internals/GroupCoordinatorState.ts
+++ b/packages/live-share-media/src/internals/GroupCoordinatorState.ts
@@ -87,6 +87,7 @@ export interface ITriggerActionEvent extends IEvent {
 export enum GroupCoordinatorStateEvents {
     newwaitpoint = "newwaitpoint",
     triggeraction = "triggeraction",
+    triggeractionignored = "triggeractionignored",
 }
 
 /**
@@ -167,19 +168,19 @@ export class GroupCoordinatorState extends EventEmitter {
                     this._logger.sendTelemetryEvent(
                         TelemetryEvents.GroupCoordinator.TrackDataChanged
                     );
-                    const clientId = await waitUntilConnected(this._runtime);
-                    this.emitTriggerAction({
-                        action: "datachange",
-                        source: evt.source,
-                        data: evt.data,
-                        clientId: evt.clientId,
-                        local: evt.clientId === clientId,
-                    });
                 } else {
                     this._logger.sendTelemetryEvent(
                         TelemetryEvents.GroupCoordinator.TrackDataChangeDelayed
                     );
                 }
+                const clientId = await waitUntilConnected(this._runtime);
+                this.emitTriggerActionOrIgnored({
+                    action: "datachange",
+                    source: evt.source,
+                    data: evt.data,
+                    clientId: evt.clientId,
+                    local: evt.clientId === clientId,
+                });
             }
         );
 
@@ -196,43 +197,6 @@ export class GroupCoordinatorState extends EventEmitter {
                             seekTime: evt.seekTime,
                         }
                     );
-
-                    const localClientId = await waitUntilConnected(
-                        this._runtime
-                    );
-                    const local = evt.clientId === localClientId;
-                    // Trigger action
-                    switch (evt.action) {
-                        case "play":
-                            this.emitTriggerAction({
-                                action: "play",
-                                source: evt.source,
-                                clientId: evt.clientId,
-                                local,
-                                seekTime: evt.seekTime,
-                            });
-                            break;
-
-                        case "pause":
-                            this.emitTriggerAction({
-                                action: "pause",
-                                source: evt.source,
-                                clientId: evt.clientId,
-                                local,
-                                seekTime: evt.seekTime,
-                            });
-                            break;
-
-                        case "seekto":
-                            this.emitTriggerAction({
-                                action: "seekto",
-                                source: evt.source,
-                                clientId: evt.clientId,
-                                local,
-                                seekTime: evt.seekTime,
-                            });
-                            break;
-                    }
                 } else {
                     this._logger.sendTelemetryEvent(
                         TelemetryEvents.GroupCoordinator
@@ -243,6 +207,41 @@ export class GroupCoordinatorState extends EventEmitter {
                             seekTime: evt.seekTime,
                         }
                     );
+                }
+
+                const localClientId = await waitUntilConnected(this._runtime);
+                const local = evt.clientId === localClientId;
+                // Trigger action
+                switch (evt.action) {
+                    case "play":
+                        this.emitTriggerActionOrIgnored({
+                            action: "play",
+                            source: evt.source,
+                            clientId: evt.clientId,
+                            local,
+                            seekTime: evt.seekTime,
+                        });
+                        break;
+
+                    case "pause":
+                        this.emitTriggerActionOrIgnored({
+                            action: "pause",
+                            source: evt.source,
+                            clientId: evt.clientId,
+                            local,
+                            seekTime: evt.seekTime,
+                        });
+                        break;
+
+                    case "seekto":
+                        this.emitTriggerActionOrIgnored({
+                            action: "seekto",
+                            source: evt.source,
+                            clientId: evt.clientId,
+                            local,
+                            seekTime: evt.seekTime,
+                        });
+                        break;
                 }
             }
         );
@@ -589,7 +588,7 @@ export class GroupCoordinatorState extends EventEmitter {
                             target: target,
                         }
                     );
-                    await this.emitTriggerAction({
+                    this.emitTriggerAction({
                         action: "catchup",
                         source: "system",
                         clientId: await waitUntilConnected(this._runtime),
@@ -613,7 +612,7 @@ export class GroupCoordinatorState extends EventEmitter {
                         localClientId === this.transportState.current.clientId;
                     switch (this.transportState.playbackState) {
                         case "playing":
-                            await this.emitTriggerAction({
+                            this.emitTriggerAction({
                                 action: "play",
                                 source: "system",
                                 clientId: this.transportState.current.clientId,
@@ -621,7 +620,7 @@ export class GroupCoordinatorState extends EventEmitter {
                             });
                             break;
                         case "paused":
-                            await this.emitTriggerAction({
+                            this.emitTriggerAction({
                                 action: "pause",
                                 source: "system",
                                 clientId: this.transportState.current.clientId,
@@ -642,7 +641,7 @@ export class GroupCoordinatorState extends EventEmitter {
                     const local =
                         localClientId ===
                         this.playbackTrackData.current.clientId;
-                    await this.emitTriggerAction({
+                    this.emitTriggerAction({
                         action: "datachange",
                         source: "system",
                         clientId: this.playbackTrackData.current.clientId,
@@ -673,6 +672,16 @@ export class GroupCoordinatorState extends EventEmitter {
         });
     }
 
+    private emitTriggerActionOrIgnored(
+        details: ExtendedMediaSessionActionDetails
+    ): void {
+        if (this.isSuspended || this.isWaiting) {
+            return this.emitTriggerActionIgnored(details);
+        } else {
+            return this.emitTriggerAction(details);
+        }
+    }
+
     private emitTriggerAction(
         details: ExtendedMediaSessionActionDetails
     ): void {
@@ -681,5 +690,16 @@ export class GroupCoordinatorState extends EventEmitter {
             details: details,
         };
         this.emit(GroupCoordinatorStateEvents.triggeraction, evt);
+    }
+
+    private emitTriggerActionIgnored(
+        details: ExtendedMediaSessionActionDetails
+    ): void {
+        details.ignored = "localusersuspended";
+        const evt: ITriggerActionEvent = {
+            name: GroupCoordinatorStateEvents.triggeractionignored,
+            details: details,
+        };
+        this.emit(GroupCoordinatorStateEvents.triggeractionignored, evt);
     }
 }

--- a/packages/live-share-media/src/internals/GroupCoordinatorState.ts
+++ b/packages/live-share-media/src/internals/GroupCoordinatorState.ts
@@ -695,7 +695,7 @@ export class GroupCoordinatorState extends EventEmitter {
     private emitTriggerActionIgnored(
         details: ExtendedMediaSessionActionDetails
     ): void {
-        details.ignored = "localusersuspended";
+        details.ignoreReason = "localusersuspended";
         const evt: ITriggerActionEvent = {
             name: GroupCoordinatorStateEvents.triggeractionignored,
             details: details,

--- a/packages/live-share-media/src/test/LiveMediaSession_Synchronizer.spec.ts
+++ b/packages/live-share-media/src/test/LiveMediaSession_Synchronizer.spec.ts
@@ -25,7 +25,9 @@ import { MockLiveShareRuntime } from "@microsoft/live-share/src/test/MockLiveSha
 import { isErrorLike } from "@microsoft/live-share/bin/internals";
 import {
     ExtendedMediaMetadata,
+    ExtendedMediaSessionAction,
     ExtendedMediaSessionActionDetails,
+    ExtendedMediaSessionActionIgnore,
     ExtendedMediaSessionActionSource,
 } from "../MediaSessionExtensions";
 import {
@@ -404,6 +406,13 @@ describeNoCompat(
             await object1.initialize([UserMeetingRole.organizer]);
             await object2.initialize([UserMeetingRole.organizer]);
             const object1ExpectedEventOrder: IExpectedEvent[] = [
+                {
+                    action: "play",
+                    clientId: await object2.clientId(),
+                    local: false,
+                    source: "user",
+                    ignored: "localusersuspended", // emitted by group action, but ignored with reason "localusersuspended".
+                },
                 {
                     action: "seekto",
                     clientId: await object1.clientId(),
@@ -880,11 +889,12 @@ async function assertActionOccurred(
     });
 }
 
-interface IExpectedEvent {
-    action: string;
+interface IExpectedEvent extends ExtendedMediaSessionActionDetails {
+    action: ExtendedMediaSessionAction;
     clientId: string;
     local: boolean;
     source: ExtendedMediaSessionActionSource;
+    ignored?: ExtendedMediaSessionActionIgnore | null;
 }
 
 async function assertExpectedEvents(

--- a/packages/live-share-media/src/test/LiveMediaSession_Synchronizer.spec.ts
+++ b/packages/live-share-media/src/test/LiveMediaSession_Synchronizer.spec.ts
@@ -411,7 +411,7 @@ describeNoCompat(
                     clientId: await object2.clientId(),
                     local: false,
                     source: "user",
-                    ignored: "localusersuspended", // emitted by group action, but ignored with reason "localusersuspended".
+                    ignoreReason: "localusersuspended", // emitted by group action, but ignored with reason "localusersuspended".
                 },
                 {
                     action: "seekto",
@@ -894,7 +894,7 @@ interface IExpectedEvent extends ExtendedMediaSessionActionDetails {
     clientId: string;
     local: boolean;
     source: ExtendedMediaSessionActionSource;
-    ignored?: ExtendedMediaSessionActionIgnore | null;
+    ignoreReason?: ExtendedMediaSessionActionIgnore | null;
 }
 
 async function assertExpectedEvents(


### PR DESCRIPTION
`MediaPlayerSynchronizer` `groupaction` events now emit ignored actions during suspension, with ignored reason.

Feature request #749 

## Test scenario and emitted events.

added console logs of group actions to sample 21.react-media-template
```typescript
synchronizerRef.current.on(
    MediaPlayerSynchronizerEvents.groupaction,
    (event: ExtendedMediaSessionActionDetails) => {
        console.log("groupaction", event);
    }
);
```
1. User in control clicks play
```json
{
    "type": "groupaction",
    "details": {
        "action": "play",
        "source": "user",
        "clientId": "2c9f76b0-805e-4e92-8063-20bea9901177",
        "local": false,
        "seekTime": 1.914871
    }
}
```
2. User not in control starts a suspension by seeking. No event emitted on groupAction.

3. User in control clicks pause, but is ignored by local client with reason `localusersuspended`.
This still affected the group state so the event gets emitted with `groupaction`
```json
{
    "type": "groupaction",
    "details": {
        "action": "pause",
        "source": "user",
        "clientId": "2c9f76b0-805e-4e92-8063-20bea9901177",
        "local": false,
        "seekTime": 8.408734,
        "ignoreReason": "localusersuspended"
    }
}
```

4. User not in control ends suspension which triggers a catchup event.
```json
{
    "type": "groupaction",
    "details": {
        "action": "catchup",
        "source": "system",
        "clientId": "66a1e2cd-a122-43df-9937-f8d481c7a317",
        "local": true,
        "seekTime": 9.72914
    }
}
```

<img width="1635" alt="image" src="https://github.com/microsoft/live-share-sdk/assets/10103298/32e025ff-ac43-4afa-9f17-73c70f6c18be">

---
Also removed property `blocked` on `ExtendedMediaSessionActionDetails`
