### PR TITLE
improvement: use public imports where possible 

### DIFF
--- a/packages/live-share/src/AzureLiveShareClient.ts
+++ b/packages/live-share/src/AzureLiveShareClient.ts
@@ -4,8 +4,11 @@
  */
 
 import { ContainerSchema, IFluidContainer } from "fluid-framework";
-import { AzureContainerServices } from "@fluidframework/azure-client/legacy";
-import { AzureClient, AzureClientProps } from "@fluidframework/azure-client";
+import {
+    AzureClient,
+    AzureClientProps,
+    AzureContainerServices,
+} from "@fluidframework/azure-client";
 import { BaseLiveShareClient } from "./internals/BaseLiveShareClient.js";
 import { ILiveShareHost } from "./interfaces.js";
 import { AzureLiveShareHost } from "./AzureLiveShareHost.js";

--- a/packages/live-share/src/internals/BaseLiveShareClient.ts
+++ b/packages/live-share/src/internals/BaseLiveShareClient.ts
@@ -10,7 +10,7 @@ import {
     SharedObjectKind,
 } from "fluid-framework";
 import { SharedMap } from "fluid-framework/legacy";
-import { AzureContainerServices } from "@fluidframework/azure-client/legacy";
+import { AzureContainerServices } from "@fluidframework/azure-client";
 import { IFluidLoadable } from "@fluidframework/core-interfaces";
 import { DynamicObjectRegistry } from "./DynamicObjectRegistry.js";
 import { DynamicObjectManager } from "./DynamicObjectManager.js";


### PR DESCRIPTION
Ran Fluid Framework's [`flub modify fluid-imports`](https://github.com/microsoft/FluidFramework/wiki/Updating-code-using-legacy-Fluid-APIs) tool to use the most supported level of imports.

This clarifies that `AzureContainerServices` is publicly supported. (No `/legacy` import needed.)

No actual runtime change.