### PR TITLE
Changed TData generic to support undefined and null

### DIFF
--- a/packages/live-share-react/src/live-hooks/useLivePresence.ts
+++ b/packages/live-share-react/src/live-hooks/useLivePresence.ts
@@ -33,15 +33,15 @@ import {
  *
  * @template TData Optional typing for the custom user presence data object. Default is `object` type.
  * @param uniqueKey The unique key for `LivePresence`. If one does not yet exist, a new one will be created.
- * @param initialData Optional. Initial presence data object for the user. Can be value or a function to get the value.
+ * @param initialData Initial presence data object for the user. Can be value or a function to get the value.
  * @param allowedRoles Optional. the user roles that are allowed to mutate the synchronized state
  * will be created, otherwise it will use the existing one. Default value is ":<dds-default>"
  * @returns stateful `localUser`, `otherUsers` list, and `allUsers` list. Also returns a callback method
  * to update the local user's presence and the `LivePresence` Fluid object.
  */
-export function useLivePresence<TData extends object = object>(
+export function useLivePresence<TData extends object | undefined | null = any>(
     uniqueKey: string,
-    initialData?: TData | (() => TData) | undefined,
+    initialData: TData | (() => TData),
     allowedRoles?: UserMeetingRole[]
 ): IUseLivePresenceResults<TData> {
     /**
@@ -144,6 +144,8 @@ export function useLivePresence<TData extends object = object>(
     };
 }
 
-function isInitialDataCallback<TData>(value: any): value is () => TData {
+function isInitialDataCallback<TData extends object | undefined | null>(
+    value: any
+): value is () => TData {
     return typeof value === "function";
 }

--- a/packages/live-share-react/src/types/ActionTypes.ts
+++ b/packages/live-share-react/src/types/ActionTypes.ts
@@ -111,9 +111,9 @@ export type OnReceivedLiveEventAction<TEvent> = (
  * Callback for OnUpdateLivePresenceAction<TData extends object = object>.
  * (data?: TData | undefined, state?: PresenceState | undefined) => Promise<void>
  */
-export type OnUpdateLivePresenceAction<TData extends object = object> = (
-    data: TData
-) => Promise<void>;
+export type OnUpdateLivePresenceAction<
+    TData extends object | undefined | null = any,
+> = (data: TData) => Promise<void>;
 
 /**
  * Callback for OnStartTimerAction.

--- a/packages/live-share-react/src/types/ResultTypes.ts
+++ b/packages/live-share-react/src/types/ResultTypes.ts
@@ -181,7 +181,9 @@ export interface IUseLiveTimerResults {
 /**
  * Return type of {@link useLivePresence} hook.
  */
-export interface IUseLivePresenceResults<TData extends object = object> {
+export interface IUseLivePresenceResults<
+    TData extends object | undefined | null = any,
+> {
     /**
      * The local user's presence object.
      */
@@ -200,8 +202,7 @@ export interface IUseLivePresenceResults<TData extends object = object> {
     livePresence: LivePresence<TData> | undefined;
     /**
      * Callback method to update the local user's presence.
-     * @param data Optional. TData to set for user.
-     * @param state Optional. PresenceState to set for user.
+     * @param data TData to set for user.
      * @returns void promise that will throw when user does not have required roles
      */
     updatePresence: OnUpdateLivePresenceAction<TData>;

--- a/packages/live-share/src/LivePresence.ts
+++ b/packages/live-share/src/LivePresence.ts
@@ -48,8 +48,9 @@ export enum LivePresenceEvents {
  * Event typings for `LivePresence` class.
  * @template TData Type of data object to share with clients.
  */
-export interface ILivePresenceEvents<TData extends object = object>
-    extends IEvent {
+export interface ILivePresenceEvents<
+    TData extends object | undefined | null = any,
+> extends IEvent {
     /**
      * The presence information for the local or a remote user has changed.
      * @param event Name of event.
@@ -73,7 +74,7 @@ export interface ILivePresenceEvents<TData extends object = object>
  * @template TData Type of data object to share with clients.
  */
 export class LivePresenceClass<
-    TData extends object = object,
+    TData extends object | undefined | null = any,
 > extends LiveDataObject<{
     Events: ILivePresenceEvents<TData>;
 }> {
@@ -130,7 +131,7 @@ export class LivePresenceClass<
     /**
      * Initialize the object to begin sending/receiving presence updates through this DDS.
      *
-     * @param data Optional. Custom data object to share. A deep copy of the data object is saved to avoid any accidental modifications.
+     * @param data Custom data object to share. A deep copy of the data object is saved to avoid any accidental modifications.
      * @param allowedRoles Optional. List of roles allowed to emit presence changes.
      *
      * @returns a void promise that resolves once complete.
@@ -140,7 +141,7 @@ export class LivePresenceClass<
      * This is most common when using dynamic objects through Fluid.
      */
     public async initialize(
-        data?: TData,
+        data: TData,
         allowedRoles?: UserMeetingRole[]
     ): Promise<void> {
         LiveDataObjectInitializeNotNeededError.assert(
@@ -250,7 +251,7 @@ export class LivePresenceClass<
      * @throws error if initialization has not yet succeeded.
      * @throws error if the local user does not have the required roles defined through the `allowedRoles` prop in `.initialize()`.
      */
-    public async update(data: TData | undefined | null): Promise<void> {
+    public async update(data: TData): Promise<void> {
         return await this.updateInternal(data);
     }
 
@@ -280,7 +281,7 @@ export class LivePresenceClass<
      * Internal method to send an update, with optional ability to throttle.
      */
     private async updateInternal(
-        data: TData | undefined | null,
+        data: TData | undefined,
         throttle: boolean = false,
         background: boolean = false
     ): Promise<void> {
@@ -471,10 +472,11 @@ export class LivePresenceClass<
             return;
         }
         const connection = user?.getConnection(clientId);
+        if (!connection) return;
 
         const evtToSend = {
             state,
-            data: connection?.data,
+            data: connection.data,
         };
         /**
          * Create an event that is not sent to other clients, since all clients should create this event at the same time.
@@ -489,7 +491,7 @@ export class LivePresenceClass<
     }
 }
 
-export type LivePresence<TData extends object = object> =
+export type LivePresence<TData extends object | undefined | null = any> =
     LivePresenceClass<TData>;
 
 // eslint-disable-next-line no-redeclare

--- a/packages/live-share/src/LivePresenceConnection.ts
+++ b/packages/live-share/src/LivePresenceConnection.ts
@@ -13,7 +13,9 @@ import { cloneValue } from "./internals/utils.js";
  * A user can join from multiple devices. If they do, they will have multiple connections and a distinct clientId on each device.
  * If the client is disconnected for any reason, and they have to reconnect, they will get a new clientId and thus a new connection.
  */
-export class LivePresenceConnection<TData = object> {
+export class LivePresenceConnection<
+    TData extends object | undefined | null = any,
+> {
     /**
      * @hidden
      */
@@ -58,7 +60,7 @@ export class LivePresenceConnection<TData = object> {
     /**
      * Optional data shared by the user.
      */
-    public get data(): TData | undefined {
+    public get data(): TData {
         return cloneValue(this._evt.data.data);
     }
 

--- a/packages/live-share/src/LivePresenceUser.ts
+++ b/packages/live-share/src/LivePresenceUser.ts
@@ -35,22 +35,24 @@ export enum PresenceState {
 /**
  * @hidden
  */
-export interface ILivePresenceEvent<TData = object> {
+export interface ILivePresenceEvent<
+    TData extends object | undefined | null = any,
+> {
     state: PresenceState;
-    data?: TData;
+    data: TData;
 }
 
 /**
  * @hidden
  */
-export type LivePresenceReceivedEventData<TData = object> = ILiveEvent<
-    ILivePresenceEvent<TData>
->;
+export type LivePresenceReceivedEventData<
+    TData extends object | undefined | null = any,
+> = ILiveEvent<ILivePresenceEvent<TData>>;
 
 /**
  * A user that presence is being tracked for.
  */
-export class LivePresenceUser<TData = object> {
+export class LivePresenceUser<TData extends object | undefined | null = any> {
     private _lastUpdateTime: number;
     private _connections: Map<string, LivePresenceConnection<TData>> =
         new Map();
@@ -109,7 +111,7 @@ export class LivePresenceUser<TData = object> {
      * Optional data shared by the user. Returns data from connection with most recent event.
      * Client connection specific data is available from each connection.
      */
-    public get data(): TData | undefined {
+    public get data(): TData {
         return cloneValue(this._evt.data.data);
     }
 

--- a/packages/live-share/src/test/LivePresence.audience.spec.ts
+++ b/packages/live-share/src/test/LivePresence.audience.spec.ts
@@ -57,8 +57,8 @@ describe("LivePresence Fluid Audience tests", () => {
         // Wait for dds to to be created
         const [dds1, dds2] = await Promise.all([promise1, promise2]);
 
-        await dds1.initialize();
-        await dds2.initialize();
+        await dds1.initialize(undefined);
+        await dds2.initialize(undefined);
 
         client1.results?.container.disconnect();
 

--- a/packages/live-share/src/test/LivePresence.spec.ts
+++ b/packages/live-share/src/test/LivePresence.spec.ts
@@ -32,14 +32,14 @@ import { SharedObjectKind } from "fluid-framework";
 import { createDataObjectKind } from "@fluidframework/aqueduct/internal";
 
 class TestLivePresenceClass<
-    TData extends object = object,
+    TData extends object | undefined | null = object,
 > extends LivePresenceClass<TData> {
     public async clientId(): Promise<string> {
         return await this.waitUntilConnected();
     }
 }
 
-export type TestLivePresence<TData extends object = object> =
+export type TestLivePresence<TData extends object | undefined | null = object> =
     TestLivePresenceClass<TData>;
 
 // eslint-disable-next-line no-redeclare
@@ -66,10 +66,10 @@ async function getObjects(
     liveRuntime2.canSendBackgroundUpdates = object2canSendBackgroundUpdates;
 
     let ObjectProxy1: any = getLiveDataObjectKind<
-        TestLivePresence<{ foo: string }>
+        TestLivePresence<{ foo: string } | undefined>
     >(TestLivePresence, liveRuntime1);
     let ObjectProxy2: any = getLiveDataObjectKind<
-        TestLivePresence<{ foo: string }>
+        TestLivePresence<{ foo: string } | undefined>
     >(TestLivePresence, liveRuntime2);
 
     await liveRuntime1.start();
@@ -82,7 +82,7 @@ async function getObjects(
     );
     let object1 =
         await getContainerEntryPointBackCompat<
-            TestLivePresence<{ foo: string }>
+            TestLivePresence<{ foo: string } | undefined>
         >(container1);
 
     let container2 = await provider.loadContainer(
@@ -90,7 +90,7 @@ async function getObjects(
     );
     let object2 =
         await getContainerEntryPointBackCompat<
-            TestLivePresence<{ foo: string }>
+            TestLivePresence<{ foo: string } | undefined>
         >(container2);
     // need to be connected to send signals
     if (!container1.connect) {
@@ -159,7 +159,7 @@ describeCompat(
             });
 
             assert(!object1.isInitialized, `presence already initialized`);
-            await object1.initialize();
+            await object1.initialize(undefined);
             assert(object1.isInitialized, `presence not initialized`);
 
             const object2done = new Deferred();
@@ -181,7 +181,7 @@ describeCompat(
                     object2done.reject(err);
                 }
             });
-            await object2.initialize();
+            await object2.initialize(undefined);
 
             // Wait for events to trigger
             await Promise.all([object1done.promise, object2done.promise]);
@@ -349,13 +349,13 @@ describeCompat(
                     object1done.reject(err);
                 }
             });
-            await object1.initialize();
+            await object1.initialize(undefined);
 
             const object2Ready = new Deferred();
             object2.on("presenceChanged", (user, local) => {
                 object2Ready.resolve();
             });
-            await object2.initialize();
+            await object2.initialize(undefined);
 
             // Wait for everything to start
             await object2Ready.promise;
@@ -386,8 +386,8 @@ describeCompat(
                     ready.resolve();
                 }
             });
-            await object1.initialize();
-            await object2.initialize();
+            await object1.initialize(undefined);
+            await object2.initialize(undefined);
 
             // Wait for ready and perform test
             let user1Found = false;
@@ -426,8 +426,8 @@ describeCompat(
                     ready.resolve();
                 }
             });
-            await object1.initialize();
-            await object2.initialize();
+            await object1.initialize(undefined);
+            await object2.initialize(undefined);
 
             // Wait for ready and perform test
             let user1Found = false;
@@ -459,12 +459,12 @@ describeCompat(
                     ready.resolve();
                 }
             });
-            await object1.initialize();
+            await object1.initialize(undefined);
             assert(
                 object1.getUsers().length === 1,
                 "getUsers() should not start empty"
             );
-            await object2.initialize();
+            await object2.initialize(undefined);
 
             // Wait for ready and perform test
             await ready.promise;
@@ -486,8 +486,8 @@ describeCompat(
                     ready.resolve();
                 }
             });
-            await object1.initialize();
-            await object2.initialize();
+            await object1.initialize(undefined);
+            await object2.initialize(undefined);
 
             // Wait for ready and perform test
             await ready.promise;
@@ -508,8 +508,8 @@ describeCompat(
                     ready.resolve();
                 }
             });
-            await object1.initialize();
-            await object2.initialize();
+            await object1.initialize(undefined);
+            await object2.initialize(undefined);
 
             // Wait for ready and perform test
             await ready.promise;
@@ -535,8 +535,8 @@ describeCompat(
                     ready.resolve();
                 }
             });
-            await object1.initialize();
-            await object2.initialize();
+            await object1.initialize(undefined);
+            await object2.initialize(undefined);
 
             // Wait for ready and perform test
             await ready.promise;
@@ -578,8 +578,8 @@ describeCompat(
                     ready.resolve();
                 }
             });
-            await object1.initialize();
-            await object2.initialize();
+            await object1.initialize(undefined);
+            await object2.initialize(undefined);
 
             // Wait for ready and get client ID's
             await ready.promise;
@@ -641,10 +641,10 @@ describeCompat(
                 }
             });
             object1.expirationPeriod = 0.2;
-            await object1.initialize();
+            await object1.initialize(undefined);
 
             object2.expirationPeriod = 0.2;
-            await object2.initialize();
+            await object2.initialize(undefined);
 
             // Wait for ready and then delay
             await ready.promise;
@@ -722,8 +722,8 @@ describeCompat(
             });
 
             assert(!object1.isInitialized, `presence already initialized`);
-            const init1 = object1.initialize();
-            const init2 = object2.initialize();
+            const init1 = object1.initialize(undefined);
+            const init2 = object2.initialize(undefined);
             await Promise.all([init1, init2]);
             assert(object1.isInitialized, `presence not initialized`);
 
@@ -786,8 +786,8 @@ describeCompat(
             });
 
             assert(!object1.isInitialized, `presence already initialized`);
-            const init1 = object1.initialize();
-            const init2 = object2.initialize();
+            const init1 = object1.initialize(undefined);
+            const init2 = object2.initialize(undefined);
             await Promise.all([init1, init2]);
             assert(object1.isInitialized, `presence not initialized`);
 
@@ -892,8 +892,8 @@ describeCompat(
             } = await getObjects(getTestObjectProvider, 10000, true, mockHost);
 
             assert(!object1.isInitialized, `presence already initialized`);
-            const init1 = object1.initialize();
-            const init2 = object2.initialize();
+            const init1 = object1.initialize(undefined);
+            const init2 = object2.initialize(undefined);
             await Promise.all([init1, init2]);
             assert(object1.isInitialized, `presence not initialized`);
 

--- a/samples/typescript/04.live-share-react/tsconfig.json
+++ b/samples/typescript/04.live-share-react/tsconfig.json
@@ -4,7 +4,8 @@
     "compilerOptions": {
         "jsx": "react-jsx",
         "outDir": "/tmp",
-        "module": "ESNext"
+        "module": "ESNext",
+        "moduleResolution": "Bundler"
     },
     "files": ["src/main.tsx"]
 }

--- a/samples/typescript/06.presence-avatars/src/pages/TabContent.tsx
+++ b/samples/typescript/06.presence-avatars/src/pages/TabContent.tsx
@@ -49,8 +49,9 @@ interface IUserData {
 const PRESENCE_KEY = "PRESENCE_AVATARS";
 
 const LiveAvatars: FC = () => {
-    const { allUsers, localUser, updatePresence } =
-        useLivePresence<IUserData>(PRESENCE_KEY);
+    const { allUsers, localUser, updatePresence } = useLivePresence<
+        IUserData | undefined
+    >(PRESENCE_KEY, undefined);
     const onlineOrAwayUsers = allUsers.filter(
         (user) =>
             user.displayName &&


### PR DESCRIPTION
`LivePresence` now supports `undefined` and `null` as valid `TData` generics, so that it can more closely align to `LiveState`. With this change, the `data` prop in `initialize` and `update` are no longer optional so the developer can have more explicit typing.