### PR TITLE
Fix some hooks in React SDK not supporting `uniqueKey` changes

### DIFF
--- a/packages/live-share-react/src/live-hooks/useLiveEvent.ts
+++ b/packages/live-share-react/src/live-hooks/useLiveEvent.ts
@@ -117,6 +117,12 @@ export function useLiveEvent<TEvent = any>(
             allEventsRef.current = [...allEventsRef.current, received];
             setLatestReceived(received);
         };
+        // Reset the events list if it allEventRef.current is non-empty.
+        // This happens when the `id` a developer provides changes on the fly.
+        if (allEventsRef.current.length > 0) {
+            allEventsRef.current = [];
+            setLatestReceived(undefined);
+        }
         liveEvent.on(LiveEventEvents.received, onEventReceived);
         if (
             liveEvent.initializeState === LiveDataObjectInitializeState.needed

--- a/packages/live-share-react/src/live-hooks/useLiveFollowMode.ts
+++ b/packages/live-share-react/src/live-hooks/useLiveFollowMode.ts
@@ -284,10 +284,9 @@ export function useLiveFollowMode<TData = any>(
                     : initialData,
                 allowedRoles
             );
-        } else {
-            onPresenceChanged();
-            onStateChanged();
         }
+        onPresenceChanged();
+        onStateChanged();
 
         return () => {
             liveFollowMode?.off("presenceChanged", onPresenceChanged);

--- a/packages/live-share-react/src/live-hooks/useLivePresence.ts
+++ b/packages/live-share-react/src/live-hooks/useLivePresence.ts
@@ -124,9 +124,8 @@ export function useLivePresence<TData extends object = object>(
                 initialPresenceState,
                 allowedRoles
             );
-        } else {
-            onPresenceChanged();
         }
+        onPresenceChanged();
 
         return () => {
             livePresence?.off("presenceChanged", onPresenceChanged);

--- a/packages/live-share-react/src/live-hooks/useLiveState.ts
+++ b/packages/live-share-react/src/live-hooks/useLiveState.ts
@@ -97,9 +97,7 @@ export function useLiveState<TState = any>(
         ) {
             liveState.initialize(initialState, allowedRoles);
         }
-        if (JSON.stringify(liveState.state) !== JSON.stringify(initialState)) {
-            onStateChanged(liveState.state);
-        }
+        onStateChanged(liveState.state);
 
         return () => {
             liveState?.off("stateChanged", onStateChanged);

--- a/packages/live-share-react/src/live-hooks/useLiveTimer.ts
+++ b/packages/live-share-react/src/live-hooks/useLiveTimer.ts
@@ -141,6 +141,10 @@ export function useLiveTimer(
      */
     React.useEffect(() => {
         if (liveTimer === undefined) return;
+        // Reset default values, which is needed for when the `id` changes and a new DDS is loaded.
+        // React does not re-render if the values are already set to defaults (e.g., initial DDS).
+        setTimerConfig(undefined);
+        setMilliRemaining(undefined);
         // Register event listeners
         const onTimerConfigChange = (config: ITimerConfig) => {
             setTimerConfig(config);


### PR DESCRIPTION
Fixed `useLiveState`, `useLivePresence`, `useLiveFollowMode`, and `useLiveEvent` bugs that caused the `uniqueKey` field not fetching the correct default values when the new DDS is loaded. Other hooks do not appear to have this same issue.

Bug originally happened because I was trying to reduce what I saw as redundant renders, but I guess React already skips re-render if the value is unchanged. For `useLivePresence` it may actually cause duplicate re-renders, but it's better to do that than to miss getting the initial values.

<img width="1040" alt="image" src="https://github.com/microsoft/live-share-sdk/assets/11748606/618dbd68-e069-4444-8409-5ce759f163af">
In this image the text input is the `uniqueKey` field passed into the `useLiveState` field. Since both users have different values, the shared count displayed is different. If I switch the right to have the same value as the left, it updates to this:
<img width="1046" alt="image" src="https://github.com/microsoft/live-share-sdk/assets/11748606/b5a94579-31af-45cb-bbe3-f8439d2f7546">
And now if I increment the counter it updates for both clients:
<img width="883" alt="image" src="https://github.com/microsoft/live-share-sdk/assets/11748606/4ab38a9c-68d9-4269-976f-1d6710fc9bfd">
And if I then change the id again on the left, the value updates to the correct default of 1 (but not the right, as expected):
<img width="1029" alt="image" src="https://github.com/microsoft/live-share-sdk/assets/11748606/c57a8a5e-2a74-40d4-bf13-11ce62347e63">

Prior to this change, it would have kept the same value from the previous DDS instance. So if I were to have changed the key to "tests 2" in the same way as that last image, the default value would have been 4 rather than 1 (even though internally `LiveState` knew the initial value was 1.

The other hooks had similar solutions, but some like `useLiveTimer` and `useLiveEvent` needed special treatment. For that, I reset it to the defaults of undefined whenever the value changed. Still seems to work fine. For `useLiveEvent` I simply reset the locally tracked `latestEvent` and `allEventsRef` to their default values whenever the underlying DDS is swapped for a new one. This works fine due to the internal nuances of those DDS's.