### PR TITLE
remove `createDataObjectKind`

### DIFF
--- a/packages/live-share-canvas/src/core/LiveCanvas.ts
+++ b/packages/live-share-canvas/src/core/LiveCanvas.ts
@@ -3,7 +3,6 @@
  * Licensed under the Microsoft Live Share SDK License.
  */
 
-import { createDataObjectKind } from "@fluidframework/aqueduct/internal";
 import { DataObjectFactory } from "@fluidframework/aqueduct/legacy";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { SharedMap } from "@fluidframework/map/legacy";
@@ -836,7 +835,7 @@ export type LiveCanvas = LiveCanvasClass;
 
 // eslint-disable-next-line no-redeclare
 export const LiveCanvas = (() => {
-    const kind = createDataObjectKind(LiveCanvasClass);
+    const kind = LiveCanvasClass;
     return kind as typeof kind & SharedObjectKind<LiveCanvasClass>;
 })();
 

--- a/packages/live-share-media/src/LiveMediaSession.ts
+++ b/packages/live-share-media/src/LiveMediaSession.ts
@@ -3,7 +3,6 @@
  * Licensed under the Microsoft Live Share SDK License.
  */
 
-import { createDataObjectKind } from "@fluidframework/aqueduct/internal";
 import { DataObjectFactory } from "@fluidframework/aqueduct/legacy";
 import {
     LiveDataObjectInitializeNotNeededError,
@@ -352,7 +351,7 @@ export type LiveMediaSession = LiveMediaSessionClass;
 
 // eslint-disable-next-line no-redeclare
 export const LiveMediaSession = (() => {
-    const kind = createDataObjectKind(LiveMediaSessionClass);
+    const kind = LiveMediaSessionClass;
     return kind as typeof kind & SharedObjectKind<LiveMediaSessionClass>;
 })();
 

--- a/packages/live-share/src/LiveEvent.ts
+++ b/packages/live-share/src/LiveEvent.ts
@@ -3,7 +3,6 @@
  * Licensed under the Microsoft Live Share SDK License.
  */
 
-import { createDataObjectKind } from "@fluidframework/aqueduct/internal";
 import { DataObjectFactory } from "@fluidframework/aqueduct/legacy";
 import { IEvent } from "@fluidframework/core-interfaces";
 import {
@@ -226,7 +225,7 @@ export type LiveEvent<TEvent = any> = LiveEventClass<TEvent>;
 
 // eslint-disable-next-line no-redeclare
 export const LiveEvent = (() => {
-    const kind = createDataObjectKind(LiveEventClass);
+    const kind = LiveEventClass;
     return kind as typeof kind & SharedObjectKind<LiveEventClass>;
 })();
 

--- a/packages/live-share/src/LiveFollowMode.ts
+++ b/packages/live-share/src/LiveFollowMode.ts
@@ -1,7 +1,6 @@
 import { LiveDataObject } from "./internals/LiveDataObject.js";
 import { LiveState } from "./LiveState.js";
 import { ILivePresenceEvents, LivePresence } from "./LivePresence.js";
-import { createDataObjectKind } from "@fluidframework/aqueduct/internal";
 import { DataObjectFactory } from "@fluidframework/aqueduct/legacy";
 import { IFluidHandle } from "@fluidframework/core-interfaces";
 import { assert } from "@fluidframework/core-utils/legacy";
@@ -1046,7 +1045,7 @@ export type LiveFollowMode<TData = any> = LiveFollowModeClass<TData>;
 
 // eslint-disable-next-line no-redeclare
 export const LiveFollowMode = (() => {
-    const kind = createDataObjectKind(LiveFollowModeClass);
+    const kind = LiveFollowModeClass;
     return kind as typeof kind & SharedObjectKind<LiveFollowModeClass>;
 })();
 

--- a/packages/live-share/src/LivePresence.ts
+++ b/packages/live-share/src/LivePresence.ts
@@ -3,7 +3,6 @@
  * Licensed under the Microsoft Live Share SDK License.
  */
 
-import { createDataObjectKind } from "@fluidframework/aqueduct/internal";
 import { DataObjectFactory } from "@fluidframework/aqueduct/legacy";
 import { IEvent } from "@fluidframework/core-interfaces";
 import {
@@ -612,7 +611,7 @@ export type LivePresence<TData extends LivePresenceData = any> =
 
 // eslint-disable-next-line no-redeclare
 export const LivePresence = (() => {
-    const kind = createDataObjectKind(LivePresenceClass<any>);
+    const kind = LivePresenceClass<any>;
     return kind as typeof kind & SharedObjectKind<LivePresenceClass<any>>;
 })();
 

--- a/packages/live-share/src/LiveState.ts
+++ b/packages/live-share/src/LiveState.ts
@@ -3,7 +3,6 @@
  * Licensed under the Microsoft Live Share SDK License.
  */
 
-import { createDataObjectKind } from "@fluidframework/aqueduct/internal";
 import { DataObjectFactory } from "@fluidframework/aqueduct/legacy";
 import { assert } from "@fluidframework/core-utils/legacy";
 import { IEvent } from "@fluidframework/core-interfaces";
@@ -323,7 +322,7 @@ export type LiveState<TState = any> = LiveStateClass<TState>;
 
 // eslint-disable-next-line no-redeclare
 export const LiveState = (() => {
-    const kind = createDataObjectKind(LiveStateClass);
+    const kind = LiveStateClass;
     return kind as typeof kind & SharedObjectKind<LiveStateClass>;
 })();
 

--- a/packages/live-share/src/LiveTimer.ts
+++ b/packages/live-share/src/LiveTimer.ts
@@ -3,7 +3,6 @@
  * Licensed under the Microsoft Live Share SDK License.
  */
 
-import { createDataObjectKind } from "@fluidframework/aqueduct/internal";
 import { DataObjectFactory } from "@fluidframework/aqueduct/legacy";
 import { LiveObjectSynchronizer } from "./internals/LiveObjectSynchronizer.js";
 import {
@@ -645,7 +644,7 @@ export type LiveTimer = LiveTimerClass;
 
 // eslint-disable-next-line no-redeclare
 export const LiveTimer = (() => {
-    const kind = createDataObjectKind(LiveTimerClass);
+    const kind = LiveTimerClass;
     return kind as typeof kind & SharedObjectKind<LiveTimerClass>;
 })();
 

--- a/packages/live-share/src/internals/DynamicObjectManager.ts
+++ b/packages/live-share/src/internals/DynamicObjectManager.ts
@@ -3,7 +3,6 @@
  * Licensed under the Microsoft Live Share SDK License.
  */
 
-import { createDataObjectKind } from "@fluidframework/aqueduct/internal";
 import { DataObjectFactory } from "@fluidframework/aqueduct/legacy";
 import {
     FluidObject,
@@ -208,7 +207,7 @@ export type DynamicObjectManager = DynamicObjectManagerClass;
 
 // eslint-disable-next-line no-redeclare
 export const DynamicObjectManager = (() => {
-    const kind = createDataObjectKind(DynamicObjectManagerClass);
+    const kind = DynamicObjectManagerClass;
     return kind as typeof kind & SharedObjectKind<DynamicObjectManagerClass>;
 })();
 

--- a/packages/live-share/src/test/LivePresence.spec.ts
+++ b/packages/live-share/src/test/LivePresence.spec.ts
@@ -29,7 +29,6 @@ import {
     ITestObjectProviderOptions,
 } from "@live-share-private/test-utils";
 import { SharedObjectKind } from "fluid-framework";
-import { createDataObjectKind } from "@fluidframework/aqueduct/internal";
 
 class TestLivePresenceClass<
     TData extends object | undefined | null = object,
@@ -44,7 +43,7 @@ export type TestLivePresence<TData extends object | undefined | null = object> =
 
 // eslint-disable-next-line no-redeclare
 export const TestLivePresence = (() => {
-    const kind = createDataObjectKind(TestLivePresenceClass<any>);
+    const kind = TestLivePresenceClass<any>;
     return kind as typeof kind & SharedObjectKind<TestLivePresenceClass<any>>;
 })();
 


### PR DESCRIPTION
- removing all instances of `createDataObjectKind` as part of effort to remove `/internal` fluid imports from customer-facing APIs