### PR TITLE
Simplify getLiveDataObjectProxyClassInternal

### DIFF
--- a/packages/live-share/src/LiveFollowMode.ts
+++ b/packages/live-share/src/LiveFollowMode.ts
@@ -1024,6 +1024,7 @@ export class LiveFollowModeClass<TData = any> extends LiveDataObject<{
             presentingUserIdLiveStateHandle?.get(),
             presenceHandle?.get(),
         ]);
+        // TODO: remove these?
         liveState?.__dangerouslySetLiveRuntime(this.liveRuntime);
         livePresence?.__dangerouslySetLiveRuntime(this.liveRuntime);
         this._presentingUserIdState = liveState;

--- a/packages/live-share/src/internals/LiveDataObject.ts
+++ b/packages/live-share/src/internals/LiveDataObject.ts
@@ -36,7 +36,7 @@ export abstract class LiveDataObject<
     /**
      * @hidden
      */
-    private _liveRuntime: LiveShareRuntime;
+    private _liveRuntime: LiveShareRuntime | undefined;
 
     /**
      * @hidden
@@ -50,6 +50,11 @@ export abstract class LiveDataObject<
      * You should usually not set this value to a DDS after calling `.initialize()`, but there is nothing preventing it.
      */
     protected get liveRuntime(): LiveShareRuntime {
+        UnexpectedError.assert(
+            this._liveRuntime !== undefined,
+            `LiveDataObject:liveRuntime:${this.debugInfo}`,
+            `LiveShareRuntime not initialized. Ensure your Fluid \`ContainerSchema\` was first wrapped inside of \`getLiveContainerSchema()\` before calling \`client.getContainer()\` / \`client.createContainer()\` from your \`AzureClient\` (or equivalent) instance.\nAlternatively, you can use the \`.join()\` in \`LiveShareClient\`, which does this for you.\nIf you are using \`LiveShareClient\` and are still encountering this issue, please report this issue at ${LiveShareReportIssueLink}.`
+        );
         return this._liveRuntime;
     }
 
@@ -82,15 +87,11 @@ export abstract class LiveDataObject<
         this.runtime.once("dispose", () => {
             this.dispose();
         });
-        const liveRuntime = LiveDataObject.__dangerousLiveRuntime.get(
+
+        // This should be provided unless using createChildInstance which will set it afterward.
+        this._liveRuntime = LiveDataObject.__dangerousLiveRuntime.get(
             this.context
         );
-        UnexpectedError.assert(
-            liveRuntime !== undefined,
-            `LiveDataObject:liveRuntime:${this.debugInfo}`,
-            `LiveShareRuntime not initialized. Ensure your Fluid \`ContainerSchema\` was first wrapped inside of \`getLiveContainerSchema()\` before calling \`client.getContainer()\` / \`client.createContainer()\` from your \`AzureClient\` (or equivalent) instance.\nAlternatively, you can use the \`.join()\` in \`LiveShareClient\`, which does this for you.\nIf you are using \`LiveShareClient\` and are still encountering this issue, please report this issue at ${LiveShareReportIssueLink}.`
-        );
-        this._liveRuntime = liveRuntime;
     }
 
     /**

--- a/packages/live-share/src/internals/LiveDataObject.ts
+++ b/packages/live-share/src/internals/LiveDataObject.ts
@@ -3,6 +3,7 @@ import {
     DataObjectTypes,
     IDataObjectProps,
 } from "@fluidframework/aqueduct/legacy";
+import { IFluidDataStoreContext } from "@fluidframework/runtime-definitions/legacy";
 import { LiveShareRuntime } from "./LiveShareRuntime.js";
 import {
     IClientInfo,
@@ -35,7 +36,7 @@ export abstract class LiveDataObject<
     /**
      * @hidden
      */
-    private _liveRuntime: LiveShareRuntime | null = null;
+    private _liveRuntime: LiveShareRuntime;
 
     /**
      * @hidden
@@ -49,11 +50,6 @@ export abstract class LiveDataObject<
      * You should usually not set this value to a DDS after calling `.initialize()`, but there is nothing preventing it.
      */
     protected get liveRuntime(): LiveShareRuntime {
-        UnexpectedError.assert(
-            this._liveRuntime !== null,
-            `LiveDataObject:liveRuntime:${this.debugInfo}`,
-            `LiveShareRuntime not initialized. Ensure your Fluid \`ContainerSchema\` was first wrapped inside of \`getLiveContainerSchema()\` before calling \`client.getContainer()\` / \`client.createContainer()\` from your \`AzureClient\` (or equivalent) instance.\nAlternatively, you can use the \`.join()\` in \`LiveShareClient\`, which does this for you.\nIf you are using \`LiveShareClient\` and are still encountering this issue, please report this issue at ${LiveShareReportIssueLink}.`
-        );
         return this._liveRuntime;
     }
 
@@ -86,6 +82,15 @@ export abstract class LiveDataObject<
         this.runtime.once("dispose", () => {
             this.dispose();
         });
+        const liveRuntime = LiveDataObject.__dangerousLiveRuntime.get(
+            this.context
+        );
+        UnexpectedError.assert(
+            liveRuntime !== undefined,
+            `LiveDataObject:liveRuntime:${this.debugInfo}`,
+            `LiveShareRuntime not initialized. Ensure your Fluid \`ContainerSchema\` was first wrapped inside of \`getLiveContainerSchema()\` before calling \`client.getContainer()\` / \`client.createContainer()\` from your \`AzureClient\` (or equivalent) instance.\nAlternatively, you can use the \`.join()\` in \`LiveShareClient\`, which does this for you.\nIf you are using \`LiveShareClient\` and are still encountering this issue, please report this issue at ${LiveShareReportIssueLink}.`
+        );
+        this._liveRuntime = liveRuntime;
     }
 
     /**
@@ -121,6 +126,15 @@ export abstract class LiveDataObject<
             this._allowedRoles ?? []
         );
     }
+
+    /**
+     * @hidden
+     * Dependency injection setter for `LiveShareRuntime`.
+     */
+    public static __dangerousLiveRuntime: WeakMap<
+        IFluidDataStoreContext,
+        LiveShareRuntime
+    > = new WeakMap();
 
     /**
      * @hidden

--- a/packages/live-share/src/internals/schema-injection-utils.ts
+++ b/packages/live-share/src/internals/schema-injection-utils.ts
@@ -1,7 +1,4 @@
-import {
-    DataObjectTypes,
-    IDataObjectProps,
-} from "@fluidframework/aqueduct/legacy";
+import { DataObjectTypes } from "@fluidframework/aqueduct/legacy";
 import { IFluidLoadable } from "@fluidframework/core-interfaces";
 import { LiveDataObject } from "./LiveDataObject.js";
 import { LiveShareRuntime } from "./LiveShareRuntime.js";
@@ -11,6 +8,16 @@ import {
     DataObjectClass,
 } from "./fluid-duplicated.js";
 import { ContainerSchema, SharedObjectKind } from "fluid-framework";
+import {
+    IFluidDataStoreChannel,
+    IFluidDataStoreContext,
+} from "@fluidframework/runtime-definitions/legacy";
+// TODO: stabilize these APIs.
+import {
+    DataObjectKind,
+    createDataObjectKind,
+} from "@fluidframework/aqueduct/internal";
+import { UnexpectedError } from "../errors.js";
 
 /**
  * A LiveObjectClass is a class that has a factory that can create a DDS (SharedObject) and a
@@ -93,7 +100,7 @@ export function getLiveDataObjectKind<TClass extends IFluidLoadable>(
             return CheckExisting;
         }
         // Create a new proxy for this type and insert it into proxiedClasses
-        const NewProxy = getLiveDataObjectProxyClassInternal(
+        const NewProxy = getLiveDataObjectKindInternal(
             objectClass,
             liveRuntime
         ) as unknown as SharedObjectKind<TClass>;
@@ -112,53 +119,46 @@ function isLiveDataObject(value: any): value is typeof LiveDataObject {
 
 /**
  * @hidden
- * Create a new class extending LiveDataObject to inject in _liveRuntime
+ * Create a DataObjectKind for a LiveDataObject compatible with LiveShareRuntime.
  */
-function getLiveDataObjectProxyClassInternal<
-    I extends DataObjectTypes = DataObjectTypes,
->(
+function getLiveDataObjectKindInternal<I extends DataObjectTypes>(
     BaseClass: typeof LiveDataObject<I>,
     runtime: LiveShareRuntime
-): LiveObjectClass<any> {
-    class ProxiedBaseClass extends (BaseClass as unknown as new (
-        props: IDataObjectProps<I>
-    ) => LiveDataObject<I>) {
-        constructor(props: IDataObjectProps<I>) {
-            // eslint-disable-next-line constructor-super
-            super(props);
-            this.__dangerouslySetLiveRuntime(runtime);
-            // Pass reference to the container runtime
-            if (!this.context || !this.context.containerRuntime) {
-                throw Error(
-                    "getLiveDataObjectProxyClassInternal: required dependencies unknown"
-                );
-            }
+): DataObjectKind<LiveDataObject<I>> {
+    const base = BaseClass as unknown as DataObjectKind<LiveDataObject<I>>;
 
-            // when interactive is false, that means that this client is from the summarizer or some other system entity.
-            // we only want to set the container runtime for interactive clients, so we return.
-            if (this.context.clientDetails.capabilities.interactive === false) {
-                return;
-            }
-
-            runtime.__dangerouslySetContainerRuntime(
-                this.context.containerRuntime
-            );
-        }
-    }
-
-    const DynamicClass: LiveObjectClass<any> = class extends BaseClass {
-        public static TypeName = (BaseClass as any).TypeName;
-        public static readonly factory = new Proxy((BaseClass as any).factory, {
-            get: function (target, prop, receiver) {
-                if (prop === "createProps") {
-                    return {
-                        ...Reflect.get(target, prop, receiver),
-                        ctor: ProxiedBaseClass,
-                    };
-                }
-                return Reflect.get(target, prop, receiver);
+    return createDataObjectKind({
+        factory: {
+            type: base.factory.type,
+            get IFluidDataStoreFactory() {
+                return this;
             },
-        });
-    };
-    return DynamicClass;
+            async instantiateDataStore(
+                context: IFluidDataStoreContext,
+                existing: boolean
+            ): Promise<IFluidDataStoreChannel> {
+                const created = await base.factory.instantiateDataStore(
+                    context,
+                    existing
+                );
+                UnexpectedError.assert(
+                    created instanceof LiveDataObject,
+                    "getLiveDataObjectKindInternal",
+                    "unexpected channel type"
+                );
+                created.__dangerouslySetLiveRuntime(runtime);
+
+                // Pass reference to the container runtime
+                // When interactive is false, that means that this client is from the summarizer or some other system entity.
+                // We only want to set the container runtime for interactive clients.
+                if (context.clientDetails.capabilities.interactive === true) {
+                    runtime.__dangerouslySetContainerRuntime(
+                        context.containerRuntime
+                    );
+                }
+
+                return created;
+            },
+        },
+    });
 }

--- a/packages/live-share/src/internals/schema-injection-utils.ts
+++ b/packages/live-share/src/internals/schema-injection-utils.ts
@@ -137,16 +137,17 @@ function getLiveDataObjectKindInternal<I extends DataObjectTypes>(
                 context: IFluidDataStoreContext,
                 existing: boolean
             ): Promise<IFluidDataStoreChannel> {
-                const created = await base.factory.instantiateDataStore(
+                const createdChannel = await base.factory.instantiateDataStore(
                     context,
                     existing
                 );
+                const createdObject = await createdChannel.entryPoint.get();
                 UnexpectedError.assert(
-                    created instanceof LiveDataObject,
+                    createdObject instanceof LiveDataObject,
                     "getLiveDataObjectKindInternal",
                     "unexpected channel type"
                 );
-                created.__dangerouslySetLiveRuntime(runtime);
+                createdObject.__dangerouslySetLiveRuntime(runtime);
 
                 // Pass reference to the container runtime
                 // When interactive is false, that means that this client is from the summarizer or some other system entity.
@@ -157,7 +158,7 @@ function getLiveDataObjectKindInternal<I extends DataObjectTypes>(
                     );
                 }
 
-                return created;
+                return createdChannel;
             },
         },
     });

--- a/packages/live-share/src/internals/schema-injection-utils.ts
+++ b/packages/live-share/src/internals/schema-injection-utils.ts
@@ -137,17 +137,19 @@ function getLiveDataObjectKindInternal<I extends DataObjectTypes>(
                 context: IFluidDataStoreContext,
                 existing: boolean
             ): Promise<IFluidDataStoreChannel> {
+                const existingRuntime =
+                    LiveDataObject.__dangerousLiveRuntime.get(context);
+                UnexpectedError.assert(
+                    existingRuntime === undefined ||
+                        existingRuntime === runtime,
+                    "getLiveDataObjectKindInternal",
+                    `Expected existing LiveRuntime to be undefined or the same as the provided runtime`
+                );
+                LiveDataObject.__dangerousLiveRuntime.set(context, runtime);
                 const createdChannel = await base.factory.instantiateDataStore(
                     context,
                     existing
                 );
-                const createdObject = await createdChannel.entryPoint.get();
-                UnexpectedError.assert(
-                    createdObject instanceof LiveDataObject,
-                    "getLiveDataObjectKindInternal",
-                    "unexpected channel type"
-                );
-                createdObject.__dangerouslySetLiveRuntime(runtime);
 
                 // Pass reference to the container runtime
                 // When interactive is false, that means that this client is from the summarizer or some other system entity.


### PR DESCRIPTION
Avoid using a proxy to intercept private properties.

Instead use some internal DataObject APIs which are more stable that those private properties, and might be stabilized in the future.