### PR TITLE
Fixed local Presence user not getting set up properly when canSendBackgroundUpdates was false

### DIFF
--- a/packages/live-share/src/LivePresence.ts
+++ b/packages/live-share/src/LivePresence.ts
@@ -204,6 +204,7 @@ export class LivePresence<
         await this.updateInternal(
             this._currentPresence!.data.data,
             this._currentPresence!.data.state,
+            true,
             true
         ).catch(() => {});
     }
@@ -275,7 +276,8 @@ export class LivePresence<
     private async updateInternal(
         data?: TData,
         state?: PresenceState,
-        throttle: boolean = false
+        throttle: boolean = false,
+        background: boolean = false
     ): Promise<void> {
         LiveDataObjectNotInitializedError.assert(
             "LivePresence:updateInternal",
@@ -299,7 +301,7 @@ export class LivePresence<
             data: cloneValue(data) ?? this._currentPresence.data.data,
         };
 
-        if (this.liveRuntime.canSendBackgroundUpdates) {
+        if (!background || this.liveRuntime.canSendBackgroundUpdates) {
             const evt = throttle
                 ? await this._synchronizer!.sendThrottledEvent(evtToSend)
                 : await this._synchronizer!.sendEvent(evtToSend);

--- a/packages/live-share/src/LivePresence.ts
+++ b/packages/live-share/src/LivePresence.ts
@@ -315,13 +315,13 @@ export class LivePresence<
              * Create an event that is not sent to other clients, but allows
              * local user state to be created.
              */
-            const fakeEvent = {
+            const localOnlyEvent = {
                 data: evtToSend,
                 name: "",
                 clientId: await this.waitUntilConnected(),
                 timestamp: 1,
             };
-            await this.updateMembersList(fakeEvent, true);
+            await this.updateMembersList(localOnlyEvent, true);
         }
     }
 

--- a/packages/live-share/src/LivePresence.ts
+++ b/packages/live-share/src/LivePresence.ts
@@ -199,15 +199,13 @@ export class LivePresence<
         // We do before sending initial update, since that requires this to happen first.
         this.initializeState = LiveDataObjectInitializeState.succeeded;
 
-        if (this.liveRuntime.canSendBackgroundUpdates) {
-            // Broadcast initial presence, or silently fail trying.
-            // Throttled so that a developer can have multiple presence instances in their app in a performant manner.
-            await this.updateInternal(
-                this._currentPresence!.data.data,
-                this._currentPresence!.data.state,
-                true
-            ).catch(() => {});
-        }
+        // Broadcast initial presence, or silently fail trying.
+        // Throttled so that a developer can have multiple presence instances in their app in a performant manner.
+        await this.updateInternal(
+            this._currentPresence!.data.data,
+            this._currentPresence!.data.state,
+            true
+        ).catch(() => {});
     }
 
     /**
@@ -300,10 +298,29 @@ export class LivePresence<
             state: state ?? this._currentPresence.data.state,
             data: cloneValue(data) ?? this._currentPresence.data.data,
         };
-        const evt = throttle
-            ? await this._synchronizer!.sendThrottledEvent(evtToSend)
-            : await this._synchronizer!.sendEvent(evtToSend);
-        await this.updateMembersList(evt, true);
+
+        if (this.liveRuntime.canSendBackgroundUpdates) {
+            const evt = throttle
+                ? await this._synchronizer!.sendThrottledEvent(evtToSend)
+                : await this._synchronizer!.sendEvent(evtToSend);
+
+            await this.updateMembersList(evt, true);
+        } else {
+            /*
+             * If canSendBackgroundUpdates is false,
+             * local user should be able to keep track of local user state.
+             *
+             * Create an event that is not sent to other clients, but allows
+             * local user state to be created.
+             */
+            const fakeEvent = {
+                data: evtToSend,
+                name: "",
+                clientId: await this.waitUntilConnected(),
+                timestamp: 1,
+            };
+            await this.updateMembersList(fakeEvent, true);
+        }
     }
 
     /**


### PR DESCRIPTION
When `canSendBackgroundUpdates` is false, create an event that is used to create the `LivePresenceUser` for the local user. This event is not sent to other clients.

local user exists now with `isShareInitiator=false`
![image](https://github.com/microsoft/live-share-sdk/assets/10103298/2ce59c7b-b5f1-4c11-beeb-cbc3acc52a3a)
