### PR TITLE
Use a param object for LiveObjectSynchronizer.start method

### DIFF
--- a/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
+++ b/packages/live-share-media/src/LiveMediaSessionCoordinator.ts
@@ -586,13 +586,12 @@ export class LiveMediaSessionCoordinator extends TypedEventEmitter<ILiveMediaSes
 
         try {
             // start needs to happen after setting initializedState to "succeeded"
-            await this._synchronizer?.start(
-                undefined,
-                async (evt, sender, local) => false,
-                async (connecting) => true,
-                false,
-                false
-            );
+            await this._synchronizer?.start({
+                initialState: undefined,
+                updateState: async (evt, sender, local) => false,
+                getLocalUserCanSend: async (connecting) => true,
+                enableBackgroundUpdates: false,
+            });
         } catch (error: unknown) {
             // not a fatal error for LiveMediaSession, only used for "connect" event to send new clients position updates.
             this._logger.sendErrorEvent(

--- a/packages/live-share/src/LivePresence.ts
+++ b/packages/live-share/src/LivePresence.ts
@@ -177,14 +177,14 @@ export class LivePresenceClass<
             ILivePresenceEvent<TData>
         >(this.id, this.runtime, this.liveRuntime);
         try {
-            await this._synchronizer!.start(
-                this._currentPresence!.data,
-                async (state, sender, local) => {
+            await this._synchronizer!.start({
+                initialState: this._currentPresence!.data,
+                updateState: async (state, sender, local) => {
                     // Add user to list
                     await this.updateMembersList(state, local);
                     return false;
                 },
-                async (connecting) => {
+                getLocalUserCanSend: async (connecting) => {
                     if (connecting) return true;
                     // If user has eligible roles, allow the update to be sent
                     try {
@@ -193,8 +193,8 @@ export class LivePresenceClass<
                         return false;
                     }
                 },
-                true // We want to update the timestamp periodically so that we know if a user is active
-            );
+                shouldUpdateTimestampPeriodically: true, // We want to update the timestamp periodically so that we know if a user is active
+            });
         } catch (error: unknown) {
             // Update initialize state as fatal error
             this.initializeState = LiveDataObjectInitializeState.fatalError;

--- a/packages/live-share/src/LiveState.ts
+++ b/packages/live-share/src/LiveState.ts
@@ -150,14 +150,14 @@ export class LiveStateClass<TState = any> extends LiveDataObject<{
             this.liveRuntime
         );
         try {
-            await this._synchronizer.start(
+            await this._synchronizer.start({
                 initialState,
-                async (evt, sender, local) => {
+                updateState: async (evt, sender, local) => {
                     // Check for state change.
                     // If it was valid, this will override the local user's previous value.
                     return await this.onReceivedStateEvent(evt, sender, local);
                 },
-                async (connecting) => {
+                getLocalUserCanSend: async (connecting) => {
                     if (connecting) return true;
                     // If user has eligible roles, allow the update to be sent
                     try {
@@ -165,8 +165,8 @@ export class LiveStateClass<TState = any> extends LiveDataObject<{
                     } catch {
                         return false;
                     }
-                }
-            );
+                },
+            });
         } catch (error: unknown) {
             // Update initialize state as fatal error
             this.initializeState = LiveDataObjectInitializeState.fatalError;

--- a/packages/live-share/src/LiveTimer.ts
+++ b/packages/live-share/src/LiveTimer.ts
@@ -189,14 +189,14 @@ export class LiveTimerClass extends LiveDataObject<{
             this.liveRuntime
         );
         try {
-            await this._synchronizer.start(
-                this._currentConfig.data,
-                async (state, sender) => {
+            await this._synchronizer.start({
+                initialState: this._currentConfig.data,
+                updateState: async (state, sender) => {
                     // Check for state change.
                     // If it was valid, this will override the local user's previous value.
                     return await this.remoteConfigReceived(state, sender);
                 },
-                async (connecting) => {
+                getLocalUserCanSend: async (connecting) => {
                     if (connecting) return true;
                     // If user has eligible roles, allow the update to be sent
                     try {
@@ -204,8 +204,8 @@ export class LiveTimerClass extends LiveDataObject<{
                     } catch {
                         return false;
                     }
-                }
-            );
+                },
+            });
         } catch (error: unknown) {
             // Update initialize state as fatal error
             this.initializeState = LiveDataObjectInitializeState.fatalError;

--- a/packages/live-share/src/internals/LiveObjectSynchronizer.ts
+++ b/packages/live-share/src/internals/LiveObjectSynchronizer.ts
@@ -12,6 +12,23 @@ import {
 } from "../interfaces";
 
 /**
+ * Starts params for a `LiveObjectSynchronizer` instance.
+ *
+ * @param initialState The initial state for the local user. Does not impact remote state that has been set since connecting to the session.
+ * @param updateState A function called to process a state update received from a remote instance. This will be called anytime a "connect" or "update" message is received.
+ * @param getLocalUserCanSend A async function called to determine whether the local user can send a connect/update message. Return true if the user can send the update.
+ * @param shouldUpdateTimestampPeriodically flag for updating the timestamp whenever sending out a periodic update.
+ * @param enableBackgroundUpdates flag for enabling/disabling background updates. True by default.
+ */
+interface LiveObjectSynchronizerStartParams<TState> {
+    initialState: TState;
+    updateState: UpdateSynchronizationState<TState>;
+    getLocalUserCanSend: GetLocalUserCanSend;
+    shouldUpdateTimestampPeriodically?: boolean | undefined;
+    enableBackgroundUpdates?: boolean | undefined;
+}
+
+/**
  * @internal
  * @hidden
  *
@@ -74,18 +91,39 @@ export class LiveObjectSynchronizer<TState> {
     /**
      * Starts a `LiveObjectSynchronizer` instance.
      *
+     * @param {LiveObjectSynchronizerStartParams} params Start params for LiveObjectSynchronizer.
+     */
+    public start({
+        initialState,
+        updateState,
+        getLocalUserCanSend,
+        shouldUpdateTimestampPeriodically = false,
+        enableBackgroundUpdates = true,
+    }: LiveObjectSynchronizerStartParams<TState>): Promise<void> {
+        return this.startInternal(
+            initialState,
+            updateState,
+            getLocalUserCanSend,
+            shouldUpdateTimestampPeriodically,
+            enableBackgroundUpdates
+        );
+    }
+
+    /**
+     * Starts a `LiveObjectSynchronizer` instance.
+     *
      * @param initialState The initial state for the local user. Does not impact remote state that has been set since connecting to the session.
      * @param updateState A function called to process a state update received from a remote instance. This will be called anytime a "connect" or "update" message is received.
      * @param getLocalUserCanSend A async function called to determine whether the local user can send a connect/update message. Return true if the user can send the update.
      * @param shouldUpdateTimestampPeriodically flag for updating the timestamp whenever sending out a periodic update.
      * @param enableBackgroundUpdates flag for enabling/disabling background updates. True by default.
      */
-    public start(
+    private startInternal(
         initialState: TState,
         updateState: UpdateSynchronizationState<TState>,
         getLocalUserCanSend: GetLocalUserCanSend,
-        shouldUpdateTimestampPeriodically = false,
-        enableBackgroundUpdates = true
+        shouldUpdateTimestampPeriodically: boolean,
+        enableBackgroundUpdates: boolean
     ): Promise<void> {
         return this.liveRuntime.objectManager.registerObject<TState>(
             this.id,

--- a/packages/live-share/src/internals/LiveObjectSynchronizer.ts
+++ b/packages/live-share/src/internals/LiveObjectSynchronizer.ts
@@ -12,7 +12,7 @@ import {
 } from "../interfaces";
 
 /**
- * Starts params for a `LiveObjectSynchronizer` instance.
+ * Start params for calling `LiveObjectSynchronizer.start` method.
  *
  * @param initialState The initial state for the local user. Does not impact remote state that has been set since connecting to the session.
  * @param updateState A function called to process a state update received from a remote instance. This will be called anytime a "connect" or "update" message is received.


### PR DESCRIPTION
Easier to make sense of what parameters mean what when looking at usage from call site.

resolves some of #750 