### PR TITLE
Use Audience in LivePresence for setting online/offline state

### DIFF
--- a/packages/live-share-media/src/VolumeManager.ts
+++ b/packages/live-share-media/src/VolumeManager.ts
@@ -61,12 +61,12 @@ export class VolumeManager {
      *
      * @remarks
      * Expressed as a value between 0.0 and 1.0. The value is applied based upon the configured
-     * `levelType`. The default value is 0.1.
+     * @see LimitLevelType. The default value is 0.1.
      *
-     * For a level type of `LevelType.fixed` the value is the exact level the volume will be
+     * For a level type of @see LimitLevelType.fixed the value is the exact level the volume will be
      * lowered to. The default value of 0.1 would cause the volume to be lowered to 0.1.
      *
-     * For a level type of `LevelType.percentage` the value is the percentage by which the volume
+     * For a level type of @see LimitLevelType.percentage the value is the percentage by which the volume
      * level should be lowered to. The default value of 0.1 would cause the volume to be lowered
      * to 10% of its starting value.
      */
@@ -118,8 +118,8 @@ export class VolumeManager {
 
     /**
      * Limits volume based on `limitLevel` and `limitLevelType` properties.
-     * @see `limitLevel`
-     * @see `limitLevelType`
+     * @see limitLevel
+     * @see limitLevelType
      */
     public startLimiting(): void {
         this._isLimiting = true;

--- a/packages/live-share-react/src/live-hooks/useLivePresence.ts
+++ b/packages/live-share-react/src/live-hooks/useLivePresence.ts
@@ -75,7 +75,7 @@ export function useLivePresence<TData extends object = object>(
      * User facing: callback to update the local user's presence.
      */
     const updatePresence: OnUpdateLivePresenceAction<TData> = React.useCallback(
-        async (data: TData) => {
+        async (data: TData | undefined | null) => {
             if (!container) {
                 throw new ActionContainerNotJoinedError(
                     "livePresence",

--- a/packages/live-share-react/src/live-hooks/useLivePresence.ts
+++ b/packages/live-share-react/src/live-hooks/useLivePresence.ts
@@ -78,7 +78,7 @@ export function useLivePresence<TData extends object = object>(
      * User facing: callback to update the local user's presence.
      */
     const updatePresence: OnUpdateLivePresenceAction<TData> = React.useCallback(
-        async (data?: TData | undefined, state?: PresenceState | undefined) => {
+        async (data: TData) => {
             if (!container) {
                 throw new ActionContainerNotJoinedError(
                     "livePresence",
@@ -97,7 +97,7 @@ export function useLivePresence<TData extends object = object>(
                     "updatePresence"
                 );
             }
-            return await livePresence.update(data, state);
+            return await livePresence.update(data);
         },
         [container, livePresence]
     );

--- a/packages/live-share-react/src/live-hooks/useLivePresence.ts
+++ b/packages/live-share-react/src/live-hooks/useLivePresence.ts
@@ -5,7 +5,6 @@
 
 import {
     LivePresenceUser,
-    PresenceState,
     LivePresence,
     UserMeetingRole,
     LiveDataObjectInitializeState,
@@ -32,7 +31,6 @@ import {
  * @template TData Optional typing for the custom user presence data object. Default is `object` type.
  * @param uniqueKey The unique key for `LivePresence`. If one does not yet exist, a new one will be created.
  * @param initialData Optional. Initial presence data object for the user. Can be value or a function to get the value.
- * @param initialPresenceState Optional. Initial status of the user's presence. Default is online.
  * @param allowedRoles Optional. the user roles that are allowed to mutate the synchronized state
  * will be created, otherwise it will use the existing one. Default value is ":<dds-default>"
  * @returns stateful `localUser`, `otherUsers` list, and `allUsers` list. Also returns a callback method
@@ -41,7 +39,6 @@ import {
 export function useLivePresence<TData extends object = object>(
     uniqueKey: string,
     initialData?: TData | (() => TData) | undefined,
-    initialPresenceState: PresenceState = PresenceState.online,
     allowedRoles?: UserMeetingRole[]
 ): IUseLivePresenceResults<TData> {
     /**
@@ -125,7 +122,6 @@ export function useLivePresence<TData extends object = object>(
                 isInitialDataCallback<TData>(initialData)
                     ? initialData()
                     : initialData,
-                initialPresenceState,
                 allowedRoles
             );
         }

--- a/packages/live-share-react/src/types/ActionTypes.ts
+++ b/packages/live-share-react/src/types/ActionTypes.ts
@@ -112,8 +112,7 @@ export type OnReceivedLiveEventAction<TEvent> = (
  * (data?: TData | undefined, state?: PresenceState | undefined) => Promise<void>
  */
 export type OnUpdateLivePresenceAction<TData extends object = object> = (
-    data?: TData | undefined,
-    state?: PresenceState | undefined
+    data: TData
 ) => Promise<void>;
 
 /**

--- a/packages/live-share/src/LivePresence.ts
+++ b/packages/live-share/src/LivePresence.ts
@@ -241,22 +241,20 @@ export class LivePresenceClass<
     }
 
     /**
-     * Updates the local user's presence shared data object and/or state.
+     * Updates the local user's presence shared data object.
      *
      * @remarks
      * This will trigger the immediate broadcast of the users presence to all other clients.
      *
-     * @param data Optional. Data object to change. A deep copy of the data object is saved to avoid any future changes.
-     * @param state Optional. Presence state to change.
+     * @param data Data object to change. A deep copy of the data object is saved to avoid any future changes.
      *
      * @returns a void promise that resolves once the update event has been sent to the server.
      *
      * @throws error if initialization has not yet succeeded.
      * @throws error if the local user does not have the required roles defined through the `allowedRoles` prop in `.initialize()`.
      */
-    // TODO: should state be updatable now that fluid audience is integrated?
-    public async update(data?: TData, state?: PresenceState): Promise<void> {
-        return await this.updateInternal(data, state);
+    public async update(data: TData): Promise<void> {
+        return await this.updateInternal(data);
     }
 
     /**

--- a/packages/live-share/src/LivePresence.ts
+++ b/packages/live-share/src/LivePresence.ts
@@ -210,7 +210,6 @@ export class LivePresenceClass<
         // Throttled so that a developer can have multiple presence instances in their app in a performant manner.
         await this.updateInternal(
             this._currentPresence!.data.data,
-            this._currentPresence!.data.state,
             true,
             true
         ).catch(() => {});
@@ -251,7 +250,7 @@ export class LivePresenceClass<
      * @throws error if initialization has not yet succeeded.
      * @throws error if the local user does not have the required roles defined through the `allowedRoles` prop in `.initialize()`.
      */
-    public async update(data: TData): Promise<void> {
+    public async update(data: TData | undefined | null): Promise<void> {
         return await this.updateInternal(data);
     }
 
@@ -281,8 +280,7 @@ export class LivePresenceClass<
      * Internal method to send an update, with optional ability to throttle.
      */
     private async updateInternal(
-        data?: TData,
-        state?: PresenceState,
+        data: TData | undefined | null,
         throttle: boolean = false,
         background: boolean = false
     ): Promise<void> {
@@ -304,7 +302,7 @@ export class LivePresenceClass<
 
         // Broadcast state change
         const evtToSend = {
-            state: state ?? this._currentPresence.data.state,
+            state: this._currentPresence.data.state,
             data: cloneValue(data) ?? this._currentPresence.data.data,
         };
 

--- a/packages/live-share/src/LivePresence.ts
+++ b/packages/live-share/src/LivePresence.ts
@@ -131,7 +131,6 @@ export class LivePresenceClass<
      * Initialize the object to begin sending/receiving presence updates through this DDS.
      *
      * @param data Optional. Custom data object to share. A deep copy of the data object is saved to avoid any accidental modifications.
-     * @param state Optional. Initial presence state. Defaults to `PresenceState.online`.
      * @param allowedRoles Optional. List of roles allowed to emit presence changes.
      *
      * @returns a void promise that resolves once complete.
@@ -142,7 +141,6 @@ export class LivePresenceClass<
      */
     public async initialize(
         data?: TData,
-        state = PresenceState.online,
         allowedRoles?: UserMeetingRole[]
     ): Promise<void> {
         LiveDataObjectInitializeNotNeededError.assert(
@@ -171,7 +169,7 @@ export class LivePresenceClass<
             name: "UpdatePresence",
             timestamp: 0,
             data: {
-                state,
+                state: PresenceState.online,
                 data,
             },
         };

--- a/packages/live-share/src/LivePresence.ts
+++ b/packages/live-share/src/LivePresence.ts
@@ -254,6 +254,7 @@ export class LivePresenceClass<
      * @throws error if initialization has not yet succeeded.
      * @throws error if the local user does not have the required roles defined through the `allowedRoles` prop in `.initialize()`.
      */
+    // TODO: should state be updatable now that fluid audience is integrated?
     public async update(data?: TData, state?: PresenceState): Promise<void> {
         return await this.updateInternal(data, state);
     }
@@ -472,7 +473,6 @@ export class LivePresenceClass<
         state: PresenceState
     ) {
         const user = this.getUserForClient(clientId);
-
         if (!user) {
             return;
         }

--- a/packages/live-share/src/LivePresenceConnection.ts
+++ b/packages/live-share/src/LivePresenceConnection.ts
@@ -46,7 +46,13 @@ export class LivePresenceConnection<TData = object> {
      * for a period of time.
      */
     public get state(): PresenceState {
-        return this.hasExpired() ? PresenceState.offline : this._evt.data.state;
+        if (this._evt.data.state !== PresenceState.online) {
+            return this._evt.data.state;
+        } else if (this.hasExpired()) {
+            return PresenceState.away;
+        }
+
+        return this._evt.data.state;
     }
 
     /**

--- a/packages/live-share/src/LivePresenceUser.ts
+++ b/packages/live-share/src/LivePresenceUser.ts
@@ -95,7 +95,13 @@ export class LivePresenceUser<TData = object> {
      * for a period of time.
      */
     public get state(): PresenceState {
-        return this.hasExpired() ? PresenceState.offline : this._evt.data.state;
+        if (this._evt.data.state !== PresenceState.online) {
+            return this._evt.data.state;
+        } else if (this.hasExpired()) {
+            return PresenceState.away;
+        }
+
+        return this._evt.data.state;
     }
 
     /**

--- a/packages/live-share/src/LivePresenceUser.ts
+++ b/packages/live-share/src/LivePresenceUser.ts
@@ -23,7 +23,6 @@ export enum PresenceState {
     /**
      * The user is away. Automatically set for users after their client has stopped sending
      * updates for a period of time. @see LivePresence.expirationPeriod.
-     *
      */
     away = "away",
 

--- a/packages/live-share/src/LivePresenceUser.ts
+++ b/packages/live-share/src/LivePresenceUser.ts
@@ -8,6 +8,7 @@ import { IClientInfo, ILiveEvent, UserMeetingRole } from "./interfaces";
 import { TimeInterval } from "./TimeInterval";
 import { LiveShareRuntime } from "./internals/LiveShareRuntime";
 import { LivePresenceConnection } from "./LivePresenceConnection";
+import { LivePresence } from "./LivePresence";
 import { cloneValue } from "./internals/utils";
 
 /**
@@ -20,13 +21,14 @@ export enum PresenceState {
     online = "online",
 
     /**
-     * The user is away. Applications can set this state based on the users activity.
+     * The user is away. Automatically set for users after their client has stopped sending
+     * updates for a period of time. @see LivePresence.expirationPeriod.
+     *
      */
     away = "away",
 
     /**
-     * The user is offline. Automatically set for users after their client has stopped sending
-     * updates for a period of time.
+     * The user is offline.
      */
     offline = "offline",
 }
@@ -167,15 +169,19 @@ export class LivePresenceUser<TData = object> {
         const currentEvent = this._evt;
         const currentClientInfo = this._clientInfo;
         if (LiveEvent.isNewer(currentEvent, evt)) {
-            // Save updated event
-            this._evt = evt;
+            // Save updated event, but change state of LivePresenceUser to reflect aggregate of connection states.
+            const aggregateState = this.aggregateConnectionState();
+            const aggregateStateEvent = cloneValue(evt);
+            aggregateStateEvent.data.state = aggregateState;
+
+            this._evt = aggregateStateEvent;
             this._clientInfo = info;
             this._lastUpdateTime = this._liveRuntime.getTimestamp();
 
             // Has anything changed?
             return (
                 remoteUserConvertedToLocal ||
-                evt.data.state != currentEvent.data.state ||
+                aggregateStateEvent.data.state != currentEvent.data.state ||
                 JSON.stringify(info) != JSON.stringify(currentClientInfo) ||
                 JSON.stringify(evt.data.data) !=
                     JSON.stringify(currentEvent.data.data)
@@ -183,6 +189,25 @@ export class LivePresenceUser<TData = object> {
         }
 
         return remoteUserConvertedToLocal;
+    }
+
+    private aggregateConnectionState(): PresenceState {
+        return Array.from(this._connections.entries())
+            .map((c) => c[1].state)
+            .reduce<PresenceState>((previous, current) => {
+                if (
+                    previous === PresenceState.online ||
+                    current === PresenceState.online
+                ) {
+                    return PresenceState.online;
+                } else if (
+                    previous === PresenceState.away ||
+                    current === PresenceState.away
+                ) {
+                    return PresenceState.away;
+                }
+                return PresenceState.offline;
+            }, PresenceState.offline);
     }
 
     /**

--- a/packages/live-share/src/internals/LiveShareRuntime.ts
+++ b/packages/live-share/src/internals/LiveShareRuntime.ts
@@ -76,6 +76,13 @@ export class LiveShareRuntime {
     }
 
     /**
+     * `IAzureAudience` instance
+     */
+    public get audience(): IAzureAudience | undefined {
+        return this._audience;
+    }
+
+    /**
      * Setting for whether `LiveDataObject` instances using `LiveObjectSynchronizer` can send background updates.
      * Default value is `true`.
      *

--- a/packages/live-share/src/test/LivePresence.audience.spec.ts
+++ b/packages/live-share/src/test/LivePresence.audience.spec.ts
@@ -1,0 +1,83 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the Microsoft Live Share SDK License.
+ */
+
+import { strict as assert } from "assert";
+import { TestLiveShareHost } from "../TestLiveShareHost";
+import { LiveShareClient } from "../LiveShareClient";
+import { LivePresence } from "../LivePresence";
+import { PresenceState } from "../LivePresenceUser";
+import { waitForDelay } from "../internals/utils";
+
+describe("LivePresence Fluid Audience tests", () => {
+    let containerId: string | undefined;
+    const getContainerId = (): string | undefined => {
+        return containerId;
+    };
+    const setContainerId = (newContainerId: string) => {
+        containerId = newContainerId;
+    };
+    const host = TestLiveShareHost.create(getContainerId, setContainerId);
+    let client1: LiveShareClient;
+    let client2: LiveShareClient;
+
+    const testPresenceKey = "TEST-MAP-KEY";
+
+    beforeEach(async () => {
+        client1 = new LiveShareClient(host);
+        client2 = new LiveShareClient(host);
+        containerId = undefined;
+        await client1.join();
+        await client2.join();
+    });
+
+    it("LivePresence User should go offline when Audience member is removed", async () => {
+        const promise1 = client1.getDDS<LivePresence>(
+            testPresenceKey,
+            LivePresence,
+            (dds: LivePresence) => {
+                assert(
+                    dds !== undefined,
+                    "dds is not defined in onFirstInitialize callback"
+                );
+            }
+        );
+        const promise2 = client2.getDDS<LivePresence>(
+            testPresenceKey,
+            LivePresence,
+            (dds: LivePresence) => {
+                assert(
+                    dds !== undefined,
+                    "dds is not defined in onFirstInitialize callback"
+                );
+            }
+        );
+
+        // Wait for dds to to be created
+        const [dds1, dds2] = await Promise.all([promise1, promise2]);
+
+        await dds1.initialize();
+        await dds2.initialize();
+
+        client1.results?.container.disconnect();
+
+        await waitForDelay(10);
+
+        const onlineFromObject2Perpsective = dds2
+            .getUsers()
+            .filter((u) => u.state == PresenceState.online).length;
+        const offlineFromObject2Perpsective = dds2
+            .getUsers()
+            .filter((u) => u.state == PresenceState.offline).length;
+
+        assert(
+            onlineFromObject2Perpsective === 1,
+            `should have 1 online user, is actually: ${onlineFromObject2Perpsective}`
+        );
+        assert(
+            offlineFromObject2Perpsective === 1,
+            `should have 1 offline user, is actually: ${offlineFromObject2Perpsective}`
+        );
+    });
+});

--- a/packages/live-share/src/test/LivePresence.spec.ts
+++ b/packages/live-share/src/test/LivePresence.spec.ts
@@ -244,12 +244,13 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
 
         await object1.initialize(undefined);
 
-        let object2PresenceChangeCount: number = 0;
         let object2PresenceChangeOnlineCount: number = 0;
         let object2PresenceChangeOfflineCount: number = 0;
+
+        let object2object2PresenceChangeCount: number = 0;
         object2.on("presenceChanged", (user, local) => {
             if (local) {
-                object2PresenceChangeCount += 1;
+                object2object2PresenceChangeCount += 1;
                 if (user.state === "online") {
                     object2PresenceChangeOnlineCount += 1;
                 } else {
@@ -258,9 +259,11 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
                 object2done.resolve();
             }
         });
+
+        let object1object2PresenceChangeCount: number = 0;
         object1.on("presenceChanged", (user, local) => {
             if (!local) {
-                object2PresenceChangeCount += 1;
+                object1object2PresenceChangeCount += 1;
                 if (user.state === "online") {
                     object2PresenceChangeOnlineCount += 1;
                 } else {
@@ -283,18 +286,16 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
         await waitForDelay(1);
         // Wait for events to trigger
         await object2done.promise;
+
         assert(
-            object2PresenceChangeCount == 2,
-            `expected three events from object2, ${object2PresenceChangeCount}`
+            object2object2PresenceChangeCount == 2,
+            `expected two events from object2 from perspective of object 2, ${object2object2PresenceChangeCount}`
         );
         assert(
-            object2PresenceChangeOnlineCount == 2,
-            `expected two events from object2 that was online, ${object2PresenceChangeOnlineCount}`
+            object1object2PresenceChangeCount == 1,
+            `expected one events from object2 from perspective of object 1, ${object1object2PresenceChangeCount}`
         );
-        assert(
-            object2PresenceChangeOfflineCount == 0,
-            `expected zero events from object2 that was offline, ${object2PresenceChangeOfflineCount}`
-        );
+
         assert(
             object1.localUser !== undefined,
             "local user should not be undefined"
@@ -316,12 +317,17 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
 
         assert(
             // @ts-ignore invalid, assersion earlier in test is making the linter think this assertion is unintentional.
-            object2PresenceChangeCount == 4,
-            `expected 4 events from object2, ${object2PresenceChangeCount}`
+            object2object2PresenceChangeCount == 3,
+            `expected 1 more event (3 total) from object2 from perspective of object 2, ${object2object2PresenceChangeCount}`
         );
         assert(
-            object2PresenceChangeOnlineCount == 2,
-            `expected two events from object2 that was online, ${object2PresenceChangeOnlineCount}`
+            // @ts-ignore invalid, assersion earlier in test is making the linter think this assertion is unintentional.
+            object1object2PresenceChangeCount == 2,
+            `expected 1 more event (2 total) from object2 from perspective of object 1, ${object1object2PresenceChangeCount}`
+        );
+        assert(
+            object2PresenceChangeOnlineCount == 3,
+            `expected three events from object2 that was online, ${object2PresenceChangeOnlineCount}`
         );
         assert(
             // @ts-ignore invalid, assersion earlier in test is making the linter think this assertion is unintentional.
@@ -933,7 +939,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
         disposeAll();
     });
 
-    it("test offline timeout for user and connections", async () => {
+    it("test away timeout for user and connections", async () => {
         // set same user test host
         const mockHost = new SameUserLiveShareTestHost();
         const { object1, object2, disposeAll, disposeObject1, disposeObject2 } =
@@ -968,11 +974,11 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
                 PresenceState.online,
             "object2 should still be online from object1's perspective"
         );
-        await waitForDelay(150);
+        await waitForDelay(1500);
         assert(
             object1User.getConnection(object2ClientId)?.state ==
-                PresenceState.offline,
-            "object2 should be offline"
+                PresenceState.away,
+            "object2 should be away"
         );
         disposeObject1();
     });

--- a/packages/live-share/src/test/LivePresence.spec.ts
+++ b/packages/live-share/src/test/LivePresence.spec.ts
@@ -183,56 +183,6 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
         disposeAll();
     });
 
-    it("Should start in alternate state", async () => {
-        const { object1, object2, disposeAll } = await getObjects(
-            getTestObjectProvider
-        );
-        const object1done = new Deferred();
-        object1.on("presenceChanged", (user, local) => {
-            try {
-                if (local) {
-                    assert(
-                        user.state == PresenceState.away,
-                        `user1: Unexpected presence state of ${user.state}`
-                    );
-                    assert(
-                        user.data == undefined,
-                        `user1: Unexpected data object of ${user.data}`
-                    );
-                    object1done.resolve();
-                }
-            } catch (err) {
-                object1done.reject(err);
-            }
-        });
-        await object1.initialize(undefined, PresenceState.away);
-
-        const object2done = new Deferred();
-        object2.on("presenceChanged", (user, local) => {
-            try {
-                if (local) {
-                    assert(
-                        user.state == PresenceState.offline,
-                        `user2: Unexpected presence state of ${user.state}`
-                    );
-                    assert(
-                        user.data == undefined,
-                        `user2: Unexpected data object of ${user.data}`
-                    );
-                    object2done.resolve();
-                }
-            } catch (err) {
-                object2done.reject(err);
-            }
-        });
-        await object2.initialize(undefined, PresenceState.offline);
-
-        // Wait for events to trigger
-        await Promise.all([object1done.promise, object2done.promise]);
-
-        disposeAll();
-    });
-
     it("test canSendBackgroundUpdates only sends when true", async () => {
         const canSendBackgroundUpdatesObject2 = false;
         const { object1, object2, disposeAll } = await getObjects(
@@ -357,8 +307,8 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
                 object1done.reject(err);
             }
         });
-        await object1.initialize({ foo: "bar" }, PresenceState.away);
-        assert(object1.localUser?.state == PresenceState.away);
+        await object1.initialize({ foo: "bar" });
+        assert(object1.localUser?.state == PresenceState.online);
         assert(object1.localUser?.data?.foo == "bar");
 
         const object2done = new Deferred();
@@ -376,7 +326,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
                 object2done.reject(err);
             }
         });
-        await object2.initialize({ foo: "bar" }, PresenceState.offline);
+        await object2.initialize({ foo: "bar" });
 
         // Wait for events to trigger
         await Promise.all([object1done.promise, object2done.promise]);
@@ -452,7 +402,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
             }
         });
         await object1.initialize();
-        await object2.initialize(undefined, PresenceState.away);
+        await object2.initialize(undefined);
 
         // Wait for ready and perform test
         let user1Found = false;
@@ -492,7 +442,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
             }
         });
         await object1.initialize();
-        await object2.initialize(undefined, PresenceState.away);
+        await object2.initialize(undefined);
 
         // Wait for ready and perform test
         let user1Found = false;
@@ -529,7 +479,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
             object1.getUsers().length === 1,
             "getUsers() should not start empty"
         );
-        await object2.initialize(undefined, PresenceState.away);
+        await object2.initialize(undefined);
 
         // Wait for ready and perform test
         await ready.promise;
@@ -552,7 +502,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
             }
         });
         await object1.initialize();
-        await object2.initialize(undefined, PresenceState.away);
+        await object2.initialize(undefined);
 
         // Wait for ready and perform test
         await ready.promise;
@@ -574,7 +524,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
             }
         });
         await object1.initialize();
-        await object2.initialize(undefined, PresenceState.away);
+        await object2.initialize(undefined);
 
         // Wait for ready and perform test
         await ready.promise;
@@ -601,7 +551,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
             }
         });
         await object1.initialize();
-        await object2.initialize(undefined, PresenceState.away);
+        await object2.initialize(undefined);
 
         // Wait for ready and perform test
         await ready.promise;
@@ -644,7 +594,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
             }
         });
         await object1.initialize();
-        await object2.initialize(undefined, PresenceState.away);
+        await object2.initialize(undefined);
 
         // Wait for ready and get client ID's
         await ready.promise;

--- a/packages/live-share/src/test/LivePresence.spec.ts
+++ b/packages/live-share/src/test/LivePresence.spec.ts
@@ -399,7 +399,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
                             user.data.foo == "bar",
                             `user1: Unexpected data object of ${user.data}`
                         );
-                        assert(user.state == PresenceState.offline);
+                        assert(user.state == PresenceState.online);
                         object1done.resolve();
                     } else {
                         triggered = true;
@@ -426,7 +426,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
         await object2Ready.promise;
 
         // Update presence
-        object2.update({ foo: "bar" }, PresenceState.offline);
+        object2.update({ foo: "bar" });
 
         // Wait for finish
         await object1done.promise;

--- a/packages/live-share/src/test/LivePresence.spec.ts
+++ b/packages/live-share/src/test/LivePresence.spec.ts
@@ -194,56 +194,42 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
 
         await object1.initialize(undefined);
 
-        let object2PresenceChangeOnlineCount: number = 0;
-        let object2PresenceChangeOfflineCount: number = 0;
+        let object2PresenceChangeTotalCount: number = 0;
 
-        let object2object2PresenceChangeCount: number = 0;
+        let object2FromObject2PerspectivePresenceChangeCount: number = 0;
         object2.on("presenceChanged", (user, local) => {
             if (local) {
-                object2object2PresenceChangeCount += 1;
-                if (user.state === "online") {
-                    object2PresenceChangeOnlineCount += 1;
-                } else {
-                    object2PresenceChangeOfflineCount += 1;
-                }
+                object2FromObject2PerspectivePresenceChangeCount += 1;
+                object2PresenceChangeTotalCount += 1;
                 object2done.resolve();
             }
         });
 
-        let object1object2PresenceChangeCount: number = 0;
+        let object1FromObject2PerspectivePresenceChangeCount: number = 0;
         object1.on("presenceChanged", (user, local) => {
             if (!local) {
-                object1object2PresenceChangeCount += 1;
-                if (user.state === "online") {
-                    object2PresenceChangeOnlineCount += 1;
-                } else {
-                    object2PresenceChangeOfflineCount += 1;
-                }
+                object1FromObject2PerspectivePresenceChangeCount += 1;
+                object2PresenceChangeTotalCount += 1;
             }
         });
         await object2.initialize(undefined);
 
         // as any to access private updateInternal, set background to true
         // should not cause an event to be sent
-        const backgroundUpdate1 = true;
-        (object2 as any).updateInternal(
-            "hello",
-            object2.localUser?.state,
-            false,
-            backgroundUpdate1
-        );
+        const backgroundUpdate = true;
+        (object2 as any).updateInternal("hello", false, backgroundUpdate);
 
         await waitForDelay(1);
         // Wait for events to trigger
         await object2done.promise;
 
         assert(
-            object2object2PresenceChangeCount == 2,
-            `expected two events from object2 from perspective of object 2, ${object2object2PresenceChangeCount}`
+            object2FromObject2PerspectivePresenceChangeCount == 2,
+            `expected two events from object2 from perspective of object 2, ${object2FromObject2PerspectivePresenceChangeCount}`
         );
         assert(
-            object1object2PresenceChangeCount == 1,
-            `expected one events from object2 from perspective of object 1, ${object1object2PresenceChangeCount}`
+            object1FromObject2PerspectivePresenceChangeCount == 1,
+            `expected one events from object2 from perspective of object 1, ${object1FromObject2PerspectivePresenceChangeCount}`
         );
 
         assert(
@@ -258,8 +244,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
         // should update as not a background update
         const backgroundUpdateFalse = false;
         (object2 as any).updateInternal(
-            "hello",
-            "offline",
+            "hello there",
             false,
             backgroundUpdateFalse
         );
@@ -267,22 +252,17 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
 
         assert(
             // @ts-ignore invalid, assersion earlier in test is making the linter think this assertion is unintentional.
-            object2object2PresenceChangeCount == 3,
-            `expected 1 more event (3 total) from object2 from perspective of object 2, ${object2object2PresenceChangeCount}`
+            object2FromObject2PerspectivePresenceChangeCount == 3,
+            `expected 1 more event (3 total) from object2 from perspective of object 2, ${object2FromObject2PerspectivePresenceChangeCount}`
         );
         assert(
             // @ts-ignore invalid, assersion earlier in test is making the linter think this assertion is unintentional.
-            object1object2PresenceChangeCount == 2,
-            `expected 1 more event (2 total) from object2 from perspective of object 1, ${object1object2PresenceChangeCount}`
+            object1FromObject2PerspectivePresenceChangeCount == 2,
+            `expected 1 more event (2 total) from object2 from perspective of object 1, ${object1FromObject2PerspectivePresenceChangeCount}`
         );
         assert(
-            object2PresenceChangeOnlineCount == 3,
-            `expected three events from object2 that was online, ${object2PresenceChangeOnlineCount}`
-        );
-        assert(
-            // @ts-ignore invalid, assersion earlier in test is making the linter think this assertion is unintentional.
-            object2PresenceChangeOfflineCount == 2,
-            `expected two events from object2 that was offline, ${object2PresenceChangeOfflineCount}`
+            object2PresenceChangeTotalCount == 5,
+            `expected three events from object2 that was online, ${object2PresenceChangeTotalCount}`
         );
 
         disposeAll();

--- a/packages/live-share/src/test/LivePresence.spec.ts
+++ b/packages/live-share/src/test/LivePresence.spec.ts
@@ -402,7 +402,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
             }
         });
         await object1.initialize();
-        await object2.initialize(undefined);
+        await object2.initialize();
 
         // Wait for ready and perform test
         let user1Found = false;
@@ -424,7 +424,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
         disposeAll();
     });
 
-    it("Should filter users by state using forEach()", async () => {
+    it("Should filter users by state and iterate using forEach()", async () => {
         const { object1, object2, disposeAll } = await getObjects(
             getTestObjectProvider
         );
@@ -442,7 +442,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
             }
         });
         await object1.initialize();
-        await object2.initialize(undefined);
+        await object2.initialize();
 
         // Wait for ready and perform test
         let user1Found = false;
@@ -459,7 +459,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
             }
         });
 
-        assert(user1Found && !user2Found);
+        assert(user1Found && user2Found);
 
         disposeAll();
     });
@@ -479,7 +479,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
             object1.getUsers().length === 1,
             "getUsers() should not start empty"
         );
-        await object2.initialize(undefined);
+        await object2.initialize();
 
         // Wait for ready and perform test
         await ready.promise;
@@ -502,7 +502,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
             }
         });
         await object1.initialize();
-        await object2.initialize(undefined);
+        await object2.initialize();
 
         // Wait for ready and perform test
         await ready.promise;
@@ -524,13 +524,13 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
             }
         });
         await object1.initialize();
-        await object2.initialize(undefined);
+        await object2.initialize();
 
         // Wait for ready and perform test
         await ready.promise;
-        const cnt = object1.getUsers(PresenceState.away).length;
-
-        assert(cnt == 1);
+        assert(object1.getUsers(PresenceState.online).length == 2);
+        assert(object1.getUsers(PresenceState.away).length == 0);
+        assert(object1.getUsers(PresenceState.offline).length == 0);
 
         disposeAll();
     });
@@ -551,7 +551,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
             }
         });
         await object1.initialize();
-        await object2.initialize(undefined);
+        await object2.initialize();
 
         // Wait for ready and perform test
         await ready.promise;
@@ -594,7 +594,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
             }
         });
         await object1.initialize();
-        await object2.initialize(undefined);
+        await object2.initialize();
 
         // Wait for ready and get client ID's
         await ready.promise;

--- a/packages/live-share/src/test/LivePresence.spec.ts
+++ b/packages/live-share/src/test/LivePresence.spec.ts
@@ -974,7 +974,7 @@ describeCompat("LivePresence", (getTestObjectProvider) => {
                 PresenceState.online,
             "object2 should still be online from object1's perspective"
         );
-        await waitForDelay(1500);
+        await waitForDelay(150);
         assert(
             object1User.getConnection(object2ClientId)?.state ==
                 PresenceState.away,

--- a/samples/javascript/04.live-share-react/src/components/ExampleLivePresence.jsx
+++ b/samples/javascript/04.live-share-react/src/components/ExampleLivePresence.jsx
@@ -30,10 +30,7 @@ export const ExampleLivePresence = () => {
                     updatePresence(
                         {
                             toggleCount: localUser.data.toggleCount + 1,
-                        },
-                        localUser.state === PresenceState.offline
-                            ? PresenceState.online
-                            : PresenceState.offline
+                        }
                     );
                 }}
             >

--- a/samples/javascript/04.live-share-react/src/components/ExampleLivePresence.jsx
+++ b/samples/javascript/04.live-share-react/src/components/ExampleLivePresence.jsx
@@ -27,11 +27,9 @@ export const ExampleLivePresence = () => {
             <button
                 onClick={() => {
                     if (!localUser) return;
-                    updatePresence(
-                        {
-                            toggleCount: localUser.data.toggleCount + 1,
-                        }
-                    );
+                    updatePresence({
+                        toggleCount: localUser.data.toggleCount + 1,
+                    });
                 }}
             >
                 {`Go ${

--- a/samples/typescript/04.live-share-react/src/components/ExampleLivePresence.tsx
+++ b/samples/typescript/04.live-share-react/src/components/ExampleLivePresence.tsx
@@ -27,15 +27,9 @@ export const ExampleLivePresence: FC = () => {
             </div>
             <button
                 onClick={() => {
-                    updatePresence(
-                        {
-                            toggleCount:
-                                (localUser?.data?.toggleCount ?? 0) + 1,
-                        },
-                        localUser?.state === PresenceState.offline
-                            ? PresenceState.online
-                            : PresenceState.offline
-                    );
+                    updatePresence({
+                        toggleCount: (localUser?.data?.toggleCount ?? 0) + 1,
+                    });
                 }}
             >
                 {`Go ${

--- a/samples/typescript/06.presence-avatars/src/pages/TabContent.tsx
+++ b/samples/typescript/06.presence-avatars/src/pages/TabContent.tsx
@@ -69,12 +69,9 @@ const LiveAvatars: FC = () => {
     });
 
     const onChangeFavoriteFood: InputProps["onChange"] = (ev, data) => {
-        updatePresence(
-            {
-                favoriteFood: data.value,
-            },
-            localUser?.state
-        );
+        updatePresence({
+            favoriteFood: data.value,
+        });
     };
 
     return (
@@ -130,12 +127,7 @@ const LiveAvatars: FC = () => {
             </AvatarGroup>
             <Button
                 onClick={() => {
-                    updatePresence(
-                        undefined,
-                        localUser?.state === PresenceState.online
-                            ? PresenceState.away
-                            : PresenceState.online
-                    );
+                    updatePresence(undefined);
                 }}
             >
                 Toggle status


### PR DESCRIPTION
- Use Audience in LivePresence for setting online/offline state of each connection.
- LivePresenceUser aggregates connection state from all of its connections. 
- Used the old expire logic to set state to `away`
- Remove ability for dev to set connection status, but added comment showing how to set expiration time for `away` state.
- Deleted old workaround code in LivePresence.