### PR TITLE
`SdkError` fix for live-share-react

### DIFF
--- a/packages/live-share-react/src/internal/errors.ts
+++ b/packages/live-share-react/src/internal/errors.ts
@@ -52,6 +52,22 @@ export class ActionLiveDataObjectInitializedError extends UseLiveDataObjectActio
 /**
  * @hidden
  */
+export interface ITeamsJsSdkError {
+    /**
+     * error code
+     */
+    errorCode: number;
+    /**
+     * Optional description for the error. This may contain useful information for web-app developers.
+     * This string will not be localized and is not for end-user consumption.
+     * App should not depend on the string content. The exact value may change. This is only for debugging purposes.
+     */
+    message?: string;
+}
+
+/**
+ * @hidden
+ */
 function toFirstLetterUppercase(word: string) {
     return word[0].toUpperCase() + word.substring(1);
 }

--- a/packages/live-share-react/src/internal/type-guards.ts
+++ b/packages/live-share-react/src/internal/type-guards.ts
@@ -1,3 +1,5 @@
+import { ITeamsJsSdkError } from "./errors";
+
 /**
  * @hidden
  * Used for useLiveState and useSharedState for checking if a value is a prevState callback
@@ -6,4 +8,14 @@ export function isPrevStateCallback<TState>(
     value: any
 ): value is (value: TState) => TState {
     return typeof value === "function";
+}
+
+/**
+ * @hidden
+ */
+export function isITeamsJsSdkError(value: any): value is ITeamsJsSdkError {
+    if (!value) return false;
+    if (typeof value.errorCode !== "number") return false;
+    if (value.message === undefined) return true;
+    return typeof value.message === "string";
 }

--- a/packages/live-share-react/src/providers/LiveShareProvider.tsx
+++ b/packages/live-share-react/src/providers/LiveShareProvider.tsx
@@ -14,6 +14,7 @@ import {
 } from "@microsoft/live-share";
 import { FluidContext, useFluidObjectsContext } from "./AzureProvider";
 import { LiveShareTurboClient } from "@microsoft/live-share-turbo";
+import { isITeamsJsSdkError } from "../internal";
 
 /**
  * React Context provider values for `<LiveShareProvider>`.
@@ -158,6 +159,17 @@ export const LiveShareProvider: React.FC<ILiveShareProviderProps> = (props) => {
             console.error(error);
             if (error instanceof Error) {
                 setJoinError(error);
+            } else if (isITeamsJsSdkError(error)) {
+                setJoinError(
+                    new Error(
+                        `[${error.errorCode}] ${
+                            error.message ??
+                            "An unknown error occurred while joining container."
+                        }`
+                    )
+                );
+            } else if (typeof error == "string") {
+                setJoinError(new Error(error));
             } else {
                 setJoinError(
                     new Error(


### PR DESCRIPTION
- Fixed issue where error message from `SdkError` is obfuscated when using `live-share-react` package.

Related to #760