### PR TITLE
Target signals to specific clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,320 +71,12 @@
                 "typescript": "~5.5.3"
             }
         },
-        "internal/test-utils/node_modules/@fluidframework/eslint-config-fluid": {
-            "version": "5.3.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@fluid-internal/eslint-plugin-fluid": "^0.1.1",
-                "@microsoft/tsdoc": "^0.14.2",
-                "@rushstack/eslint-patch": "~1.4.0",
-                "@rushstack/eslint-plugin": "~0.13.0",
-                "@rushstack/eslint-plugin-security": "~0.7.0",
-                "@typescript-eslint/eslint-plugin": "~6.7.2",
-                "@typescript-eslint/parser": "~6.7.2",
-                "eslint-config-prettier": "~9.0.0",
-                "eslint-import-resolver-typescript": "~3.6.1",
-                "eslint-plugin-eslint-comments": "~3.2.0",
-                "eslint-plugin-import": "npm:eslint-plugin-i@~2.29.0",
-                "eslint-plugin-jsdoc": "~46.8.1",
-                "eslint-plugin-promise": "~6.1.1",
-                "eslint-plugin-react": "~7.33.2",
-                "eslint-plugin-react-hooks": "~4.6.0",
-                "eslint-plugin-tsdoc": "~0.2.17",
-                "eslint-plugin-unicorn": "~48.0.1",
-                "eslint-plugin-unused-imports": "~3.0.0"
-            }
-        },
-        "internal/test-utils/node_modules/@fluidframework/eslint-config-fluid/node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "6.7.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.7.5",
-                "@typescript-eslint/type-utils": "6.7.5",
-                "@typescript-eslint/utils": "6.7.5",
-                "@typescript-eslint/visitor-keys": "6.7.5",
-                "debug": "^4.3.4",
-                "graphemer": "^1.4.0",
-                "ignore": "^5.2.4",
-                "natural-compare": "^1.4.0",
-                "semver": "^7.5.4",
-                "ts-api-utils": "^1.0.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-                "eslint": "^7.0.0 || ^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "internal/test-utils/node_modules/@fluidframework/eslint-config-fluid/node_modules/@typescript-eslint/parser": {
-            "version": "6.7.5",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "@typescript-eslint/scope-manager": "6.7.5",
-                "@typescript-eslint/types": "6.7.5",
-                "@typescript-eslint/typescript-estree": "6.7.5",
-                "@typescript-eslint/visitor-keys": "6.7.5",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "internal/test-utils/node_modules/@fluidframework/eslint-config-fluid/node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.7.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "6.7.5",
-                "@typescript-eslint/visitor-keys": "6.7.5"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "internal/test-utils/node_modules/@fluidframework/eslint-config-fluid/node_modules/@typescript-eslint/type-utils": {
-            "version": "6.7.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/typescript-estree": "6.7.5",
-                "@typescript-eslint/utils": "6.7.5",
-                "debug": "^4.3.4",
-                "ts-api-utils": "^1.0.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "internal/test-utils/node_modules/@fluidframework/eslint-config-fluid/node_modules/@typescript-eslint/types": {
-            "version": "6.7.5",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "internal/test-utils/node_modules/@fluidframework/eslint-config-fluid/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.7.5",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "@typescript-eslint/types": "6.7.5",
-                "@typescript-eslint/visitor-keys": "6.7.5",
-                "debug": "^4.3.4",
-                "globby": "^11.1.0",
-                "is-glob": "^4.0.3",
-                "semver": "^7.5.4",
-                "ts-api-utils": "^1.0.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "internal/test-utils/node_modules/@fluidframework/eslint-config-fluid/node_modules/@typescript-eslint/utils": {
-            "version": "6.7.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@eslint-community/eslint-utils": "^4.4.0",
-                "@types/json-schema": "^7.0.12",
-                "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.7.5",
-                "@typescript-eslint/types": "6.7.5",
-                "@typescript-eslint/typescript-estree": "6.7.5",
-                "semver": "^7.5.4"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
-            }
-        },
-        "internal/test-utils/node_modules/@fluidframework/eslint-config-fluid/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.7.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/types": "6.7.5",
-                "eslint-visitor-keys": "^3.4.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "internal/test-utils/node_modules/@fluidframework/eslint-config-fluid/node_modules/eslint-config-prettier": {
-            "version": "9.0.0",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "eslint-config-prettier": "bin/cli.js"
-            },
-            "peerDependencies": {
-                "eslint": ">=7.0.0"
-            }
-        },
-        "internal/test-utils/node_modules/@fluidframework/eslint-config-fluid/node_modules/eslint-plugin-unused-imports": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "eslint-rule-composer": "^0.3.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "peerDependencies": {
-                "@typescript-eslint/eslint-plugin": "^6.0.0",
-                "eslint": "^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@typescript-eslint/eslint-plugin": {
-                    "optional": true
-                }
-            }
-        },
         "internal/test-utils/node_modules/brace-expansion": {
             "version": "2.0.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
-            }
-        },
-        "internal/test-utils/node_modules/doctrine": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-            "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-            "dev": true,
-            "dependencies": {
-                "esutils": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "internal/test-utils/node_modules/eslint-plugin-react": {
-            "version": "7.33.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz",
-            "integrity": "sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==",
-            "dev": true,
-            "dependencies": {
-                "array-includes": "^3.1.6",
-                "array.prototype.flatmap": "^1.3.1",
-                "array.prototype.tosorted": "^1.1.1",
-                "doctrine": "^2.1.0",
-                "es-iterator-helpers": "^1.0.12",
-                "estraverse": "^5.3.0",
-                "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-                "minimatch": "^3.1.2",
-                "object.entries": "^1.1.6",
-                "object.fromentries": "^2.0.6",
-                "object.hasown": "^1.1.2",
-                "object.values": "^1.1.6",
-                "prop-types": "^15.8.1",
-                "resolve": "^2.0.0-next.4",
-                "semver": "^6.3.1",
-                "string.prototype.matchall": "^4.0.8"
-            },
-            "engines": {
-                "node": ">=4"
-            },
-            "peerDependencies": {
-                "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
-            }
-        },
-        "internal/test-utils/node_modules/eslint-plugin-react/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
-        "internal/test-utils/node_modules/eslint-plugin-unused-imports": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "eslint-rule-composer": "^0.3.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "peerDependencies": {
-                "@typescript-eslint/eslint-plugin": "6 - 7",
-                "eslint": "8"
-            },
-            "peerDependenciesMeta": {
-                "@typescript-eslint/eslint-plugin": {
-                    "optional": true
-                }
             }
         },
         "internal/test-utils/node_modules/glob": {
@@ -597,96 +289,42 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.23.5",
-            "license": "MIT",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+            "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
             "dependencies": {
-                "@babel/highlight": "^7.23.4",
-                "chalk": "^2.4.2"
+                "@babel/highlight": "^7.24.7",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/chalk": {
-            "version": "2.4.2",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/color-convert": {
-            "version": "1.9.3",
-            "license": "MIT",
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/color-name": {
-            "version": "1.1.3",
-            "license": "MIT"
-        },
-        "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-            "version": "1.0.5",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8.0"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/has-flag": {
-            "version": "3.0.0",
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/supports-color": {
-            "version": "5.5.0",
-            "license": "MIT",
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/@babel/compat-data": {
-            "version": "7.23.5",
+            "version": "7.25.4",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+            "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.23.9",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
+            "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.23.5",
-                "@babel/generator": "^7.23.6",
-                "@babel/helper-compilation-targets": "^7.23.6",
-                "@babel/helper-module-transforms": "^7.23.3",
-                "@babel/helpers": "^7.23.9",
-                "@babel/parser": "^7.23.9",
-                "@babel/template": "^7.23.9",
-                "@babel/traverse": "^7.23.9",
-                "@babel/types": "^7.23.9",
+                "@babel/code-frame": "^7.24.7",
+                "@babel/generator": "^7.25.0",
+                "@babel/helper-compilation-targets": "^7.25.2",
+                "@babel/helper-module-transforms": "^7.25.2",
+                "@babel/helpers": "^7.25.0",
+                "@babel/parser": "^7.25.0",
+                "@babel/template": "^7.25.0",
+                "@babel/traverse": "^7.25.2",
+                "@babel/types": "^7.25.2",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -710,13 +348,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.23.6",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
+            "integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.23.6",
-                "@jridgewell/gen-mapping": "^0.3.2",
-                "@jridgewell/trace-mapping": "^0.3.17",
+                "@babel/types": "^7.25.6",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
             },
             "engines": {
@@ -724,13 +363,14 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.23.6",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
+            "integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.23.5",
-                "@babel/helper-validator-option": "^7.23.5",
-                "browserslist": "^4.22.2",
+                "@babel/compat-data": "^7.25.2",
+                "@babel/helper-validator-option": "^7.24.8",
+                "browserslist": "^4.23.1",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
             },
@@ -740,64 +380,36 @@
         },
         "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
             "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
-            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
-        "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.22.20",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-function-name": {
-            "version": "7.23.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/template": "^7.22.15",
-                "@babel/types": "^7.23.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.22.5",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.22.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.22.15",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+            "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.22.15"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.23.3",
+            "version": "7.25.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
+            "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-module-imports": "^7.22.15",
-                "@babel/helper-simple-access": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/helper-validator-identifier": "^7.22.20"
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-simple-access": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7",
+                "@babel/traverse": "^7.25.2"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -815,70 +427,66 @@
             }
         },
         "node_modules/@babel/helper-simple-access": {
-            "version": "7.22.5",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+            "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.22.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.22.6",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.23.4",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+            "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.22.20",
-            "license": "MIT",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+            "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.23.5",
+            "version": "7.24.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
+            "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.23.9",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
+            "integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.23.9",
-                "@babel/traverse": "^7.23.9",
-                "@babel/types": "^7.23.9"
+                "@babel/template": "^7.25.0",
+                "@babel/types": "^7.25.6"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.23.4",
-            "license": "MIT",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+            "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.22.20",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0"
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -886,7 +494,8 @@
         },
         "node_modules/@babel/highlight/node_modules/ansi-styles": {
             "version": "3.2.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dependencies": {
                 "color-convert": "^1.9.0"
             },
@@ -896,7 +505,8 @@
         },
         "node_modules/@babel/highlight/node_modules/chalk": {
             "version": "2.4.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "dependencies": {
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
@@ -908,32 +518,37 @@
         },
         "node_modules/@babel/highlight/node_modules/color-convert": {
             "version": "1.9.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
             "dependencies": {
                 "color-name": "1.1.3"
             }
         },
         "node_modules/@babel/highlight/node_modules/color-name": {
             "version": "1.1.3",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
             "version": "1.0.5",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@babel/highlight/node_modules/has-flag": {
             "version": "3.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/@babel/highlight/node_modules/supports-color": {
             "version": "5.5.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "dependencies": {
                 "has-flag": "^3.0.0"
             },
@@ -942,9 +557,13 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.23.9",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
+            "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
             "dev": true,
-            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.25.6"
+            },
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -991,31 +610,30 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.23.9",
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
+            "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.23.5",
-                "@babel/parser": "^7.23.9",
-                "@babel/types": "^7.23.9"
+                "@babel/code-frame": "^7.24.7",
+                "@babel/parser": "^7.25.0",
+                "@babel/types": "^7.25.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.23.9",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
+            "integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.23.5",
-                "@babel/generator": "^7.23.6",
-                "@babel/helper-environment-visitor": "^7.22.20",
-                "@babel/helper-function-name": "^7.23.0",
-                "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.23.9",
-                "@babel/types": "^7.23.9",
+                "@babel/code-frame": "^7.24.7",
+                "@babel/generator": "^7.25.6",
+                "@babel/parser": "^7.25.6",
+                "@babel/template": "^7.25.0",
+                "@babel/types": "^7.25.6",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -1025,19 +643,21 @@
         },
         "node_modules/@babel/traverse/node_modules/globals": {
             "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.23.9",
+            "version": "7.25.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
+            "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.23.4",
-                "@babel/helper-validator-identifier": "^7.22.20",
+                "@babel/helper-string-parser": "^7.24.8",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -1141,9 +761,10 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.56.0",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+            "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
@@ -2339,44 +1960,45 @@
             }
         },
         "node_modules/@fluid-experimental/attributor": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluid-experimental/attributor/-/attributor-2.1.0.tgz",
-            "integrity": "sha512-9l/dAk0EN+n8DGQZM/5Az2hQcxH2LXe48yp2yRwLyIL81qHHhPx3dZzobUm+Xs+KOg9SiKsvTFu6BOyWEG7WUQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluid-experimental/attributor/-/attributor-2.2.0.tgz",
+            "integrity": "sha512-jSbfgOOBTJamnXCiM6UYFILRH72isWg6JM8hppsCxgpwrRnC1wbklG584w21ZYmJgp5ttHKb+R4grxXRoMWGSA==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/container-runtime": "~2.1.0",
-                "@fluidframework/container-runtime-definitions": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/container-runtime": "~2.2.0",
+                "@fluidframework/container-runtime-definitions": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "lz4js": "^0.2.0"
             }
         },
         "node_modules/@fluid-experimental/sequence-deprecated": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluid-experimental/sequence-deprecated/-/sequence-deprecated-2.1.0.tgz",
-            "integrity": "sha512-nIsvTmGUQaerDs3+kv6yRlcqYDOQfmfmf86BoyNnsYzZa8gtCBs0EoMna0Thc8mv29ISwzABAjLLbcgZRJWl+g==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluid-experimental/sequence-deprecated/-/sequence-deprecated-2.2.0.tgz",
+            "integrity": "sha512-y+hlNS6rAX7GtZiZyU5DqFmEmIrjGtgN8ierRSpu8tMg4j5zdo0z9dpMyUm1D4vJyzSRWbYnn81RE+B9TNwp1w==",
             "dependencies": {
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/merge-tree": "~2.1.0",
-                "@fluidframework/sequence": "~2.1.0",
-                "@fluidframework/shared-object-base": "~2.1.0"
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/merge-tree": "~2.2.0",
+                "@fluidframework/sequence": "~2.2.0",
+                "@fluidframework/shared-object-base": "~2.2.0"
             }
         },
         "node_modules/@fluid-internal/client-utils": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.1.0.tgz",
-            "integrity": "sha512-M6H0rJLtjHlx2w8vLlJkFSltB5OuJfXINufYhZGB40gZVJZRkElM/f0MKD0BlLIurVAtpIgZ/pAFWpiTvbgH1g==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluid-internal/client-utils/-/client-utils-2.2.0.tgz",
+            "integrity": "sha512-EfwSDsNMhWvVXRSaaU6m5i8aPBrupSvg0vPLlOmCyeXVfO0e4jERJoadkgP2uBMZFIgiKFVqP+E+35zrY5Ajqw==",
             "dependencies": {
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
                 "@types/events_pkg": "npm:@types/events@^3.0.0",
                 "base64-js": "^1.5.1",
                 "buffer": "^6.0.3",
@@ -2385,19 +2007,21 @@
             }
         },
         "node_modules/@fluid-internal/eslint-plugin-fluid": {
-            "version": "0.1.1",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@fluid-internal/eslint-plugin-fluid/-/eslint-plugin-fluid-0.1.2.tgz",
+            "integrity": "sha512-E7LF4ukpCoyZcxpDUQz0edXsKllbh4m8NAdiug6sSI1KIIQFwtq5vvW3kQ0Op5xA9w10T6crfcvmuAzdP84UGg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@microsoft/tsdoc": "^0.14.2",
-                "@typescript-eslint/parser": "^6.7.2",
-                "ts-morph": "^20.0.0"
+                "@typescript-eslint/parser": "^6.21.0",
+                "ts-morph": "^22.0.0"
             }
         },
         "node_modules/@fluid-internal/eslint-plugin-fluid/node_modules/@typescript-eslint/parser": {
             "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+            "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "@typescript-eslint/scope-manager": "6.21.0",
                 "@typescript-eslint/types": "6.21.0",
@@ -2423,8 +2047,9 @@
         },
         "node_modules/@fluid-internal/eslint-plugin-fluid/node_modules/@typescript-eslint/scope-manager": {
             "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+            "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@typescript-eslint/types": "6.21.0",
                 "@typescript-eslint/visitor-keys": "6.21.0"
@@ -2439,8 +2064,9 @@
         },
         "node_modules/@fluid-internal/eslint-plugin-fluid/node_modules/@typescript-eslint/types": {
             "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+            "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
             },
@@ -2451,8 +2077,9 @@
         },
         "node_modules/@fluid-internal/eslint-plugin-fluid/node_modules/@typescript-eslint/typescript-estree": {
             "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+            "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "dependencies": {
                 "@typescript-eslint/types": "6.21.0",
                 "@typescript-eslint/visitor-keys": "6.21.0",
@@ -2478,8 +2105,9 @@
         },
         "node_modules/@fluid-internal/eslint-plugin-fluid/node_modules/@typescript-eslint/visitor-keys": {
             "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+            "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@typescript-eslint/types": "6.21.0",
                 "eslint-visitor-keys": "^3.4.1"
@@ -2494,16 +2122,18 @@
         },
         "node_modules/@fluid-internal/eslint-plugin-fluid/node_modules/brace-expansion": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
         },
         "node_modules/@fluid-internal/eslint-plugin-fluid/node_modules/minimatch": {
             "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -2515,84 +2145,84 @@
             }
         },
         "node_modules/@fluid-internal/test-driver-definitions": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluid-internal/test-driver-definitions/-/test-driver-definitions-2.1.0.tgz",
-            "integrity": "sha512-RCumaxnbPrHPzfltjteRx6NuB+EDGk2Kq5bhsLzY7YZLmxJAYDM6/8jlp78lA3EX8RS7Y43LXHnNGX011UVyrQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluid-internal/test-driver-definitions/-/test-driver-definitions-2.2.0.tgz",
+            "integrity": "sha512-63OLTC7PS8eQeQrN5tLa3MfTaJ1O8melk8/Iv6YU/KfRkgPus5jn7IlZWUNvH/5/iMuSq/fjW64BRRNkb/aJUw==",
             "dependencies": {
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0"
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/agent-scheduler": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-2.1.0.tgz",
-            "integrity": "sha512-aVIvIjz9mD+Vx5uSjkK0IunmCld7Gzl60KZJ9yXvs4Auk2pCDqMeOEUty1IyW5ee2QtRT9kO22pSKWc33QZx2g==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-2.2.0.tgz",
+            "integrity": "sha512-yoN5KZgY+d00pRRfHha9zA1GFfdPB7NYXP9F9YwvSIZNR98g2iP0z7AGfANh6MzUQd6f07kCCCjzsBzuXSdPvg==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/map": "~2.1.0",
-                "@fluidframework/register-collection": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/map": "~2.2.0",
+                "@fluidframework/register-collection": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "uuid": "^9.0.0"
             }
         },
         "node_modules/@fluidframework/aqueduct": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.1.0.tgz",
-            "integrity": "sha512-DlNqYux74TssM6TYRK53s23pv2pCFw2gye05rpE5P+ANJykHkNvfAVEWeUjz6ukniuJYqS1CLUHwzr8E12S1KQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-2.2.0.tgz",
+            "integrity": "sha512-vc5bH0Q/0i13eyjSgkp+KHNG33QfMxg/ZDlrNVnI3gMX25TP2GCLP2DRK6U5WCR6QxCUCbIpQEPBVy2E9WiU3g==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/container-runtime": "~2.1.0",
-                "@fluidframework/container-runtime-definitions": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/map": "~2.1.0",
-                "@fluidframework/request-handler": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0",
-                "@fluidframework/shared-object-base": "~2.1.0",
-                "@fluidframework/synthesize": "~2.1.0"
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/container-runtime": "~2.2.0",
+                "@fluidframework/container-runtime-definitions": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/map": "~2.2.0",
+                "@fluidframework/request-handler": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/shared-object-base": "~2.2.0",
+                "@fluidframework/synthesize": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/azure-client": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-2.1.0.tgz",
-            "integrity": "sha512-TibsZlDmIRxfIVj4NDFfk055acMKSi1abY4ToEqnDRDg1Do11eTgiZAhdXtejJDGN5mGnXO8DplvoDEsMVZYEw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/azure-client/-/azure-client-2.2.0.tgz",
+            "integrity": "sha512-ZhHudAbnkFKhw3QYUNCIlO1WFwKttCxshHuOk1ggqJLEE9BPcVLxQCn+HsofQ1oQDnLnyxRH095DFTN3BpWD9w==",
             "dependencies": {
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/container-loader": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/driver-utils": "~2.1.0",
-                "@fluidframework/fluid-static": "~2.1.0",
-                "@fluidframework/map": "~2.1.0",
-                "@fluidframework/routerlicious-driver": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0"
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/container-loader": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/driver-utils": "~2.2.0",
+                "@fluidframework/fluid-static": "~2.2.0",
+                "@fluidframework/map": "~2.2.0",
+                "@fluidframework/routerlicious-driver": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/cell": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.1.0.tgz",
-            "integrity": "sha512-k5kpQiBL8G/nPqVmSTHtorISfvVOlhqFmZvSks2fD8X2z6JsPKbvgEtCg7QTYMOC25YMDbpTs/YoTiFWUc3BoA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/cell/-/cell-2.2.0.tgz",
+            "integrity": "sha512-RjNiFyL+enKNPxOZhGFBXsVeWYoYNKid2wAR8GrYFipCmgkDE9q3TyU3D0DeRLMaklQOaLjQ8JOw1MD/lLqaFg==",
             "dependencies": {
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/driver-utils": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/shared-object-base": "~2.1.0"
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/driver-utils": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/shared-object-base": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/common-definitions": {
@@ -2613,26 +2243,26 @@
             }
         },
         "node_modules/@fluidframework/container-definitions": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.1.0.tgz",
-            "integrity": "sha512-gTYYb+X9Mfvp5x9GepvoI7xyupjVVqvE8hUQoo3Rg3XelxjnO4vJSj1/rKLZBVDhEy0HgJ75X2N4scP7RZ1YlQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-2.2.0.tgz",
+            "integrity": "sha512-UXqE6wRNgscd6QNGVbgYuPfGlnS6dbSDVEsBUQKc6g29nwcBDe2ynM1RuRl+xCwhYnJx5OiaXDIgDHtpyD2GcQ==",
             "dependencies": {
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0"
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/container-loader": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.1.0.tgz",
-            "integrity": "sha512-Dto6vL4HtanVgHbiNzbl0tx0vT5PqKtLSSGkU9NHn4qe6Yz+RNqvSt2TIyFTd3ZX2d93PAeR+uyZKve7RgSHZw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-2.2.0.tgz",
+            "integrity": "sha512-Kgp3THALf6FCyGOm0p0MaEHKOxJZ8bh+A7HXqAJz7Onhos8QSXPBZ1GyXFGqyv0haQ7gqLYB7GXk50KKx87W0Q==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/driver-utils": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/driver-utils": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "@types/events_pkg": "npm:@types/events@^3.0.0",
                 "@ungap/structured-clone": "^1.2.0",
                 "debug": "^4.3.4",
@@ -2642,22 +2272,22 @@
             }
         },
         "node_modules/@fluidframework/container-runtime": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.1.0.tgz",
-            "integrity": "sha512-e1ReWc7Dk2/QjwenpTZAQSswKnSh2kIxcO7fTgvZZu11DGOj4JeeRi8PV/aIeTuvZ4JVnfDvJr9EGAVkjdWuHw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-2.2.0.tgz",
+            "integrity": "sha512-7jSSxaSLFVVAlXvG6vIJ2bbTEZm71F8pHpNislFhBS9UT90XlUncTDvumTvq3MBEcbT2Pod/jmeQUz8CUVLp7g==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/container-runtime-definitions": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/driver-utils": "~2.1.0",
-                "@fluidframework/id-compressor": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/container-runtime-definitions": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/driver-utils": "~2.2.0",
+                "@fluidframework/id-compressor": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "@tylerbu/sorted-btree-es6": "^1.8.0",
                 "double-ended-queue": "^2.1.0-0",
                 "lz4js": "^0.2.0",
@@ -2665,126 +2295,425 @@
             }
         },
         "node_modules/@fluidframework/container-runtime-definitions": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.1.0.tgz",
-            "integrity": "sha512-pjvIPjXBcOLFRmGabXNF6MNCFOjT8dtIWfaqiCdGUNlcfRiqFLe0oE7owXydfvNl6eYMqe8bTmUow6PSY3mT8g==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-2.2.0.tgz",
+            "integrity": "sha512-ImOT6hr1PWBV2ADlHXFEB1f2MsiguOoIs2py02y3K8hv+EZnw6yUO2K2OOMd/abK2r43PCSRNRnM1Z3C/VyMxg==",
             "dependencies": {
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0"
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/core-interfaces": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.1.0.tgz",
-            "integrity": "sha512-lGCFrz/XIGmZDbD7I/qqJ9jV/FmK9gFZwRA/zORQkruqfkt9JpmJ6FrI4FctU7kEKsFhy4I5rj6d7I04gvNYSQ=="
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-2.2.0.tgz",
+            "integrity": "sha512-Ja9NrOJvTW9vxkXEapqBQfSjIDiowOrBE+++y34CsnCQlXIj8fxKqsf/WcrILhnXoxD4kSXqkz/tQhR30iUyjw=="
         },
         "node_modules/@fluidframework/core-utils": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.1.0.tgz",
-            "integrity": "sha512-DkPjeuqb3LHIIb9rz7NfZ5U0s3jJPfiiTg1Dho3lZoy+ZC4ppynr/lEcrg9lnPl0pDuo/yRuYzIiFMM6rotNKQ=="
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/core-utils/-/core-utils-2.2.0.tgz",
+            "integrity": "sha512-UT+WRm8TPebpZ8pjn0V4U+9Y5in01NIPNc5MtHJYpmPkLLa9+hVnyMOX8VbnZ9zShdhyzn9uYGc3ti4a2tzDMg=="
         },
         "node_modules/@fluidframework/counter": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.1.0.tgz",
-            "integrity": "sha512-51r7sM6iwJBn8daxluTKc0AcvCBg9zJAJQce6QBjJInveozz/JCNBuLgPqJwM6c0H2Yu92CTuHXrJSzszYFmUQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/counter/-/counter-2.2.0.tgz",
+            "integrity": "sha512-N4hlOQXJLgTRu5h3IO2i7Rn4iuLmu0Yau/IjNZ+OuzNxTg1byqxPxfrqyircW1uck4isTp5nVT7gu7KCCKrUgA==",
             "dependencies": {
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/driver-utils": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/shared-object-base": "~2.1.0"
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/driver-utils": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/shared-object-base": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/datastore": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.1.0.tgz",
-            "integrity": "sha512-TPPLBzm9fYmqp+FdKav1bMypEOtInm/XbNtOUy8SkV1Bl8I6OEoaT9nDiylebglNYC4XUXoIaUSskPOVViPDWA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-2.2.0.tgz",
+            "integrity": "sha512-qeDVNUn+SM0geeJbuECYx5rkHPFUk0XU9ZolLK3pmYGzUTJ5vEhNAXeXkGC3CVR/h9BTAKW4DtCorpz8BqVvTw==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/driver-utils": "~2.1.0",
-                "@fluidframework/id-compressor": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/driver-utils": "~2.2.0",
+                "@fluidframework/id-compressor": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "uuid": "^9.0.0"
             }
         },
         "node_modules/@fluidframework/datastore-definitions": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.1.0.tgz",
-            "integrity": "sha512-T/06Uj2+iJ63Pr5yRdGMbjPYs5Z8gNVl0QOlPkRfbYQHASzh6MTCWes2czkFAWNQSzbhLp3+nPJMCfLoeOBp3Q==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-2.2.0.tgz",
+            "integrity": "sha512-MuUUkiM+gMiBFpV+Uvd4snqu/rGds5o/dpqN46utnuxbcMomUDtgb1m8B1M/OadHHXOBs9mbAjWRkbjlf3tfFg==",
             "dependencies": {
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/id-compressor": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0"
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/id-compressor": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/driver-base": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.1.0.tgz",
-            "integrity": "sha512-0dLfLwj7MaeQbiQNpaa0mnpTmgIotOiO0C3NKBmOuUJHG153wkUmON1bG/u2kV/bTx8USIuzHakFSMoUNnbRzw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-2.2.0.tgz",
+            "integrity": "sha512-kk1uhOK613Yzp76D8HriLD4xumZ1MY3Tj4wMMwiv+b/URhw7x5mTWG55t1AUC+JTNqttNNmc8PmGB46Fxf0fiA==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/driver-utils": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0"
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/driver-utils": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/driver-definitions": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.1.0.tgz",
-            "integrity": "sha512-ZeZfyuaIRknjBtLHcolXIgHHhsd44+Pfz59zCmGAoFIaq75wfeT0M2ci3lVeA8O1nkXu0C4gzJXFtXRgHrd61g==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-2.2.0.tgz",
+            "integrity": "sha512-r0jRut/MqNPii5CLZ6ShtGfGy1RpQ8163KzTOw1Af2wLCoEOKnZaSvDb23/UDMUEaM0Pv663d1K0jmOgltKf2g==",
             "dependencies": {
-                "@fluidframework/core-interfaces": "~2.1.0"
+                "@fluidframework/core-interfaces": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/driver-utils": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.1.0.tgz",
-            "integrity": "sha512-WyqpBf4OlcCthTwPt18gIg05kbebjIIJvWwzWutJ71Z8Y/Xo7oQgIwThFV5dTLuqInOBP5I5MlosF4jd1jg6Qw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-2.2.0.tgz",
+            "integrity": "sha512-xf/3ytaRNRlSVgmAusFVECntF9q02Z+H8qrRk6mlr7mzt+VaR8oDavRoOrn0pzqer9v40qzk3N3tBD9F8qM90A==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "axios": "^1.6.2",
                 "lz4js": "^0.2.0",
                 "uuid": "^9.0.0"
             }
         },
-        "node_modules/@fluidframework/fluid-static": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.1.0.tgz",
-            "integrity": "sha512-Lq+W9a4C+nFoYSMHEWcb3gO64Kee+1aMv8GSnPqA8G3xsiVIZog5rHclsQmeDviKPAEIZgDsV4g8cWrN3S565A==",
+        "node_modules/@fluidframework/eslint-config-fluid": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/eslint-config-fluid/-/eslint-config-fluid-5.4.0.tgz",
+            "integrity": "sha512-V9lKsH1oFq3pX8UjSv8AyZ9BswPEcozGi3Ic/KuMdsYHj8Ibm3EgTtYSyNgVOAFivDW474qvXc5PDhKD8T/mfw==",
+            "dev": true,
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/aqueduct": "~2.1.0",
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/container-loader": "~2.1.0",
-                "@fluidframework/container-runtime": "~2.1.0",
-                "@fluidframework/container-runtime-definitions": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/request-handler": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0",
-                "@fluidframework/shared-object-base": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0"
+                "@fluid-internal/eslint-plugin-fluid": "^0.1.2",
+                "@microsoft/tsdoc": "^0.14.2",
+                "@rushstack/eslint-patch": "~1.4.0",
+                "@rushstack/eslint-plugin": "~0.13.0",
+                "@rushstack/eslint-plugin-security": "~0.7.0",
+                "@typescript-eslint/eslint-plugin": "~6.7.2",
+                "@typescript-eslint/parser": "~6.7.2",
+                "eslint-config-prettier": "~9.0.0",
+                "eslint-import-resolver-typescript": "~3.6.1",
+                "eslint-plugin-eslint-comments": "~3.2.0",
+                "eslint-plugin-import": "npm:eslint-plugin-i@~2.29.0",
+                "eslint-plugin-jsdoc": "~46.8.1",
+                "eslint-plugin-promise": "~6.1.1",
+                "eslint-plugin-react": "~7.33.2",
+                "eslint-plugin-react-hooks": "~4.6.0",
+                "eslint-plugin-tsdoc": "~0.2.17",
+                "eslint-plugin-unicorn": "~48.0.1",
+                "eslint-plugin-unused-imports": "~3.0.0"
+            }
+        },
+        "node_modules/@fluidframework/eslint-config-fluid/node_modules/@typescript-eslint/eslint-plugin": {
+            "version": "6.7.5",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.7.5.tgz",
+            "integrity": "sha512-JhtAwTRhOUcP96D0Y6KYnwig/MRQbOoLGXTON2+LlyB/N35SP9j1boai2zzwXb7ypKELXMx3DVk9UTaEq1vHEw==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/regexpp": "^4.5.1",
+                "@typescript-eslint/scope-manager": "6.7.5",
+                "@typescript-eslint/type-utils": "6.7.5",
+                "@typescript-eslint/utils": "6.7.5",
+                "@typescript-eslint/visitor-keys": "6.7.5",
+                "debug": "^4.3.4",
+                "graphemer": "^1.4.0",
+                "ignore": "^5.2.4",
+                "natural-compare": "^1.4.0",
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+                "eslint": "^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@fluidframework/eslint-config-fluid/node_modules/@typescript-eslint/parser": {
+            "version": "6.7.5",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.7.5.tgz",
+            "integrity": "sha512-bIZVSGx2UME/lmhLcjdVc7ePBwn7CLqKarUBL4me1C5feOd663liTGjMBGVcGr+BhnSLeP4SgwdvNnnkbIdkCw==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "6.7.5",
+                "@typescript-eslint/types": "6.7.5",
+                "@typescript-eslint/typescript-estree": "6.7.5",
+                "@typescript-eslint/visitor-keys": "6.7.5",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@fluidframework/eslint-config-fluid/node_modules/@typescript-eslint/scope-manager": {
+            "version": "6.7.5",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.7.5.tgz",
+            "integrity": "sha512-GAlk3eQIwWOJeb9F7MKQ6Jbah/vx1zETSDw8likab/eFcqkjSD7BI75SDAeC5N2L0MmConMoPvTsmkrg71+B1A==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.7.5",
+                "@typescript-eslint/visitor-keys": "6.7.5"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@fluidframework/eslint-config-fluid/node_modules/@typescript-eslint/type-utils": {
+            "version": "6.7.5",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.7.5.tgz",
+            "integrity": "sha512-Gs0qos5wqxnQrvpYv+pf3XfcRXW6jiAn9zE/K+DlmYf6FcpxeNYN0AIETaPR7rHO4K2UY+D0CIbDP9Ut0U4m1g==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/typescript-estree": "6.7.5",
+                "@typescript-eslint/utils": "6.7.5",
+                "debug": "^4.3.4",
+                "ts-api-utils": "^1.0.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@fluidframework/eslint-config-fluid/node_modules/@typescript-eslint/types": {
+            "version": "6.7.5",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.7.5.tgz",
+            "integrity": "sha512-WboQBlOXtdj1tDFPyIthpKrUb+kZf2VroLZhxKa/VlwLlLyqv/PwUNgL30BlTVZV1Wu4Asu2mMYPqarSO4L5ZQ==",
+            "dev": true,
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@fluidframework/eslint-config-fluid/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "6.7.5",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.7.5.tgz",
+            "integrity": "sha512-NhJiJ4KdtwBIxrKl0BqG1Ur+uw7FiOnOThcYx9DpOGJ/Abc9z2xNzLeirCG02Ig3vkvrc2qFLmYSSsaITbKjlg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.7.5",
+                "@typescript-eslint/visitor-keys": "6.7.5",
+                "debug": "^4.3.4",
+                "globby": "^11.1.0",
+                "is-glob": "^4.0.3",
+                "semver": "^7.5.4",
+                "ts-api-utils": "^1.0.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@fluidframework/eslint-config-fluid/node_modules/@typescript-eslint/utils": {
+            "version": "6.7.5",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.7.5.tgz",
+            "integrity": "sha512-pfRRrH20thJbzPPlPc4j0UNGvH1PjPlhlCMq4Yx7EGjV7lvEeGX0U6MJYe8+SyFutWgSHsdbJ3BXzZccYggezA==",
+            "dev": true,
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@types/json-schema": "^7.0.12",
+                "@types/semver": "^7.5.0",
+                "@typescript-eslint/scope-manager": "6.7.5",
+                "@typescript-eslint/types": "6.7.5",
+                "@typescript-eslint/typescript-estree": "6.7.5",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^7.0.0 || ^8.0.0"
+            }
+        },
+        "node_modules/@fluidframework/eslint-config-fluid/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "6.7.5",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.7.5.tgz",
+            "integrity": "sha512-3MaWdDZtLlsexZzDSdQWsFQ9l9nL8B80Z4fImSpyllFC/KLqWQRdEcB+gGGO+N3Q2uL40EsG66wZLsohPxNXvg==",
+            "dev": true,
+            "dependencies": {
+                "@typescript-eslint/types": "6.7.5",
+                "eslint-visitor-keys": "^3.4.1"
+            },
+            "engines": {
+                "node": "^16.0.0 || >=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@fluidframework/eslint-config-fluid/node_modules/doctrine": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+            "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+            "dev": true,
+            "dependencies": {
+                "esutils": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@fluidframework/eslint-config-fluid/node_modules/eslint-config-prettier": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+            "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
+            "dev": true,
+            "bin": {
+                "eslint-config-prettier": "bin/cli.js"
+            },
+            "peerDependencies": {
+                "eslint": ">=7.0.0"
+            }
+        },
+        "node_modules/@fluidframework/eslint-config-fluid/node_modules/eslint-plugin-react": {
+            "version": "7.33.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz",
+            "integrity": "sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==",
+            "dev": true,
+            "dependencies": {
+                "array-includes": "^3.1.6",
+                "array.prototype.flatmap": "^1.3.1",
+                "array.prototype.tosorted": "^1.1.1",
+                "doctrine": "^2.1.0",
+                "es-iterator-helpers": "^1.0.12",
+                "estraverse": "^5.3.0",
+                "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+                "minimatch": "^3.1.2",
+                "object.entries": "^1.1.6",
+                "object.fromentries": "^2.0.6",
+                "object.hasown": "^1.1.2",
+                "object.values": "^1.1.6",
+                "prop-types": "^15.8.1",
+                "resolve": "^2.0.0-next.4",
+                "semver": "^6.3.1",
+                "string.prototype.matchall": "^4.0.8"
+            },
+            "engines": {
+                "node": ">=4"
+            },
+            "peerDependencies": {
+                "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+            }
+        },
+        "node_modules/@fluidframework/eslint-config-fluid/node_modules/eslint-plugin-react/node_modules/semver": {
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/@fluidframework/eslint-config-fluid/node_modules/eslint-plugin-unused-imports": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.0.0.tgz",
+            "integrity": "sha512-sduiswLJfZHeeBJ+MQaG+xYzSWdRXoSw61DpU13mzWumCkR0ufD0HmO4kdNokjrkluMHpj/7PJeN35pgbhW3kw==",
+            "dev": true,
+            "dependencies": {
+                "eslint-rule-composer": "^0.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/eslint-plugin": "^6.0.0",
+                "eslint": "^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@typescript-eslint/eslint-plugin": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@fluidframework/fluid-static": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/fluid-static/-/fluid-static-2.2.0.tgz",
+            "integrity": "sha512-BvQzYV/ZG2s0K0LDFwY+4WRVxZ/fmbRfvS0+ZD3L7AgOq9j1t/aMssdjBJne3YiO5ct79JQTecv9VeWUCv7QBg==",
+            "dependencies": {
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/aqueduct": "~2.2.0",
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/container-loader": "~2.2.0",
+                "@fluidframework/container-runtime": "~2.2.0",
+                "@fluidframework/container-runtime-definitions": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/request-handler": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/shared-object-base": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/gitresources": {
@@ -2793,75 +2722,75 @@
             "integrity": "sha512-nfam1KT+EUqFCENHcxrU9VwUfbhUC83UcLuOsdLpn9I7VuClL+w8KMWosoYauZraO9gDhTo2kCErjgQji5GzGA=="
         },
         "node_modules/@fluidframework/id-compressor": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/id-compressor/-/id-compressor-2.1.0.tgz",
-            "integrity": "sha512-hB2VmU1+rfmpUo1ShN5vOrMk/I+KJR4wWiR12szYhuqjlcB5hggVtuTBwAswWq5VacTD9/8U7pWwaqTto6Eurw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/id-compressor/-/id-compressor-2.2.0.tgz",
+            "integrity": "sha512-T6Y6OPTqKumlsNihlGWaPoMCfdAxRC/I2soGZIvYSCOYiULfGPNo+F/ZEVRUeG0zD80ZA47U1ee/fTpNWIBFjQ==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "@tylerbu/sorted-btree-es6": "^1.8.0",
                 "uuid": "^9.0.0"
             }
         },
         "node_modules/@fluidframework/local-driver": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.1.0.tgz",
-            "integrity": "sha512-NTUUs/3ZNZb0fHWdgUzY0mxncs5LSUh7RQklS2V5hYKHeGxxFfNmXn9zmkG0d7eYQOZ8Fj70JGSc4QZx8gV2Fw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-2.2.0.tgz",
+            "integrity": "sha512-Ukdc49lWNzEn3mGYj/NIloqK96MoL44p9QL97neHd3NfqL6nHP1iV+mAdsfSLyZmLVDGWlxZN/S4bfQgdB93og==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/driver-base": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/driver-utils": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/driver-base": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/driver-utils": "~2.2.0",
                 "@fluidframework/protocol-base": "^5.0.0",
-                "@fluidframework/routerlicious-driver": "~2.1.0",
+                "@fluidframework/routerlicious-driver": "~2.2.0",
                 "@fluidframework/server-local-server": "^5.0.0",
                 "@fluidframework/server-services-client": "^5.0.0",
                 "@fluidframework/server-services-core": "^5.0.0",
                 "@fluidframework/server-test-utils": "^5.0.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "jsrsasign": "^11.0.0",
                 "uuid": "^9.0.0"
             }
         },
         "node_modules/@fluidframework/map": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.1.0.tgz",
-            "integrity": "sha512-EPCtiDPwy0AfJfQnTP4/NjHh3aKiYH0+gAdYLxnyZPhk5Spcewggy68k9V7gDw4ZjiNIuDHrsKC2Mam6mpUlaw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-2.2.0.tgz",
+            "integrity": "sha512-WhNI3qb5aY4f33Vy4lpooUlzdMpUY2L0dLHIbfLyfZVqX4ZyS8tWBaRIc6gekwyCCC6dn+CikOct8yZ+zuJ78A==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/driver-utils": "~2.1.0",
-                "@fluidframework/merge-tree": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0",
-                "@fluidframework/shared-object-base": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/driver-utils": "~2.2.0",
+                "@fluidframework/merge-tree": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/shared-object-base": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "path-browserify": "^1.0.1"
             }
         },
         "node_modules/@fluidframework/matrix": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.1.0.tgz",
-            "integrity": "sha512-OfHkbxfehxyDlgCwqXqzRLphUfeNlqEPE8+UN/jKC3ugYWGZs5nxJ5T6lb/RilnQoOVBjeZJYLjEl19wxIZwOA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/matrix/-/matrix-2.2.0.tgz",
+            "integrity": "sha512-ujyIzsm2QfmyaLJ1vz0IbYVnO+JOXq0HtWQB4ErFnoijLimj/ubpJFTyCfKvqmGlvVDcDyzgbVnytXy7Ytwefg==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/driver-utils": "~2.1.0",
-                "@fluidframework/merge-tree": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0",
-                "@fluidframework/shared-object-base": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/driver-utils": "~2.2.0",
+                "@fluidframework/merge-tree": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/shared-object-base": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "@tiny-calc/nano": "0.0.0-alpha.5",
                 "double-ended-queue": "^2.1.0-0",
                 "tslib": "^1.10.0"
@@ -2872,20 +2801,20 @@
             "license": "0BSD"
         },
         "node_modules/@fluidframework/merge-tree": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.1.0.tgz",
-            "integrity": "sha512-XdIICdpruO/rknYPeK1MaOJNER6gUMxTdbXjm7s41AwHuvqKoaBORU7WA+IUr4Pz1BLY8SA1SyA+pertnlx7CA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-2.2.0.tgz",
+            "integrity": "sha512-cWilAM4sCnVicnOCpk1P8zj3CVDfocv2Exkx4AbNZqmOpvwdL4jMXpqO/KSAzMoH/Gv9eUu8OgcNQIXRyBchIQ==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0",
-                "@fluidframework/shared-object-base": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0"
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/shared-object-base": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/mocha-test-setup": {
@@ -2905,19 +2834,19 @@
             "license": "MIT"
         },
         "node_modules/@fluidframework/ordered-collection": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.1.0.tgz",
-            "integrity": "sha512-OfAvu/t/U2qcXM2t6QUEvpE5+XqOLBP2btj4ISVG89JbhkrEvv0BpYsO9zOneJ9n6KJA7ScPV+F8/+A4li9CpQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/ordered-collection/-/ordered-collection-2.2.0.tgz",
+            "integrity": "sha512-nQoim/dSHY/ue/SDyfllk7GLPKNfxLBg3wFG5TI5EnT5d027UoXcPCSai5aY+loPhWmSlMjSEnVioH9/u/lhxA==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0",
-                "@fluidframework/shared-object-base": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/shared-object-base": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "uuid": "^9.0.0"
             }
         },
@@ -2937,45 +2866,45 @@
             "license": "MIT"
         },
         "node_modules/@fluidframework/register-collection": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.1.0.tgz",
-            "integrity": "sha512-p17zjQ2cbj5M41vQw5xi4BPns1jkGFk7bC7OKg5Djmb3RXLw4ev12UPR0l3Wrpd8esFKQBIZi+d6wjNZCTXhgg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-2.2.0.tgz",
+            "integrity": "sha512-XTpSqPK46m4Y667UHQsQBAsGhOwx5Zq0Xe2l3uR8ufn4FHq+TEgPk89iW261vJWLsLHpbyzao6tCw+cSLnux6g==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/driver-utils": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/shared-object-base": "~2.1.0"
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/driver-utils": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/shared-object-base": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/request-handler": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.1.0.tgz",
-            "integrity": "sha512-KIBv+bglRDWad6jyq3qzBQ3Gs7JI+UnTfhnF+gE21ve4Fi2brhPO2p/syPmNPhPIk9tNO5bgLhcmfiUu4xILCg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-2.2.0.tgz",
+            "integrity": "sha512-urldbVteWlLUHFNsqQk2qQQD53FtCgLqgX6m7KIhMfoSAY/2U45QPPT2gvyS04T1rE+3IK4i6OORd8tBm1BRzQ==",
             "dependencies": {
-                "@fluidframework/container-runtime-definitions": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0"
+                "@fluidframework/container-runtime-definitions": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/routerlicious-driver": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.1.0.tgz",
-            "integrity": "sha512-rvoQOZl3xs0eYuW7VGuGCnQwfIj4ypJ0FpNRbIWT0mhJ+K1bmf1wzczYNUhb0XpgvoLklngqRdFM/mRwVZaX8Q==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-2.2.0.tgz",
+            "integrity": "sha512-HMLby/MpWsehTf7tbKNx+qrDP1B1v1OchiNCMojXpj/eqFFdByMdKbv/xHfiwDtg/JdibD9W4UG/aRUnluFvYw==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/driver-base": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/driver-utils": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/driver-base": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/driver-utils": "~2.2.0",
                 "@fluidframework/server-services-client": "^5.0.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "cross-fetch": "^3.1.5",
                 "json-stringify-safe": "5.0.1",
                 "socket.io-client": "^4.7.3",
@@ -2983,49 +2912,49 @@
             }
         },
         "node_modules/@fluidframework/runtime-definitions": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.1.0.tgz",
-            "integrity": "sha512-AEJO+C/cEEkB7HmTPK4dqq+N4dqF3QmdEKaz0l8E21iBq8/y8fdgL+anuKLcjR5QvT2iyVdnMK3PDmxEZtVpGA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-2.2.0.tgz",
+            "integrity": "sha512-NH89DRen66GmRmhjWiuf0t71yEAtvj6Y54XWViMeHeU5uMP1EyozWECzZfNWeUrrXr68/pRQFas+Og42gY9Wpg==",
             "dependencies": {
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/id-compressor": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0"
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/id-compressor": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/runtime-utils": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.1.0.tgz",
-            "integrity": "sha512-9hF/GeRaTZJCMf64iMlekAeN/ziJ1ov+buTSj0ATUqNxGPfM4wnv/8+Gp076R6+hqKzVktVy3yuTzeGsjjM5BQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-2.2.0.tgz",
+            "integrity": "sha512-7A8DHKKZV8phBq9onTnnIgiPWTZgSk5gknOPx6lzTRzq/zAbWjaKoAtQowcN1ygteY9ixtNR0nALdrsUt40Otg==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/container-runtime-definitions": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/driver-utils": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0"
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/container-runtime-definitions": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/driver-utils": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/sequence": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.1.0.tgz",
-            "integrity": "sha512-2JmIhGPKqNDCyQ/XLL/ZEkLSpQAD9vhi+Qrl392x8QX+K7dUpM/U6x6rWRRQ5vqV3YLvnJi0AfaLQ+XXMbkg9Q==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-2.2.0.tgz",
+            "integrity": "sha512-kO4O9nDjYAty5LLKZOS3vmEuPber3alrPJWAgR0o2h1SZnhE9u+rSdytOEgD6DxzwHjDwi/hKgE5M/apaFQwxg==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/merge-tree": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0",
-                "@fluidframework/shared-object-base": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/merge-tree": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/shared-object-base": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "double-ended-queue": "^2.1.0-0",
                 "uuid": "^9.0.0"
             }
@@ -3229,41 +3158,41 @@
             }
         },
         "node_modules/@fluidframework/shared-object-base": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.1.0.tgz",
-            "integrity": "sha512-a35lLQDNI+GSqAg6ctUYZ5FzBmG30Kzzpf4BJgPgVmoRTibltg6ALNABnTS8SGwmLIA1G3CiD1FHqknBIEtP4g==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-2.2.0.tgz",
+            "integrity": "sha512-hyyY+Hpi3lYXDasJUK38nDWMaE3kDiym7JnxzUsSoUEQbOH+t9ubxP8TOfZLNTxIG8rQUoAko9qVJHompGgRog==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/container-runtime": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/container-runtime": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "uuid": "^9.0.0"
             }
         },
         "node_modules/@fluidframework/synthesize": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.1.0.tgz",
-            "integrity": "sha512-AHfwjjOHf4nEF+nTJY476JKUCdsDxvH7h7il1FYZXfzAX1Xni8gTSjhz90Mq5vP0A+VGVszkhqaraS+ungYxxA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-2.2.0.tgz",
+            "integrity": "sha512-gcI/Sqbe24/ktC44tjrQ62Dwe2yNKLfkAzJKJURFpEPPeBR0i4DPM2z3LKYjpZtxqgwfIEDqAT7z88byxjpUig==",
             "dependencies": {
-                "@fluidframework/core-utils": "~2.1.0"
+                "@fluidframework/core-utils": "~2.2.0"
             }
         },
         "node_modules/@fluidframework/telemetry-utils": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.1.0.tgz",
-            "integrity": "sha512-lmurwDfWnOd84+3JMSrQ9MxvsVzDOOEM8NEiPEpna6Kh9MzZJZSj9tdJ40asRwop5ufuBiMPHncj0QYrmAY7YQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-2.2.0.tgz",
+            "integrity": "sha512-KRDDgYCqiabZ7KFo/vcgzVf09rWU6ExQza50zfBjB+GrDL/lL7/tyrY/3P4sY4Nw+iC/QcLblNX3ugDF2NtwLw==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
                 "debug": "^4.3.4",
                 "uuid": "^9.0.0"
             }
@@ -3294,51 +3223,51 @@
             }
         },
         "node_modules/@fluidframework/test-runtime-utils": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.1.0.tgz",
-            "integrity": "sha512-Xx6PLZYeXZG4EiVr5HRuJjUqMDenG63k8VXeXyEeoa2qIMCdN+UioQMc05EaC/9FBaBkuvGUVsAaZN5OjrJWEQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-2.2.0.tgz",
+            "integrity": "sha512-Y/5CvcnAKjHQcuJH2Lvaxe0E5RNIiFnd0zTGDDqbze8xZyu7IblQACYpXrtYUISkG8WovSa/81Y3DTbdclkA9Q==",
             "dev": true,
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/container-runtime-definitions": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/id-compressor": "~2.1.0",
-                "@fluidframework/routerlicious-driver": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/container-runtime-definitions": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/id-compressor": "~2.2.0",
+                "@fluidframework/routerlicious-driver": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "jsrsasign": "^11.0.0",
                 "uuid": "^9.0.0"
             }
         },
         "node_modules/@fluidframework/test-utils": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.1.0.tgz",
-            "integrity": "sha512-ktuKEc+rJY2kV/W8DqodhRm9jsw17VpaI4lH7bQOkLmWls+I9Kv5QWDRnsP0U+tsAbJue+NDxcjyg/usYNWPzw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/test-utils/-/test-utils-2.2.0.tgz",
+            "integrity": "sha512-D7glt6sSAouG18l5p3uMog4vaZbqwENM6c/Au1G7+Wb7GbxngxuJIQr3eAcJys3l2V7zG1NumM2UiIs/ZKP0HA==",
             "dependencies": {
-                "@fluid-internal/test-driver-definitions": "~2.1.0",
-                "@fluidframework/aqueduct": "~2.1.0",
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/container-loader": "~2.1.0",
-                "@fluidframework/container-runtime": "~2.1.0",
-                "@fluidframework/container-runtime-definitions": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/driver-utils": "~2.1.0",
-                "@fluidframework/local-driver": "~2.1.0",
-                "@fluidframework/map": "~2.1.0",
-                "@fluidframework/request-handler": "~2.1.0",
-                "@fluidframework/routerlicious-driver": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluid-internal/test-driver-definitions": "~2.2.0",
+                "@fluidframework/aqueduct": "~2.2.0",
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/container-loader": "~2.2.0",
+                "@fluidframework/container-runtime": "~2.2.0",
+                "@fluidframework/container-runtime-definitions": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/driver-utils": "~2.2.0",
+                "@fluidframework/local-driver": "~2.2.0",
+                "@fluidframework/map": "~2.2.0",
+                "@fluidframework/request-handler": "~2.2.0",
+                "@fluidframework/routerlicious-driver": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "best-random": "^1.0.0",
                 "debug": "^4.3.4",
                 "mocha": "^10.2.0",
@@ -3346,21 +3275,21 @@
             }
         },
         "node_modules/@fluidframework/tree": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@fluidframework/tree/-/tree-2.1.0.tgz",
-            "integrity": "sha512-okbidEWgFfuxMvPlAP5KkxhU5ixNEDX4BYfUbnnoChS0LQkDBWixHMi77dp08Y4vRneSjyQ6cbmmD2Qa4Fm/Vg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@fluidframework/tree/-/tree-2.2.0.tgz",
+            "integrity": "sha512-QDe9nxhP7ylYyL12prOkgEoFR4ipcAHaHyLBkPtv/P+YhfXqb1RsxR/9vrA8BlkEYzbXK88QWaODw2Ow5lsp+Q==",
             "dependencies": {
-                "@fluid-internal/client-utils": "~2.1.0",
-                "@fluidframework/container-runtime": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/core-utils": "~2.1.0",
-                "@fluidframework/datastore-definitions": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/id-compressor": "~2.1.0",
-                "@fluidframework/runtime-definitions": "~2.1.0",
-                "@fluidframework/runtime-utils": "~2.1.0",
-                "@fluidframework/shared-object-base": "~2.1.0",
-                "@fluidframework/telemetry-utils": "~2.1.0",
+                "@fluid-internal/client-utils": "~2.2.0",
+                "@fluidframework/container-runtime": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/core-utils": "~2.2.0",
+                "@fluidframework/datastore-definitions": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/id-compressor": "~2.2.0",
+                "@fluidframework/runtime-definitions": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/shared-object-base": "~2.2.0",
+                "@fluidframework/telemetry-utils": "~2.2.0",
                 "@sinclair/typebox": "^0.32.29",
                 "@tylerbu/sorted-btree-es6": "^1.8.0",
                 "@ungap/structured-clone": "^1.2.0",
@@ -3705,13 +3634,14 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.3",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
@@ -3726,9 +3656,10 @@
             }
         },
         "node_modules/@jridgewell/set-array": {
-            "version": "1.1.2",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
             }
@@ -3749,9 +3680,10 @@
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.22",
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -3974,8 +3906,9 @@
             }
         },
         "node_modules/@remix-run/router": {
-            "version": "1.15.0",
-            "license": "MIT",
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.1.tgz",
+            "integrity": "sha512-S45oynt/WH19bHbIXjtli6QmwNYvaz+vtnubvNpNDvUOoA/OWh6j1OikIP3G+v5GHdxyC6EXoChG3HgYGEUfcg==",
             "engines": {
                 "node": ">=14.0.0"
             }
@@ -4168,42 +4101,46 @@
             "license": "MIT"
         },
         "node_modules/@ts-morph/common": {
-            "version": "0.21.0",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.23.0.tgz",
+            "integrity": "sha512-m7Lllj9n/S6sOkCkRftpM7L24uvmfXQFedlW/4hENcuJH1HHm9u5EgxZb9uVjQSCGrbBWBkOGgcTxNg36r6ywA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "fast-glob": "^3.2.12",
-                "minimatch": "^7.4.3",
-                "mkdirp": "^2.1.6",
+                "fast-glob": "^3.3.2",
+                "minimatch": "^9.0.3",
+                "mkdirp": "^3.0.1",
                 "path-browserify": "^1.0.1"
             }
         },
         "node_modules/@ts-morph/common/node_modules/brace-expansion": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
         },
         "node_modules/@ts-morph/common/node_modules/minimatch": {
-            "version": "7.4.6",
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@ts-morph/common/node_modules/mkdirp": {
-            "version": "2.1.6",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+            "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "mkdirp": "dist/cjs/src/bin.js"
             },
@@ -4252,20 +4189,11 @@
             "version": "8.56.2",
             "dev": true,
             "license": "MIT",
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "@types/estree": "*",
                 "@types/json-schema": "*"
-            }
-        },
-        "node_modules/@types/eslint-scope": {
-            "version": "3.7.7",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@types/eslint": "*",
-                "@types/estree": "*"
             }
         },
         "node_modules/@types/estree": {
@@ -4804,9 +4732,10 @@
             }
         },
         "node_modules/@webassemblyjs/ast": {
-            "version": "1.11.6",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
+            "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@webassemblyjs/helper-numbers": "1.11.6",
@@ -4815,26 +4744,30 @@
         },
         "node_modules/@webassemblyjs/floating-point-hex-parser": {
             "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
+            "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
+            "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/@webassemblyjs/helper-buffer": {
-            "version": "1.11.6",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
+            "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
+            "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@webassemblyjs/floating-point-hex-parser": "1.11.6",
@@ -4844,26 +4777,29 @@
         },
         "node_modules/@webassemblyjs/helper-wasm-bytecode": {
             "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
+            "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
-            "version": "1.11.6",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
+            "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.6",
-                "@webassemblyjs/helper-buffer": "1.11.6",
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-buffer": "1.12.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-                "@webassemblyjs/wasm-gen": "1.11.6"
+                "@webassemblyjs/wasm-gen": "1.12.1"
             }
         },
         "node_modules/@webassemblyjs/ieee754": {
             "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
+            "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
@@ -4871,8 +4807,9 @@
         },
         "node_modules/@webassemblyjs/leb128": {
             "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
+            "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
             "dev": true,
-            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
@@ -4880,33 +4817,36 @@
         },
         "node_modules/@webassemblyjs/utf8": {
             "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
+            "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
             "dev": true,
-            "license": "MIT",
             "peer": true
         },
         "node_modules/@webassemblyjs/wasm-edit": {
-            "version": "1.11.6",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
+            "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.6",
-                "@webassemblyjs/helper-buffer": "1.11.6",
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-buffer": "1.12.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-                "@webassemblyjs/helper-wasm-section": "1.11.6",
-                "@webassemblyjs/wasm-gen": "1.11.6",
-                "@webassemblyjs/wasm-opt": "1.11.6",
-                "@webassemblyjs/wasm-parser": "1.11.6",
-                "@webassemblyjs/wast-printer": "1.11.6"
+                "@webassemblyjs/helper-wasm-section": "1.12.1",
+                "@webassemblyjs/wasm-gen": "1.12.1",
+                "@webassemblyjs/wasm-opt": "1.12.1",
+                "@webassemblyjs/wasm-parser": "1.12.1",
+                "@webassemblyjs/wast-printer": "1.12.1"
             }
         },
         "node_modules/@webassemblyjs/wasm-gen": {
-            "version": "1.11.6",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
+            "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.6",
+                "@webassemblyjs/ast": "1.12.1",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
                 "@webassemblyjs/ieee754": "1.11.6",
                 "@webassemblyjs/leb128": "1.11.6",
@@ -4914,24 +4854,26 @@
             }
         },
         "node_modules/@webassemblyjs/wasm-opt": {
-            "version": "1.11.6",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
+            "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.6",
-                "@webassemblyjs/helper-buffer": "1.11.6",
-                "@webassemblyjs/wasm-gen": "1.11.6",
-                "@webassemblyjs/wasm-parser": "1.11.6"
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-buffer": "1.12.1",
+                "@webassemblyjs/wasm-gen": "1.12.1",
+                "@webassemblyjs/wasm-parser": "1.12.1"
             }
         },
         "node_modules/@webassemblyjs/wasm-parser": {
-            "version": "1.11.6",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
+            "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.6",
+                "@webassemblyjs/ast": "1.12.1",
                 "@webassemblyjs/helper-api-error": "1.11.6",
                 "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
                 "@webassemblyjs/ieee754": "1.11.6",
@@ -4940,25 +4882,28 @@
             }
         },
         "node_modules/@webassemblyjs/wast-printer": {
-            "version": "1.11.6",
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
+            "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.6",
+                "@webassemblyjs/ast": "1.12.1",
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
             "dev": true,
-            "license": "BSD-3-Clause",
             "peer": true
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true,
-            "license": "Apache-2.0",
             "peer": true
         },
         "node_modules/acorn": {
@@ -4972,10 +4917,11 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/acorn-import-assertions": {
-            "version": "1.9.0",
+        "node_modules/acorn-import-attributes": {
+            "version": "1.9.5",
+            "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+            "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "peerDependencies": {
                 "acorn": "^8"
@@ -5073,8 +5019,9 @@
             }
         },
         "node_modules/ansi-colors": {
-            "version": "4.1.1",
-            "license": "MIT",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
             "engines": {
                 "node": ">=6"
             }
@@ -5358,10 +5305,11 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.6.7",
-            "license": "MIT",
+            "version": "1.7.5",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
+            "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
             "dependencies": {
-                "follow-redirects": "^1.15.4",
+                "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }
@@ -5460,10 +5408,11 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "license": "MIT",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -5474,7 +5423,9 @@
             "license": "ISC"
         },
         "node_modules/browserslist": {
-            "version": "4.23.0",
+            "version": "4.23.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
+            "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
             "dev": true,
             "funding": [
                 {
@@ -5490,12 +5441,11 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001587",
-                "electron-to-chromium": "^1.4.668",
-                "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.13"
+                "caniuse-lite": "^1.0.30001646",
+                "electron-to-chromium": "^1.5.4",
+                "node-releases": "^2.0.18",
+                "update-browserslist-db": "^1.1.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -5598,7 +5548,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001587",
+            "version": "1.0.30001653",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001653.tgz",
+            "integrity": "sha512-XGWQVB8wFQ2+9NZwZ10GxTYC5hk0Fa+q8cSkr0tgvMhYhMHP/QC+WTgrePMDBWiWc/pV+1ik82Al20XOK25Gcw==",
             "dev": true,
             "funding": [
                 {
@@ -5613,8 +5565,7 @@
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
-            ],
-            "license": "CC-BY-4.0"
+            ]
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -5771,9 +5722,10 @@
             }
         },
         "node_modules/code-block-writer": {
-            "version": "12.0.0",
-            "dev": true,
-            "license": "MIT"
+            "version": "13.0.2",
+            "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.2.tgz",
+            "integrity": "sha512-XfXzAGiStXSmCIwrkdfvc7FS5Dtj8yelCtyOf2p2skCAfvLd6zu0rGzuS9NSCO3bq1JKpFZ7tbKdKlcd5occQA==",
+            "dev": true
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -6102,8 +6054,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/diff": {
-            "version": "5.0.0",
-            "license": "BSD-3-Clause",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
             "engines": {
                 "node": ">=0.3.1"
             }
@@ -6192,9 +6145,10 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.673",
-            "dev": true,
-            "license": "ISC"
+            "version": "1.5.13",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.13.tgz",
+            "integrity": "sha512-lbBcvtIJ4J6sS4tb5TLp1b4LyfCdMkwStzXPyAgVgTRAsep4bvrAGaBOP7ZJtQMNJpSQ9SqG4brWOroNaQtm7Q==",
+            "dev": true
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -6259,9 +6213,10 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.15.0",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+            "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
                 "tapable": "^2.2.0"
@@ -6533,15 +6488,16 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.56.0",
+            "version": "8.57.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+            "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
                 "@eslint/eslintrc": "^2.1.4",
-                "@eslint/js": "8.56.0",
-                "@humanwhocodes/config-array": "^0.11.13",
+                "@eslint/js": "8.57.0",
+                "@humanwhocodes/config-array": "^0.11.14",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
                 "@ungap/structured-clone": "^1.2.0",
@@ -6754,13 +6710,13 @@
             }
         },
         "node_modules/eslint-plugin-prettier": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.1.3.tgz",
-            "integrity": "sha512-C9GCVAs4Eq7ZC/XFQHITLiHJxQngdtraXaM+LoUFoFp/lHNl2Zn8f3WQbe9HvTBBQ9YnKFB0/2Ajdqwo5D1EAw==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.1.tgz",
+            "integrity": "sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==",
             "dev": true,
             "dependencies": {
                 "prettier-linter-helpers": "^1.0.0",
-                "synckit": "^0.8.6"
+                "synckit": "^0.9.1"
             },
             "engines": {
                 "node": "^14.18.0 || >=16.0.0"
@@ -6907,6 +6863,27 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/eslint-plugin-unused-imports": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.2.0.tgz",
+            "integrity": "sha512-6uXyn6xdINEpxE1MtDjxQsyXB37lfyO2yKGVVgtD7WEWQGORSOZjgrD6hBhvGv4/SO+TOlS+UnC6JppRqbuwGQ==",
+            "dev": true,
+            "dependencies": {
+                "eslint-rule-composer": "^0.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "@typescript-eslint/eslint-plugin": "6 - 7",
+                "eslint": "8"
+            },
+            "peerDependenciesMeta": {
+                "@typescript-eslint/eslint-plugin": {
+                    "optional": true
+                }
             }
         },
         "node_modules/eslint-rule-composer": {
@@ -7251,8 +7228,9 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "license": "MIT",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -7365,30 +7343,32 @@
             "license": "ISC"
         },
         "node_modules/fluid-framework": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.1.0.tgz",
-            "integrity": "sha512-Un1NpfpvYnTF7POsowJ00rhzX3Z0YGEUiY5fNsvlCtmog+kL5qiWIr9Pc6gTm9dPAsMcaajt/TUnsJCgc8JS4Q==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/fluid-framework/-/fluid-framework-2.2.0.tgz",
+            "integrity": "sha512-5VEiEC0KuCJaph2ud1+U1pKNcbm896PgbQGqD/9PTK5W8GfGD+BeXqpeD2tyZrJfblLqkCLCrZLPTHXciUE4Kg==",
             "dependencies": {
-                "@fluidframework/container-definitions": "~2.1.0",
-                "@fluidframework/container-loader": "~2.1.0",
-                "@fluidframework/core-interfaces": "~2.1.0",
-                "@fluidframework/driver-definitions": "~2.1.0",
-                "@fluidframework/fluid-static": "~2.1.0",
-                "@fluidframework/map": "~2.1.0",
-                "@fluidframework/sequence": "~2.1.0",
-                "@fluidframework/shared-object-base": "~2.1.0",
-                "@fluidframework/tree": "~2.1.0"
+                "@fluidframework/container-definitions": "~2.2.0",
+                "@fluidframework/container-loader": "~2.2.0",
+                "@fluidframework/core-interfaces": "~2.2.0",
+                "@fluidframework/driver-definitions": "~2.2.0",
+                "@fluidframework/fluid-static": "~2.2.0",
+                "@fluidframework/map": "~2.2.0",
+                "@fluidframework/runtime-utils": "~2.2.0",
+                "@fluidframework/sequence": "~2.2.0",
+                "@fluidframework/shared-object-base": "~2.2.0",
+                "@fluidframework/tree": "~2.2.0"
             }
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.5",
+            "version": "1.15.6",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
             "funding": [
                 {
                     "type": "individual",
                     "url": "https://github.com/sponsors/RubenVerborgh"
                 }
             ],
-            "license": "MIT",
             "engines": {
                 "node": ">=4.0"
             },
@@ -7666,8 +7646,9 @@
         },
         "node_modules/glob-to-regexp": {
             "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "dev": true,
-            "license": "BSD-2-Clause",
             "peer": true
         },
         "node_modules/global-modules": {
@@ -8320,7 +8301,8 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -9009,8 +8991,9 @@
         },
         "node_modules/jsesc": {
             "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "jsesc": "bin/jsesc"
             },
@@ -9232,8 +9215,9 @@
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "yallist": "^3.0.2"
             }
@@ -9318,10 +9302,11 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "license": "MIT",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -9429,29 +9414,30 @@
             "license": "MIT"
         },
         "node_modules/mocha": {
-            "version": "10.3.0",
-            "license": "MIT",
+            "version": "10.7.3",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.7.3.tgz",
+            "integrity": "sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==",
             "dependencies": {
-                "ansi-colors": "4.1.1",
-                "browser-stdout": "1.3.1",
-                "chokidar": "3.5.3",
-                "debug": "4.3.4",
-                "diff": "5.0.0",
-                "escape-string-regexp": "4.0.0",
-                "find-up": "5.0.0",
-                "glob": "8.1.0",
-                "he": "1.2.0",
-                "js-yaml": "4.1.0",
-                "log-symbols": "4.1.0",
-                "minimatch": "5.0.1",
-                "ms": "2.1.3",
-                "serialize-javascript": "6.0.0",
-                "strip-json-comments": "3.1.1",
-                "supports-color": "8.1.1",
-                "workerpool": "6.2.1",
-                "yargs": "16.2.0",
-                "yargs-parser": "20.2.4",
-                "yargs-unparser": "2.0.0"
+                "ansi-colors": "^4.1.3",
+                "browser-stdout": "^1.3.1",
+                "chokidar": "^3.5.3",
+                "debug": "^4.3.5",
+                "diff": "^5.2.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-up": "^5.0.0",
+                "glob": "^8.1.0",
+                "he": "^1.2.0",
+                "js-yaml": "^4.1.0",
+                "log-symbols": "^4.1.0",
+                "minimatch": "^5.1.6",
+                "ms": "^2.1.3",
+                "serialize-javascript": "^6.0.2",
+                "strip-json-comments": "^3.1.1",
+                "supports-color": "^8.1.1",
+                "workerpool": "^6.5.1",
+                "yargs": "^16.2.0",
+                "yargs-parser": "^20.2.9",
+                "yargs-unparser": "^2.0.0"
             },
             "bin": {
                 "_mocha": "bin/_mocha",
@@ -9501,6 +9487,27 @@
                 "wrap-ansi": "^7.0.0"
             }
         },
+        "node_modules/mocha/node_modules/debug": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+            "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/mocha/node_modules/debug/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
         "node_modules/mocha/node_modules/glob": {
             "version": "8.1.0",
             "license": "ISC",
@@ -9519,8 +9526,9 @@
             }
         },
         "node_modules/mocha/node_modules/minimatch": {
-            "version": "5.0.1",
-            "license": "ISC",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -9569,8 +9577,9 @@
             }
         },
         "node_modules/mocha/node_modules/yargs-parser": {
-            "version": "20.2.4",
-            "license": "ISC",
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
             "engines": {
                 "node": ">=10"
             }
@@ -9719,9 +9728,10 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.14",
-            "dev": true,
-            "license": "MIT"
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
+            "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+            "dev": true
         },
         "node_modules/normalize-package-data": {
             "version": "2.5.0",
@@ -10357,9 +10367,9 @@
             "license": "MIT"
         },
         "node_modules/picocolors": {
-            "version": "1.0.0",
-            "dev": true,
-            "license": "ISC"
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+            "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -10722,10 +10732,11 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.11.2",
-            "license": "BSD-3-Clause",
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
             "dependencies": {
-                "side-channel": "^1.0.4"
+                "side-channel": "^1.0.6"
             },
             "engines": {
                 "node": ">=0.6"
@@ -10766,8 +10777,9 @@
             }
         },
         "node_modules/react": {
-            "version": "18.2.0",
-            "license": "MIT",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -10860,10 +10872,11 @@
             }
         },
         "node_modules/react-router": {
-            "version": "6.22.0",
-            "license": "MIT",
+            "version": "6.26.1",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.1.tgz",
+            "integrity": "sha512-kIwJveZNwp7teQRI5QmwWo39A5bXRyqpH0COKKmPnyD2vBvDwgFXSqDUYtt1h+FEyfnE8eXr7oe0MxRzVwCcvQ==",
             "dependencies": {
-                "@remix-run/router": "1.15.0"
+                "@remix-run/router": "1.19.1"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -10873,11 +10886,12 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "6.22.0",
-            "license": "MIT",
+            "version": "6.26.1",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.1.tgz",
+            "integrity": "sha512-veut7m41S1fLql4pLhxeSW3jlqs+4MtjRLj0xvuCEXsxusJCbs6I8yn9BxzzDX2XDgafrccY6hwjmd/bL54tFw==",
             "dependencies": {
-                "@remix-run/router": "1.15.0",
-                "react-router": "6.22.0"
+                "@remix-run/router": "1.19.1",
+                "react-router": "6.26.1"
             },
             "engines": {
                 "node": ">=14.0.0"
@@ -11425,8 +11439,9 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.0",
-            "license": "BSD-3-Clause",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dependencies": {
                 "randombytes": "^2.1.0"
             }
@@ -11766,15 +11781,15 @@
             "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
         },
         "node_modules/start-server-and-test": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.0.4.tgz",
-            "integrity": "sha512-CKNeBTcP0hVqIlNismHMudb9q3lLdAjcVPO13/7gfI66fcJpeIb/o4NzQd1JK/CD+lfWVqr10ZH9Y14+OwlJuw==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-2.0.5.tgz",
+            "integrity": "sha512-2CV4pz69NJVJKQmJeSr+O+SPtOreu0yxvhPmSXclzmAKkPREuMabyMh+Txpzemjx0RDzXOcG2XkhiUuxjztSQw==",
             "dev": true,
             "dependencies": {
                 "arg": "^5.0.2",
                 "bluebird": "3.7.2",
                 "check-more-types": "2.24.0",
-                "debug": "4.3.5",
+                "debug": "4.3.6",
                 "execa": "5.1.1",
                 "lazy-ass": "1.6.0",
                 "ps-tree": "1.2.0",
@@ -11790,9 +11805,9 @@
             }
         },
         "node_modules/start-server-and-test/node_modules/debug": {
-            "version": "4.3.5",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-            "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+            "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
             "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
@@ -12029,9 +12044,9 @@
             }
         },
         "node_modules/synckit": {
-            "version": "0.8.8",
-            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
-            "integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
+            "integrity": "sha512-7gr8p9TQP6RAHusBOSLs46F4564ZrjV8xFmw5zCmgmhGUcw2hxsShhJ6CEiHQMgPDwAQ1fWHPM0ypc4RMAig4A==",
             "dev": true,
             "dependencies": {
                 "@pkgr/core": "^0.1.0",
@@ -12150,15 +12165,6 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
-        "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true,
-            "dependencies": {
-                "randombytes": "^2.1.0"
-            }
-        },
         "node_modules/terser/node_modules/commander": {
             "version": "2.20.3",
             "dev": true,
@@ -12201,15 +12207,17 @@
         },
         "node_modules/to-fast-properties": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
             "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -12262,12 +12270,13 @@
             }
         },
         "node_modules/ts-morph": {
-            "version": "20.0.0",
+            "version": "22.0.0",
+            "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-22.0.0.tgz",
+            "integrity": "sha512-M9MqFGZREyeb5fTl6gNHKZLqBQA0TjA1lea+CR48R8EBTDuWrNqW6ccC5QvjNR4s6wDumD3LTCjOFSp9iwlzaw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
-                "@ts-morph/common": "~0.21.0",
-                "code-block-writer": "^12.0.0"
+                "@ts-morph/common": "~0.23.0",
+                "code-block-writer": "^13.0.1"
             }
         },
         "node_modules/ts-node": {
@@ -12466,9 +12475,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.5.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
-            "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
+            "version": "5.5.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+            "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -12537,7 +12546,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.13",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+            "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
             "dev": true,
             "funding": [
                 {
@@ -12553,10 +12564,9 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
-                "escalade": "^3.1.1",
-                "picocolors": "^1.0.0"
+                "escalade": "^3.1.2",
+                "picocolors": "^1.0.1"
             },
             "bin": {
                 "update-browserslist-db": "cli.js"
@@ -12574,11 +12584,15 @@
             }
         },
         "node_modules/url": {
-            "version": "0.11.3",
-            "license": "MIT",
+            "version": "0.11.4",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+            "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
             "dependencies": {
                 "punycode": "^1.4.1",
-                "qs": "^6.11.2"
+                "qs": "^6.12.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/url/node_modules/punycode": {
@@ -12639,9 +12653,10 @@
             }
         },
         "node_modules/vite": {
-            "version": "4.5.2",
+            "version": "4.5.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+            "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.18.10",
                 "postcss": "^8.4.27",
@@ -12719,9 +12734,10 @@
             }
         },
         "node_modules/watchpack": {
-            "version": "2.4.0",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+            "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
@@ -12740,26 +12756,26 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/webpack": {
-            "version": "5.90.2",
+            "version": "5.94.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
+            "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
             "dev": true,
-            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@types/eslint-scope": "^3.7.3",
                 "@types/estree": "^1.0.5",
-                "@webassemblyjs/ast": "^1.11.5",
-                "@webassemblyjs/wasm-edit": "^1.11.5",
-                "@webassemblyjs/wasm-parser": "^1.11.5",
+                "@webassemblyjs/ast": "^1.12.1",
+                "@webassemblyjs/wasm-edit": "^1.12.1",
+                "@webassemblyjs/wasm-parser": "^1.12.1",
                 "acorn": "^8.7.1",
-                "acorn-import-assertions": "^1.9.0",
+                "acorn-import-attributes": "^1.9.5",
                 "browserslist": "^4.21.10",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.15.0",
+                "enhanced-resolve": "^5.17.1",
                 "es-module-lexer": "^1.2.1",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
-                "graceful-fs": "^4.2.9",
+                "graceful-fs": "^4.2.11",
                 "json-parse-even-better-errors": "^2.3.1",
                 "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
@@ -12767,7 +12783,7 @@
                 "schema-utils": "^3.2.0",
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.3.10",
-                "watchpack": "^2.4.0",
+                "watchpack": "^2.4.1",
                 "webpack-sources": "^3.2.3"
             },
             "bin": {
@@ -12912,8 +12928,9 @@
             }
         },
         "node_modules/workerpool": {
-            "version": "6.2.1",
-            "license": "Apache-2.0"
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+            "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA=="
         },
         "node_modules/wrap-ansi": {
             "version": "7.0.0",
@@ -12981,8 +12998,9 @@
         },
         "node_modules/yallist": {
             "version": "3.1.1",
-            "dev": true,
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "dev": true
         },
         "node_modules/yargs-parser": {
             "version": "21.1.1",

--- a/packages/live-share-react/src/live-hooks/useLiveEvent.ts
+++ b/packages/live-share-react/src/live-hooks/useLiveEvent.ts
@@ -104,7 +104,7 @@ export function useLiveEvent<TEvent = any>(
      * User facing: callback to send event through `LiveEvent`
      */
     const sendEvent: SendLiveEventAction<TEvent> = React.useCallback(
-        async (event: TEvent) => {
+        async (event: TEvent, targetClientId?: string) => {
             if (!container) {
                 throw new ActionContainerNotJoinedError(
                     "liveEvent",
@@ -123,7 +123,7 @@ export function useLiveEvent<TEvent = any>(
                     "sendEvent"
                 );
             }
-            return await liveEvent.send(event);
+            return await liveEvent.send(event, targetClientId);
         },
         [container, liveEvent]
     );

--- a/packages/live-share-react/src/types/ActionTypes.ts
+++ b/packages/live-share-react/src/types/ActionTypes.ts
@@ -96,10 +96,11 @@ export type SetLiveStateAction<TState = undefined> = (
 
 /**
  * Callback for SendLiveEventAction<TEvent>.
- * (event: TEvent) => Promise<void>
+ * (event: TEvent, targetClientId?: string) => Promise<void>
  */
 export type SendLiveEventAction<TEvent> = (
-    event: TEvent
+    event: TEvent,
+    targetClientId?: string
 ) => Promise<ILiveEvent<TEvent>>;
 
 /**

--- a/packages/live-share/src/LiveEvent.ts
+++ b/packages/live-share/src/LiveEvent.ts
@@ -167,6 +167,7 @@ export class LiveEventClass<TEvent = any> extends LiveDataObject<{
      * The event will be queued for delivery if the client isn't currently connected.
      *
      * @param evt Event to send. If omitted, an event will still be sent but it won't include any custom event data.
+     * @param targetClientId Optional. When specified, the signal is only sent to the provided client id.
      *
      * @returns A promise with the full event object that was sent, including the timestamp of when the event was sent and the clientId if known.
      * The clientId will be `undefined` if the client is disconnected at time of delivery.
@@ -204,7 +205,10 @@ export class LiveEventClass<TEvent = any> extends LiveDataObject<{
         });
      ```
      */
-    public async send(evt: TEvent): Promise<ILiveEvent<TEvent>> {
+    public async send(
+        evt: TEvent,
+        targetClientId?: string
+    ): Promise<ILiveEvent<TEvent>> {
         LiveDataObjectNotInitializedError.assert(
             "LiveEvent:send",
             "send",
@@ -216,7 +220,7 @@ export class LiveEventClass<TEvent = any> extends LiveDataObject<{
             "`this._eventTarget` is undefined, implying there was an error during initialization that should not occur."
         );
 
-        return await this._eventTarget.sendEvent(evt);
+        return await this._eventTarget.sendEvent(evt, targetClientId);
     }
 }
 

--- a/packages/live-share/src/interfaces.ts
+++ b/packages/live-share/src/interfaces.ts
@@ -311,6 +311,7 @@ export interface ILiveShareJoinResults {
  * just pass `this.context.containerRuntime` to any class that takes an `IContainerRuntimeSignaler`.
  */
 export interface IContainerRuntimeSignaler {
+    clientId?: string;
     on(
         event: "signal",
         listener: (message: IInboundSignalMessage, local: boolean) => void

--- a/packages/live-share/src/interfaces.ts
+++ b/packages/live-share/src/interfaces.ts
@@ -15,6 +15,10 @@ export interface IEvent {
      * Name of the event.
      */
     name: string;
+    /**
+     * Optional. When specified, the signal is only sent to the provided client id.
+     */
+    targetClientId?: string;
 }
 
 /**
@@ -315,7 +319,13 @@ export interface IContainerRuntimeSignaler {
         event: "signal",
         listener: (message: IInboundSignalMessage, local: boolean) => void
     ): this;
-    submitSignal(type: string, content: any): void;
+    /**
+     * Submits the signal to be sent to other clients.
+     * @param type - Type of the signal.
+     * @param content - Content of the signal. Should be a JSON serializable object or primitive.
+     * @param targetClientId Optional. When specified, the signal is only sent to the provided client id.
+     */
+    submitSignal(type: string, content: any, targetClientId?: string): void;
 }
 
 /**

--- a/packages/live-share/src/internals/LiveEventScope.ts
+++ b/packages/live-share/src/internals/LiveEventScope.ts
@@ -133,14 +133,14 @@ export class LiveEventScope extends TypedEventEmitter<IErrorEvent> {
                 // While the Fluid odsp-driver currently supports targeted signals, it isn't guaranteed in other drivers.
                 // As of Fluid v2.2.0, azure-client and tinylicious do not support it currently.
                 // For consistency, we return early when the local client is not the targeted one.
-                if (message.targetClientId && message.content.targetClientId) {
+                if (message.targetClientId && content.targetClientId) {
                     // If we know the true targetClientId, we are in a supported driver so we override it
-                    message.content.targetClientId = message.targetClientId;
+                    content.targetClientId = message.targetClientId;
                 }
                 if (
                     !local &&
-                    message.content.targetClientId &&
-                    message.content.targetClientId !== this._runtime.clientId
+                    content.targetClientId &&
+                    content.targetClientId !== this._runtime.clientId
                 )
                     return;
                 content.clientId = clientId;

--- a/packages/live-share/src/internals/LiveEventScope.ts
+++ b/packages/live-share/src/internals/LiveEventScope.ts
@@ -41,7 +41,17 @@ export interface IRuntimeSignaler {
         event: "signal",
         listener: (message: IInboundSignalMessage, local: boolean) => void
     ): this;
-    submitSignal(type: string, content: any): void;
+    /**
+     * Submits the signal to be sent to other clients.
+     * @param type Type of the signal.
+     * @param content Content of the signal. Should be a JSON serializable object or primitive.
+     * @param targetClientId Optional. When specified, the signal is only sent to the provided client id.
+     */
+    submitSignal: (
+        type: string,
+        content: unknown,
+        targetClientId?: string
+    ) => void;
 }
 
 /**
@@ -120,6 +130,19 @@ export class LiveEventScope extends TypedEventEmitter<IErrorEvent> {
 
             if (isILiveEvent(message.content)) {
                 const content = message.content;
+                // While the Fluid odsp-driver currently supports targeted signals, it isn't guaranteed in other drivers.
+                // As of Fluid v2.2.0, azure-client and tinylicious do not support it currently.
+                // For consistency, we return early when the local client is not the targeted one.
+                if (message.targetClientId && message.content.targetClientId) {
+                    // If we know the true targetClientId, we are in a supported driver so we override it
+                    message.content.targetClientId = message.targetClientId;
+                }
+                if (
+                    !local &&
+                    message.content.targetClientId &&
+                    message.content.targetClientId !== this._runtime.clientId
+                )
+                    return;
                 content.clientId = clientId;
                 this.emitToListeners(clientId, content, local);
             }
@@ -182,6 +205,7 @@ export class LiveEventScope extends TypedEventEmitter<IErrorEvent> {
      * @template TEvent Type of event to send.
      * @param eventName Name of the event to send.
      * @param evt Optional. Partial event object to send. The `ILiveEvent.name`,
+     * @param targetClientId Optional. When specified, the signal is only sent to the provided client id.
      * `ILiveEvent.timestamp`, and `ILiveEvent.clientId`
      * fields will be automatically populated prior to sending.
      * @returns The full event, including `ILiveEvent.name`,
@@ -189,11 +213,12 @@ export class LiveEventScope extends TypedEventEmitter<IErrorEvent> {
      */
     public async sendEvent<TEvent>(
         eventName: string,
-        evt: TEvent
+        evt: TEvent,
+        targetClientId?: string
     ): Promise<ILiveEvent<TEvent>> {
-        const event = await this.createEvent(eventName, evt);
+        const event = await this.createEvent(eventName, evt, targetClientId);
         // Send event
-        this._runtime.submitSignal(eventName, event);
+        this._runtime.submitSignal(eventName, event, targetClientId);
         return event;
     }
 
@@ -219,7 +244,8 @@ export class LiveEventScope extends TypedEventEmitter<IErrorEvent> {
 
     private async createEvent<TEvent>(
         eventName: string,
-        evt: TEvent
+        evt: TEvent,
+        targetClientId?: string
     ): Promise<ILiveEvent<TEvent>> {
         const clientId = await this.waitUntilConnected();
         const isAllowed = await this._liveRuntime.verifyRolesAllowed(
@@ -236,6 +262,7 @@ export class LiveEventScope extends TypedEventEmitter<IErrorEvent> {
         // Clone passed in event and fill out required props.
         const clone: ILiveEvent<TEvent> = {
             clientId,
+            targetClientId,
             name: eventName,
             timestamp: this._liveRuntime.getTimestamp(),
             data: evt,

--- a/packages/live-share/src/internals/LiveEventSource.ts
+++ b/packages/live-share/src/internals/LiveEventSource.ts
@@ -31,13 +31,21 @@ export class LiveEventSource<TEvent> {
     /**
      * Broadcasts an event to any listening `LiveEventTarget` instances.
      * @param evt Optional. Partial event object to send. The `ILiveEvent.name`,
+     * @param targetClientId Optional. When specified, the signal is only sent to the provided client id.
      * `ILiveEvent.timestamp`, and `ILiveEvent.clientId`
      * fields will be automatically populated prior to sending.
      * @returns The full event, including `ILiveEvent.name`,
      * `ILiveEvent.timestamp`, and `ILiveEvent.clientId` fields if known.
      */
-    public async sendEvent(evt: TEvent): Promise<ILiveEvent<TEvent>> {
-        return await this._scope.sendEvent<TEvent>(this._eventName, evt);
+    public async sendEvent(
+        evt: TEvent,
+        targetClientId?: string
+    ): Promise<ILiveEvent<TEvent>> {
+        return await this._scope.sendEvent<TEvent>(
+            this._eventName,
+            evt,
+            targetClientId
+        );
     }
 
     /**

--- a/packages/live-share/src/internals/LiveObjectManager.ts
+++ b/packages/live-share/src/internals/LiveObjectManager.ts
@@ -260,7 +260,9 @@ export class LiveObjectManager extends TypedEventEmitter<IContainerLiveObjectSto
         );
         // If the non-local user is connecting for the first time
         if (message.type === ObjectSynchronizerEvents.connect) {
-            this._synchronizer?.onSendBackgroundUpdates();
+            // Sent with a targetClientId so that only the user connecting receives the signal.
+            // This reduces the cost & server burden of connect messages, particularly in larger session sizes.
+            this._synchronizer?.onSendBackgroundUpdates(message.clientId);
         }
     }
 

--- a/packages/live-share/src/internals/LiveObjectSynchronizer.ts
+++ b/packages/live-share/src/internals/LiveObjectSynchronizer.ts
@@ -192,6 +192,7 @@ export class LiveObjectSynchronizer<TState> {
     /**
      * Sends a one-time event through the synchronizer
      * @param data the date for the event to send
+     * @param targetClientId Optional. When specified, the signal is only sent to the provided client id.
      * @returns the event that was sent
      */
     public sendEvent<TState = any>(data: TState): Promise<ILiveEvent<TState>> {

--- a/packages/live-share/src/internals/mock/MockLiveShareRuntime.ts
+++ b/packages/live-share/src/internals/mock/MockLiveShareRuntime.ts
@@ -37,10 +37,12 @@ export class MockLiveShareRuntime extends LiveShareRuntime {
             return this._containerRuntime;
         return undefined;
     }
-    connectToOtherRuntime(otherLiveRuntime: MockLiveShareRuntime) {
+    connectToOtherRuntime(...otherLiveRuntimes: MockLiveShareRuntime[]) {
         MockContainerRuntimeSignaler.connectContainers([
             this.getLocalMockContainer()!,
-            otherLiveRuntime.getLocalMockContainer()!,
+            ...otherLiveRuntimes.map(
+                (runtime) => runtime.getLocalMockContainer()!
+            ),
         ]);
     }
 }

--- a/packages/live-share/src/internals/type-guards.ts
+++ b/packages/live-share/src/internals/type-guards.ts
@@ -48,6 +48,8 @@ export function isILiveEvent(value: any): value is ILiveEvent {
     return (
         typeof value === "object" &&
         typeof value.clientId === "string" &&
+        (typeof value.targetClientId === "string" ||
+            value.targetClientId === undefined) &&
         typeof value.timestamp === "number" &&
         typeof value.name === "string"
     );

--- a/samples/typescript/04.live-share-react/src/components/ExampleLiveEvent.tsx
+++ b/samples/typescript/04.live-share-react/src/components/ExampleLiveEvent.tsx
@@ -9,12 +9,35 @@ export const ExampleLiveEvent: FC = () => {
     return (
         <div style={{ marginTop: "12px" }}>
             {/* Render counts of notifications sent/received */}
-            <div>{`Total received: ${
-                allEvents.filter((event) => !event.local).length
-            }`}</div>
-            <div>{`Total sent: ${
-                allEvents.filter((event) => event.local).length
-            }`}</div>
+            <div>
+                <strong>Total received:</strong>
+                {` ${allEvents.filter((event) => !event.local).length}`}
+            </div>
+            <div>
+                <strong>Total sent:</strong>
+                {` ${allEvents.filter((event) => event.local).length}`}
+            </div>
+            {/* Show latest reaction */}
+            {latestEvent?.local === false && (
+                <div>
+                    <strong>Received:</strong>
+                    {` ${latestEvent?.value}, `}
+                    <strong>From:</strong>
+                    {` ${latestEvent?.clientId}`}
+                </div>
+            )}
+            {latestEvent?.local === true && (
+                <div>
+                    <strong>Sent:</strong>
+                    {` ${latestEvent?.value}`}
+                </div>
+            )}
+            {!latestEvent && (
+                <div>
+                    <strong>Latest:</strong>
+                    {` N/A`}
+                </div>
+            )}
             {/* Buttons for sending reactions */}
             <div className="flex row hAlign wrap">
                 <button
@@ -46,13 +69,6 @@ export const ExampleLiveEvent: FC = () => {
                 >
                     {"🎯"}
                 </button>
-                {/* Show latest reaction */}
-                {latestEvent?.local === false && (
-                    <div>{`Received: ${latestEvent?.value}, From: ${latestEvent?.clientId}`}</div>
-                )}
-                {latestEvent?.local === true && (
-                    <div>{`Sent: ${latestEvent?.value}`}</div>
-                )}
             </div>
         </div>
     );

--- a/samples/typescript/04.live-share-react/src/components/ExampleLiveEvent.tsx
+++ b/samples/typescript/04.live-share-react/src/components/ExampleLiveEvent.tsx
@@ -1,9 +1,10 @@
 import { useLiveEvent } from "@microsoft/live-share-react";
-import { FC } from "react";
+import { FC, useState } from "react";
 
 export const ExampleLiveEvent: FC = () => {
     const { latestEvent, allEvents, sendEvent } =
         useLiveEvent<string>("EVENT-ID");
+    const [targetClientId, setTargetClientId] = useState("");
 
     return (
         <div style={{ marginTop: "12px" }}>
@@ -30,9 +31,24 @@ export const ExampleLiveEvent: FC = () => {
                 >
                     {"😂"}
                 </button>
+                <input
+                    placeholder="Enter targetClientId..."
+                    value={targetClientId}
+                    onChange={(ev) => {
+                        setTargetClientId(ev.target.value);
+                    }}
+                />
+                <button
+                    disabled={!targetClientId}
+                    onClick={() => {
+                        sendEvent("🎯", targetClientId);
+                    }}
+                >
+                    {"🎯"}
+                </button>
                 {/* Show latest reaction */}
                 {latestEvent?.local === false && (
-                    <div>{`Received: ${latestEvent?.value}`}</div>
+                    <div>{`Received: ${latestEvent?.value}, From: ${latestEvent?.clientId}`}</div>
                 )}
                 {latestEvent?.local === true && (
                     <div>{`Sent: ${latestEvent?.value}`}</div>


### PR DESCRIPTION
- Added ability to send signals to specific clients, for drivers that support it (e.g., odsp-driver).
- Once azure-client and tinylicious supports `targetClientId` at service level, this will work automatically.
- For unsupported drivers, the behavior is simulated appropriately such that events are only handled from the targeted client.
- Updated `LiveEvent` and `useLiveEvent` to support optional targeting, and updated sample 04 with an example.
- Implement targeting out of box for `LiveObjectSynchronizer` and `LiveMediaSessionCoordinator` `connect` events out of the box. For supported drivers, this will decrease COGS and server load considerably in larger session sizes (no N^2).

**Non-targeted behavior (existing):**
This is the behavior when no `targetClientId` is provided. All remote clients will receive the event.
<img width="1682" alt="image" src="https://github.com/user-attachments/assets/173deca1-ae82-4543-9528-a04f3fecd295">

**Target client behavior**:
This is the behavior when `targetClientId` is provided (left side is targeting top-right). Notice how the top-right received the most recent message sent by the top-left.
<img width="1683" alt="image" src="https://github.com/user-attachments/assets/0bdda3f1-d5dc-455d-a8e8-443220a9b489">
